### PR TITLE
Fix shared `store` instance bug

### DIFF
--- a/new/src/config/.entry.js
+++ b/new/src/config/.entry.js
@@ -12,7 +12,7 @@ import "../../Index.js";
 
 export default class Entry extends Component {
     static defaultProps = {
-        store: store
+        store: store()
     };
 
     render () {

--- a/new/src/config/.store.js
+++ b/new/src/config/.store.js
@@ -1,5 +1,7 @@
 /** DO NOT MODIFY **/
 // The following lines create the store and properly sets up hot module replacement for reducers
 import { createStore } from "gluestick";
-export default createStore(() => require("../reducers"), (cb) => module.hot && module.hot.accept("../reducers", cb));
+export default function () {
+    return createStore(() => require("../reducers"), (cb) => module.hot && module.hot.accept("../reducers", cb));
+}
 

--- a/src/lib/server-request-handler.js
+++ b/src/lib/server-request-handler.js
@@ -20,7 +20,7 @@ module.exports = async function (req, res) {
     try {
         const Index = require(path.join(process.cwd(), "Index"));
         const Entry = require(path.join(process.cwd(), "src/config/.entry"));
-        const store = require(path.join(process.cwd(), "src/config/.store"));
+        const store = require(path.join(process.cwd(), "src/config/.store"))();
         const originalRoutes = require(path.join(process.cwd(), "src/config/routes"));
         const rawConfig = require(path.join(process.cwd(), "src/config/application"));
         const config = rawConfig[process.env.NODE_ENV] || rawConfig.development;


### PR DESCRIPTION
The way the store was being created and imported was actually creating a
single store instance that was shared on the server. This update ensures
that it generates a new store on each new web request.
