### PR TITLE
Add `gsBeforeRoute` and deprecate `fetchData`

### DIFF
--- a/generate/component.js
+++ b/generate/component.js
@@ -1,12 +1,12 @@
 import React, { Component, PropTypes } from "react";
 
 export default class __$NAME__ extends Component {
-    render () {
-        return (
-            <div>
-                __$NAME__
-            </div>
-        );
-    }
+  render () {
+    return (
+      <div>
+        __$NAME__
+      </div>
+    );
+  }
 }
 

--- a/generate/component.test.js
+++ b/generate/component.test.js
@@ -1,10 +1,10 @@
 import __$NAME__ from "components/__$NAME__";
 
 describe("components/__$NAME__", () => {
-    it("should render without an issue", () => {
-        const subject = <__$NAME__ />;
-        const renderedSubject = TestUtils.renderIntoDocument(subject);
-        expect(renderedSubject).to.not.equal(undefined);
-    });
+  it("should render without an issue", () => {
+    const subject = <__$NAME__ />;
+    const renderedSubject = TestUtils.renderIntoDocument(subject);
+    expect(renderedSubject).to.not.equal(undefined);
+  });
 });
 

--- a/generate/container.js
+++ b/generate/container.js
@@ -3,16 +3,30 @@ import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 
 @connect(
-    (state) => ({/** _INSERT_STATE_  **/}),
-    (dispatch) => bindActionCreators({/** _INSERT_ACTION_CREATORS_ **/}, dispatch)
+  (state) => ({/** _INSERT_STATE_  **/}),
+  (dispatch) => bindActionCreators({/** _INSERT_ACTION_CREATORS_ **/}, dispatch)
 )
 export default class __$NAME__ extends Component {
-    static fetchData ({dispatch}) {}
+  /**
+   * Called by ReactRouter before loading the container. Called prior to the
+   * React life cycle so doesn't have access to component's props or state.
+   *
+   * @param {Object} store redux store object
+   * @param {Object} renderProps render properties returned from ReactRouter
+   * @param {Object} query location data
+   * @param {Object} serverProps server specific properties
+   * @param {Boolean} serverProps.isServer method running on server or not
+   * @param {Request} [serverProps.request] express request if isServer
+   *
+   * @return {(Promise|undefined)} If this method returns a promise, the router
+   * will wait for the promise to resolve before the container is loaded.
+   */
+  static gsBeforeRoute ({dispatch}, renderProps, query, serverProps)
 
-    render () {
-        return (
-            <div>__$NAME__</div>
-        );
-    }
+  render () {
+    return (
+      <div>__$NAME__</div>
+    );
+  }
 }
 

--- a/generate/reducer.js
+++ b/generate/reducer.js
@@ -1,9 +1,9 @@
 const INITIAL_STATE = null;
 
 export default (state=INITIAL_STATE, action) => {
-    switch (action.type) {
-        default:
-            return state;
-    }
+  switch (action.type) {
+    default:
+      return state;
+  }
 };
 

