### PR TITLE
Update gluestick to have a proper production mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,17 @@ great most of the time. However, sometimes you will still need to refresh the
 browser for certain changes.
 
 ## Deployment & Production
-This is not finished yet but we have some cool things in the works. Stay tuned
-for more.
+To run a gluestick application in production mode, simple set `NODE_ENV`
+envrionment variable to `production`.
+For example: `NODE_ENV=production gluestick start`
+
+GlueStick will serve assets for you in production mode but it is recommended
+you serve assets from a Content Delivery Network. To do that, simply run
+`gluestick build` and it will generate a folder named `build` in your project
+root. This folder will contain all of the assets needed to run your app.
+
+Finally, you need to update your application config file
+(src/config/application.js) to define the asset path for production.
 
 [npm-badge]: https://img.shields.io/npm/v/gluestick.svg?style=flat-square
 [npm]: https://www.npmjs.org/package/gluestick

--- a/new/package.json
+++ b/new/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test-core",
+  "name": "AppName",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/new/src/config/application.js
+++ b/new/src/config/application.js
@@ -1,0 +1,10 @@
+export default {
+    development: {
+        assetPath: "http://localhost:8888/assets"
+    },
+    production: {
+        // This should be a CDN in development
+        assetPath: "http://localhost:8888/assets"
+    }
+}
+

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "AppName",
+  "name": "gluestick",
   "version": "0.1.7",
   "description": "",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gluestick",
+  "name": "AppName",
   "version": "0.1.6",
   "description": "",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AppName",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "",
   "main": "build/index.js",
   "bin": "src/cli-harmony.js",

--- a/src/auto-upgrade.js
+++ b/src/auto-upgrade.js
@@ -50,6 +50,15 @@ module.exports = function () {
         }
     });
 
