### PR TITLE
remove default params from cli.js

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -87,7 +87,9 @@ function spawnProcess (type) {
     return childProcess;
 }
 
-function startAll(withoutTests=false) {
+function startAll(withoutTests) {
+    var withoutTests = withoutTests || false;
+    
     autoUpgrade();
 
     var client = spawnProcess("client");


### PR DESCRIPTION
Version 0.1.8 of gluestick generates an app that can't be started:

```
$ npm start

> AppName@1.0.0 start /Users/a/FooApp
> gluestick start

/Users/a/FooApp/node_modules/gluestick/src/cli.js:90
function startAll(withoutTests=false) {
                              ^

SyntaxError: Unexpected token =
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:374:25)
    at Module._extensions..js (module.js:405:10)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/a/FooApp/node_modules/babel-core/lib/api/register/node.js:214:7)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Module.require (module.js:354:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/Users/a/FooApp/node_modules/gluestick/src/cli-harmony.js:17:1)
    at Module._compile (module.js:398:26)
```

This is due to the fact that default params haven't yet landed in node: https://github.com/nodejs/node/issues/3070

This pull request puts the default value within the function. Writing a test for this is beyond my testing abilities, but I did generate and start an app with this branch on my machine and confirmed it works.