--- a/src/lib/route-helper.js
+++ b/src/lib/route-helper.js
@@ -1,7 +1,14 @@
-const getFetchData = (component = {}) => {
-  return component.WrappedComponent ?
-    getFetchData(component.WrappedComponent) :
-      component.fetchData;
+const getBeforeRoute = (component = {}) => {
+  const c = component.WrappedComponent || component;
+
+  // @deprecated since 0.2
+  // check for deprecated fetchData method
+  if (c.fetchData) {
+    console.warn("`fetchData` is deprecated. Please use `gsBeforeRoute` instead.");
+    return c.fetchData;
+  }
+
+  return c.gsBeforeRoute || c.fetchData;
 };
 
 function getRouteComponents(routes) {
@@ -17,21 +24,31 @@ function getRouteComponents(routes) {
   return components;
 }
 
-export function fetchAllData(store, renderProps) {
+/**
+ * @param {ReduxStore} store the redux store
+ * @param {Object} renderProps render properties
+ * @param {Object} [serverProps] server specific properties
+ * @param {Boolean} [serverProps.isServer] whether or not we are running from the
+ * server
+ * @param {Express.Request} [serverProps.request] if we are on the server, the
+ * server request that triggered the method
+ */
+export function runBeforeRoutes (store, renderProps, serverParams) {
   const { params, location: query } = renderProps;
+  serverParams = serverParams || {isServer: false};
 
   const promises = getRouteComponents(renderProps.routes)
-  .map(getFetchData).filter(f => f) // only look at ones with a static fetchData()
-  .map(fetchData => fetchData(store, params, query || {}));  // call fetch data methods and save promises
+  .map(getBeforeRoute).filter(f => f) // only look at ones with a static gsBeforeRoute()
+  .map(beforeRoute => beforeRoute(store, params, query || {}, serverParams));  // call fetch data methods and save promises
 
   return Promise.all(promises)
 }
 
-export function createTransitionHook(store, history) {
+export function createTransitionHook (store, history) {
   return function(location, cb) {
     history.match(location, async function (error, redirectLocation, renderProps) {
       try {
-        await fetchAllData(store, renderProps)
+        await runBeforeRoutes(store, renderProps)
       } catch(err) {
         console.error(err);
       } finally {

--- a/src/lib/route-helper.js
+++ b/src/lib/route-helper.js
@@ -32,7 +32,7 @@ function getRouteComponents(routes) {
  * @param {Express.Request} [serverProps.request] if we are on the server, the
  * server request that triggered the method
  */
-export function runBeforeRoutes (store, renderProps, serverParams) {
+export function runBeforeRoutes (store, renderProps, serverProps) {
   const { params, location: query } = renderProps;
   serverParams = serverParams || {isServer: false};
 

--- a/src/lib/route-helper.js
+++ b/src/lib/route-helper.js
@@ -1,7 +1,7 @@
 const getBeforeRoute = (component = {}) => {
   const c = component.WrappedComponent || component;
 
-  // @deprecated since 0.2
+  // @deprecated since 1.12
   // check for deprecated fetchData method
   if (c.fetchData) {
     console.warn("`fetchData` is deprecated. Please use `gsBeforeRoute` instead.");

--- a/src/lib/route-helper.js
+++ b/src/lib/route-helper.js
@@ -1,7 +1,7 @@
 const getBeforeRoute = (component = {}) => {
   const c = component.WrappedComponent || component;
 
-  // @deprecated since 1.12
+  // @deprecated since 0.2
   // check for deprecated fetchData method
   if (c.fetchData) {
     console.warn("`fetchData` is deprecated. Please use `gsBeforeRoute` instead.");

--- a/src/lib/route-helper.js
+++ b/src/lib/route-helper.js
@@ -5,7 +5,6 @@ const getBeforeRoute = (component = {}) => {
   // check for deprecated fetchData method
   if (c.fetchData) {
     console.warn("`fetchData` is deprecated. Please use `gsBeforeRoute` instead.");
-    return c.fetchData;
   }
 
   return c.gsBeforeRoute || c.fetchData;

--- a/src/lib/server-request-handler.js
+++ b/src/lib/server-request-handler.js
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import path from "path";
 import { createElement } from "react";
 import { renderToString } from "react-dom/server";
-import { fetchAllData } from "./route-helper";
+import { runBeforeRoutes } from "./route-helper";
 import { match, RoutingContext, Route } from "react-router";
 import { ROUTE_NAME_404_NOT_FOUND } from "../shared/constants";
 import showHelpText, { MISSING_404_TEXT } from "../lib/help-text";
@@ -39,7 +39,7 @@ module.exports = async function (req, res) {
           // embed the router itself, on the server you embed a routing
           // context.
           // [https://github.com/rackt/react-router/blob/master/docs/guides/advanced/ServerRendering.md]
-          await fetchAllData(store, renderProps || {});
+          await runBeforeRoutes(store, renderProps || {}, {isServer: true, request: req});
           const routingContext = createElement(RoutingContext, renderProps);
 
           // grab the main component which is capable of loading routes


### PR DESCRIPTION
`fetchData` is currently the only place where you can execute code
before routing to a container. Since it is not only used for fetching
data, it shouldn't be called `fetchData`. Also, some people were
confusing `fetchData` as a React method and not realizing it was
specific to GlueStick. For this reason we are going to rename the method
to `gsBeforeRoute`.

Along with the rename, we need to include arguments so that developers
will know if this method is being called from the server or from the
client.

While updating the container generator I noticed that our generator
output needed to be re-tabbed so that was done with this commit as well.
