### PR TITLE
fix redux dev tools

### DIFF
--- a/new/package.json
+++ b/new/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "gluestick-shared": "0.0.4",
+    "gluestick-shared": "0.0.6",
     "radium": "0.16.2",
     "react": "0.14.6",
     "history": "1.16.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "extract-text-webpack-plugin": "0.9.1",
     "file-loader": "0.8.5",
     "fs-extra": "0.26.2",
-    "gluestick-shared": "0.0.4",
+    "gluestick-shared": "0.0.6",
     "history": "1.16.0",
     "inquirer": "0.11.0",
     "karma": "0.13.15",

--- a/src/shared/components/getHead.js
+++ b/src/shared/components/getHead.js
@@ -1,8 +1,10 @@
 import React, { Component } from "react";
+import serialize from "serialize-javascript";
 
 export default (config) => {
   return [
-    <link key={0} rel="stylesheet" type="text/css" href={`${config.assetPath}/main.css`} />
+    <link key={0} rel="stylesheet" type="text/css" href={`${config.assetPath}/main.css`} />,
+    <script type="text/javascript" dangerouslySetInnerHTML={{__html: `window.__GS_ENVIRONMENT__ = ${serialize(process.env.NODE_ENV)}`}}></script>
   ];
 };
 


### PR DESCRIPTION
There was no way for the dev tools to know which environment gluestick
was running in. We now expose this in a global variable and we only show
the dev tools if we are not in production mode

Related to https://github.com/TrueCar/gluestick-shared/commit/c2c655f48760e53913d9707446fb2e038dbd37d4
and
https://github.com/TrueCar/gluestick-shared/commit/2109beb26af2afd336d3c0f289599e98cc9ce4c2
