### PR TITLE
add matchMedia polyfill (IE9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "karma-sourcemap-loader": "0.3.6",
     "karma-spec-reporter": "0.0.23",
     "karma-webpack": "1.7.0",
+    "match-media": "0.2.0",
     "mocha": "2.3.4",
     "node-sass": "3.4.2",
     "pretty-error": "1.2.0",

--- a/src/entrypoints/client.js
+++ b/src/entrypoints/client.js
@@ -3,3 +3,4 @@ require("match-media/matchMedia.addListener.js");
 require("babel-core/polyfill");
 var Entry = require(__PATH_TO_ENTRY__);
 Entry.start();
+

--- a/src/entrypoints/client.js
+++ b/src/entrypoints/client.js
@@ -1,4 +1,5 @@
+require("match-media/matchMedia.js");
+require("match-media/matchMedia.addListener.js");
 require("babel-core/polyfill");
 var Entry = require(__PATH_TO_ENTRY__);
 Entry.start();
-


### PR DESCRIPTION
Add polyfills to support Radium media queries on IE9
https://github.com/paulirish/matchMedia.js
