### PR TITLE
Render simple loading page during server restarts

### DIFF
--- a/src/commands/start-client.js
+++ b/src/commands/start-client.js
@@ -126,6 +126,15 @@ module.exports = function (buildOnly) {
                 return require("url").parse(req.url).path;
             }
         }));
+        app.use(function(err, req, res, next) {
+            if (err && err.code == "ECONNREFUSED") {
+                // render a friendly loading page during server restarts
+                res.status(200).sendFile("poll.html", {root: path.join(__dirname, "../lib")});
+            }
+            else {
+                next(err);
+            }
+        });
         app.listen(PORT, "localhost", function (error) {
             if (error) {
                 console.log(error);

--- a/src/commands/start-server.js
+++ b/src/commands/start-server.js
@@ -21,6 +21,12 @@ module.exports = function () {
 
             }
             else {
+                app.get("/gluestick-proxy-poll", function(req, res) { 
+                    // allow requests from our client side loading page
+                    res.header("Access-Control-Allow-Origin", "*"); 
+                    res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+                    res.status(200).json({up: true}); 
+                });
                 console.log("Server side rendering proxy running at http://localhost:" + PORT);
             }
 

--- a/src/lib/poll.html
+++ b/src/lib/poll.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <style>
+      body {
+        color: white;
+        font-family: sans-serif; 
+        padding: 2em; 
+        background: #ECF3F7;
+      }
+      .loader {
+        margin: 60px auto;
+        font-size: 10px;
+        position: relative;
+        text-indent: -9999em;
+        border-top: 1.1em solid rgba(255, 255, 255, 0.2);
+        border-right: 1.1em solid rgba(255, 255, 255, 0.2);
+        border-bottom: 1.1em solid rgba(255, 255, 255, 0.2);
+        border-left: 1.1em solid #ffffff;
+        -webkit-transform: translateZ(0);
+        -ms-transform: translateZ(0);
+        transform: translateZ(0);
+        -webkit-animation: load8 1.1s infinite linear;
+        animation: load8 1.1s infinite linear;
+      }
+      .loader,
+      .loader:after {
+        border-radius: 50%;
+        width: 10em;
+        height: 10em;
+      }
+      @-webkit-keyframes load8 {
+        0% {
+          -webkit-transform: rotate(0deg);
+          transform: rotate(0deg);
+        }
+        100% {
+          -webkit-transform: rotate(360deg);
+          transform: rotate(360deg);
+        }
+      }
+      @keyframes load8 {
+        0% {
+          -webkit-transform: rotate(0deg);
+          transform: rotate(0deg);
+        }
+        100% {
+          -webkit-transform: rotate(360deg);
+          transform: rotate(360deg);
+        }
+      }
+    </style>
+    <script>
+      var httpRequest;
+  
+      function queryServer() {
+        httpRequest = new XMLHttpRequest();
+        if (!httpRequest) return;
+  
+        httpRequest.onreadystatechange = reload;
+        httpRequest.open("GET", "http://localhost:8880/gluestick-proxy-poll");
+        httpRequest.send();
+      }
+  
+      function reload() {
+        if (httpRequest.readyState === XMLHttpRequest.DONE) {
+          if (httpRequest.status === 200) { 
+            window.location.reload();
+          } 
+          else { 
+            // server is still restarting, poll again
+            setTimeout(queryServer, 250);
+          }
+        }
+      }
+  
+      setTimeout(queryServer, 250);
+    </script>
+  </head>
+  <body>
+    <h1 style="text-align: center">Restarting dev server...</h1>
+    <div class="loader">
+      Loading...
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This PR addresses issues seen when one refreshes the page during server restarts.  

A loading screen with a spinner is now rendered instead of a page with the error "Error: connect ECONNREFUSED 127.0.0.1:8880."