+    // If there is no src/config/application.js file make one now (This is to upgrade apps created prior to 0.1.6)
+    try {
+        fs.statSync(path.join(process.cwd(), "src/config/application.js"))
+    }
+    catch (e) {
+        const newApplicationConfigFile = fs.readFileSync(path.join(__dirname, "..", "new", "src", "config", "application.js"), "utf8");
+        replaceFile("application.js", newApplicationConfigFile);
+    }
+
     // @TODO we should load the package.json file and match up the gluestick module version to the CLI version
 };
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -21,6 +21,7 @@ const scripts = {
     generate: generate,
     "start-test": startTest,
     "start-client": startClient,
+    "build": startClient.bind(null, true),
     "start-server": startServer,
     "--version": showVersion,
     help: help

--- a/src/cli.js
+++ b/src/cli.js
@@ -64,9 +64,9 @@ function startAll() {
     var client = spawnProcess("client");
     var server = spawnProcess("server");
 
-    // Start tests unless they asked us not to
+    // Start tests unless they asked us not to or we are in production mode
     // @TODO: would be better to use something like `commander` for these things
-    if (process.argv[3] !== "--no-tests") {
+    if (!isProduction && process.argv[3] !== "--no-tests") {
         var testProcess = spawnProcess("test");
     }
 

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -6,6 +6,7 @@ Available Commands:
   gluestick generate component COMPONENT_NAME   # Generate a new component and test file
   gluestick generate reducer REDUCER_NAME       # Generator used for creating things
   gluestick help                                # What you are seeing now
+  gluestick build                               # Create production asset build
   gluestick start [options]                     # Start everything
 
 Start Options:

--- a/src/commands/start-client.js
+++ b/src/commands/start-client.js
@@ -10,7 +10,7 @@ var ExtractTextPlugin = require("extract-text-webpack-plugin");
 var PORT = 8888;
 var OUTPUT_PATH = path.join(process.cwd(), "build");
 var OUTPUT_FILE = "main-bundle.js";
-var PUBLIC_PATH = "http://localhost:" + PORT + "/";
+var PUBLIC_PATH = "http://localhost:" + PORT + "/assets/";
 
 var webpackIsomorphicToolsPlugin = new WebpackIsomorphicToolsPlugin(require('../../webpack-isomorphic-tools-configuration'))
                                         .development(process.env.NODE_ENV !== "production");
@@ -113,8 +113,8 @@ var compiler = webpack({
     }
 });
 
-module.exports = function () {
-    if (!isProduction) {
+module.exports = function (buildOnly) {
+    if (!buildOnly && !isProduction) {
         var app = express();
         app.use(require("webpack-dev-middleware")(compiler, {
             noInfo: true,
@@ -136,8 +136,10 @@ module.exports = function () {
         });
     }
     else {
+        console.log(chalk.yellow("Bundling assets…"));
         compiler.run(() => {
-            console.log(chalk.green("Production assets compiled"));
+            console.log(chalk.green("Assets have been prepared for production."));
+            console.log(chalk.green(`Assets can be served from the /assets route but it is recommended that you serve the generated \`build\` folder from a Content Delivery Network`));
         });
     }
 };

--- a/src/commands/start-server.js
+++ b/src/commands/start-server.js
@@ -1,9 +1,12 @@
 var express = require("express");
+var chalk = require("chalk");
 
 var WebpackIsomorphicTools = require("webpack-isomorphic-tools");
 var projectBasePath = process.cwd();
 
-var PORT = 8880;
+var isProduction = process.env.NODE_ENV === "production";
+
+var PORT = isProduction ? 8888 : 8880;
 
 module.exports = function () {
     global.webpackIsomorphicTools = new WebpackIsomorphicTools(require("../../webpack-isomorphic-tools-configuration"))
@@ -12,13 +15,17 @@ module.exports = function () {
             var app = express();
             var serverRequestHandler = require("../lib/server-request-handler");
 
-            // @TODO do better job of settings this up for production environment, we probably
-            // only want to serve assets in dev mode and lean on a CDN in production
-            app.use("/assets", express.static("assets"));
+            if (isProduction) {
+                app.use("/assets", express.static("build"));
+                console.log(chalk.green("Server side rendering server running at http://localhost:" + PORT));
+
+            }
+            else {
+                console.log("Server side rendering proxy running at http://localhost:" + PORT);
+            }
 
             app.use(serverRequestHandler);
             app.listen(PORT);
-            console.log("Backend proxy running on " + PORT);
         });
 };
 

--- a/src/lib/server-request-handler.js
+++ b/src/lib/server-request-handler.js
@@ -8,7 +8,7 @@ import { match, RoutingContext, Route } from "react-router";
 
 import prepareRoutesWithTransitionHooks from "./prepareRoutesWithTransitionHooks";
 import Body from "../shared/components/Body";
-import head from "../shared/components/head";
+import getHead from "../shared/components/getHead";
 
 const pretty = new PrettyError();
 
@@ -22,6 +22,8 @@ module.exports = async function (req, res) {
         const Entry = require(path.join(process.cwd(), "src/config/.entry"));
         const store = require(path.join(process.cwd(), "src/config/.store"));
         const originalRoutes = require(path.join(process.cwd(), "src/config/routes"));
+        const rawConfig = require(path.join(process.cwd(), "src/config/application"));
+        const config = rawConfig[process.env.NODE_ENV] || rawConfig.development;
         const routes = prepareRoutesWithTransitionHooks(originalRoutes);
         match({routes: routes, location: req.path}, async (error, redirectLocation, renderProps) => {
             try {
@@ -44,11 +46,12 @@ module.exports = async function (req, res) {
                     // grab the main component which is capable of loading routes
                     // and hot loading them if in development mode
                     const radiumConfig = { userAgent: req.headers["user-agent"] };
-                    const main = createElement(Entry, {store: store, routingContext: routingContext, radiumConfig: radiumConfig});
+                    const main = createElement(Entry, {store: store, routingContext: routingContext, config: config, radiumConfig: radiumConfig});
 
                     // grab the react generated body stuff. This includes the
                     // script tag that hooks up the client side react code.
-                    const body = createElement(Body, {html: renderToString(main), initialState: store.getState()});
+                    const body = createElement(Body, {html: renderToString(main), config: config, initialState: store.getState()});
+                    const head = getHead(config);
 
                     // Grab the html from the project which is stored in the root
                     // folder named Index.js. Pass the body and the head to that

--- a/src/lib/server-request-handler.js
+++ b/src/lib/server-request-handler.js
@@ -12,7 +12,12 @@ import head from "../shared/components/head";
 
 const pretty = new PrettyError();
 
+process.on("unhandledRejection", (reason, promise) => {
+    console.log(chalk.red(reason), promise);
+});
+
 module.exports = async function (req, res) {
+    try {
         const Index = require(path.join(process.cwd(), "Index"));
         const Entry = require(path.join(process.cwd(), "src/config/.entry"));
         const store = require(path.join(process.cwd(), "src/config/.store"));
@@ -57,11 +62,16 @@ module.exports = async function (req, res) {
                     // @TODO custom 404 handling
                     res.status(404).send("Not Found");
                 }
-        }
-        catch (error) {
-            console.error('SERVER ERROR:', pretty.render(error));
-            res.status(500).send({error: error.stack});
-        }
-    });
+            }
+            catch (error) {
+                console.error('SERVER ERROR:', pretty.render(error));
+                res.status(500).send({error: error.stack});
+            }
+        });
+    }
+    catch (error) {
+        console.error('A SERVER ERROR:', pretty.render(error));
+        res.status(500).send({error: error.stack});
+    }
 };
 

--- a/src/shared/components/Body.js
+++ b/src/shared/components/Body.js
@@ -4,13 +4,14 @@ import serialize from "serialize-javascript";
 export default class Body extends Component {
     render () {
         const {
-            initialState
+            initialState,
+            config
         } = this.props;
         return (
             <div>
                 <div id="main" dangerouslySetInnerHTML={{__html: this.props.html}} />
                 <script type="text/javascript" dangerouslySetInnerHTML={{__html: `window.__INITIAL_STATE__=${serialize(initialState)};`}}></script>
-                <script type="text/javascript" src="http://localhost:8888/main-bundle.js"></script>
+                <script type="text/javascript" src={`${config.assetPath}/main-bundle.js`}></script>
             </div>
         );
     }

--- a/src/shared/components/getHead.js
+++ b/src/shared/components/getHead.js
@@ -1,0 +1,8 @@
+import React, { Component } from "react";
+
+export default (config) => {
+    return [
+        <link key={0} rel="stylesheet" type="text/css" href={`${config.assetPath}/main.css`} />
+    ];
+};
+

--- a/src/shared/components/head.js
+++ b/src/shared/components/head.js
@@ -1,7 +1,0 @@
-import React, { Component } from "react";
-
-export default [
-    // @TODO make this point to the development or production path based on env
-    <link key={0} rel="stylesheet" type="text/css" href="/main.css" />
-];
-


### PR DESCRIPTION
Production mode bundles the assets so you can load them from a CDN, it disables hot module replacement and doesn't use webpack dev tools for static file serving.
