### PR TITLE
Add destroy to the CLI

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -8,6 +8,7 @@ const startClient = require("./commands/start-client");
 const startServer = require("./commands/start-server");
 const startTest = require("./commands/test");
 const generate = require("./commands/generate");
+const destroy = require("./commands/destroy");
 const chalk = require("chalk");
 const autoUpgrade = require("./auto-upgrade");
 const chokidar = require("chokidar");
@@ -31,6 +32,12 @@ commander
   .description("generate a new container")
   .arguments("<name>")
   .action(generate);
+
+commander
+  .command("destroy <container|component|reducer>")
+  .description("destroy a generated container")
+  .arguments("<name>")
+  .action(destroy);
 
 commander
   .command("start")
@@ -101,4 +108,3 @@ async function startAll(withoutTests=false) {
     var testProcess = spawnProcess("test");
   }
 }
-

--- a/src/commands/destroy.js
+++ b/src/commands/destroy.js
@@ -1,0 +1,107 @@
+var fs = require("fs");
+var path = require("path");
+var chalk = require("chalk");
+
+var availableCommands = {
+  "container": "containers",
+  "component": "components",
+  "reducer": "reducers"
+};
+
+module.exports = function () {
+  var command = process.argv[3];
+  var name = process.argv[4];
+
+  // Step 1: Check if we are in the root of a gluestick project by looking for the `.gluestick` file
+  try {
+    fs.statSync(path.join(process.cwd(), ".gluestick"));
+  }
+  catch (e) {
+    console.log(chalk.yellow(".gluestick file not found"));
+    console.log(chalk.red("ERROR: `destroy` commands must be run from the root of a gluestick project."));
+    return;
+  }
+
+  // Step 2: Validate the command type by verifying that it exists in `availableCommands`
+  if (!availableCommands[command]) {
+    console.log(chalk.red(`ERROR: ${chalk.yellow(command)} is not a valid destroy command.`));
+    console.log(chalk.yellow(`Available destroy commands: ${JSON.stringify(availableCommands)}`));
+    return;
+  }
+
+  // Step 3: Validate the name by stripping out unwanted characters
+  if (!name || name.length === 0) {
+    console.log(chalk.red(`ERROR: invalid arguments. You must specify a name.`));
+    return;
+  }
+
+  if (/\W/.test(name)) {
+    console.log(chalk.red(`ERROR: ${chalk.yellow(name)} is not a valid name.`));
+    return;
+  }
+
+  // Step 4: Possibly mutate the name by converting it to Pascal Case (only for container and component for now)
+  if (["container", "component"].indexOf(command) !== -1) {
+    name = name.substr(0, 1).toUpperCase() + name.substr(1);
+  }
+  if (["reducer", "action-creator"].indexOf(command) !== -1) {
+    name = name.substr(0, 1).toLowerCase() + name.substr(1);
+  }
+
+  // Step 5: Remove the file
+  var destinationPath = path.join(process.cwd(), "/src/", availableCommands[command] + "/" + name + ".js");
+  var fileExists = true;
+  try {
+    fs.statSync(destinationPath);
+  }
+  catch (e) {
+    fileExists = false;
+  }
+
+  if (fileExists) {
+    fs.unlinkSync(destinationPath);
+    console.log(chalk.red(`Removed file: ${destinationPath}`));
+  }
+  else {
+    console.log(chalk.red(`ERROR: ${chalk.yellow(destinationPath)} does not exist`));
+    return;
+  }
+
+  // Step 6: If we destroyed a reducer, remove it from the reducers index
+  if (command === "reducer") {
+    var reducerIndexPath = path.resolve(process.cwd(), "src/reducers/index.js");
+    try {
+      var indexLines = fs.readFileSync(reducerIndexPath, {encoding: "utf8"}).split("\n");
+      var reducerLine = `export { default as ${name} } from "./${name}"`;
+      var reducerLineIndex = indexLines.indexOf(reducerLine);
+      indexLines.splice(reducerLineIndex, 1);
+      fs.writeFileSync(reducerIndexPath, indexLines.join("\n"));
+      console.log(chalk.red(`${name} removed from reducer index ${reducerIndexPath}`));
+    }
+    catch (e) {
+      console.log(chalk.red(`ERROR: Unable to modify reducers index. Reducer not removed from index`));
+      return;
+    }
+  }
+
+  // Step 7: Remove the test file for a component
+  if(command === "component") {
+    var testPath = path.join(process.cwd(), "/test/", availableCommands[command], `/${name}.test.js`);
+    var testFileExists = true;
+    try {
+      fs.statSync(testPath);
+    }
+    catch (e) {
+      testFileExists = false;
+    }
+
+    if (testFileExists) {
+      fs.unlinkSync(testPath);
+      console.log(chalk.red(`Removed file: ${testPath}`));
+    }
+    else {
+      console.log(chalk.red(`ERROR: ${chalk.yellow(testPath)} does not exist`));
+      return;
+    }
+  }
+};

--- a/src/commands/destroy.js
+++ b/src/commands/destroy.js
@@ -1,6 +1,7 @@
 var fs = require("fs");
 var path = require("path");
 var chalk = require("chalk");
+var inquirer = require("inquirer");
 
 var availableCommands = {
   "container": "containers",
@@ -8,7 +9,8 @@ var availableCommands = {
   "reducer": "reducers"
 };
 
-module.exports = function () {
+// @NOTE, we use async here because we use await later in the function
+module.exports = async function () {
   var command = process.argv[3];
   var name = process.argv[4];
 
@@ -41,6 +43,7 @@ module.exports = function () {
   }
 
   // Step 4: Possibly mutate the name by converting it to Pascal Case (only for container and component for now)
+  var originalName = name; // store original name for later
   if (["container", "component"].indexOf(command) !== -1) {
     name = name.substr(0, 1).toUpperCase() + name.substr(1);
   }
@@ -59,8 +62,27 @@ module.exports = function () {
   }
 
   if (fileExists) {
+    // If they typed a name that would normally be mutated, check with the user first before deleting the files
+    if (originalName !== name) {
+      // @NOTE: We are using await so that we can wait for the result of the promise before moving on
+      const continueDestroying = await new Promise((resolve, reject) => {
+        const question = {
+          type: "confirm",
+          name: "confirm",
+          message: `You wanted to destroy ${chalk.yellow(originalName)} but the generated name is ${chalk.green(name)}. Would you like to continue with destroying ${chalk.green(name)}?`
+        };
+        inquirer.prompt([question], function (answers) {
+          if (!answers.confirm) resolve(false);
+          resolve(true);
+        });
+      });
+
+      // Since we used await, this code will not be executed until the promise above resolves
+      if (!continueDestroying) process.exit();
+    }
+
     fs.unlinkSync(destinationPath);
-    console.log(chalk.red(`Removed file: ${destinationPath}`));
+    console.log(`${chalk.red("Removed file:")} ${destinationPath}`);
   }
   else {
     console.log(chalk.red(`ERROR: ${chalk.yellow(destinationPath)} does not exist`));
@@ -71,12 +93,15 @@ module.exports = function () {
   if (command === "reducer") {
     var reducerIndexPath = path.resolve(process.cwd(), "src/reducers/index.js");
     try {
-      var indexLines = fs.readFileSync(reducerIndexPath, {encoding: "utf8"}).split("\n");
-      var reducerLine = `export { default as ${name} } from "./${name}"`;
-      var reducerLineIndex = indexLines.indexOf(reducerLine);
-      indexLines.splice(reducerLineIndex, 1);
-      fs.writeFileSync(reducerIndexPath, indexLines.join("\n"));
-      console.log(chalk.red(`${name} removed from reducer index ${reducerIndexPath}`));
+      const indexLines = fs.readFileSync(reducerIndexPath, {encoding: "utf8"}).split("\n");
+      const reducerLine = `export { default as ${name} } from "./${name}"`;
+      const newIndexLines = indexLines.filter((indexLine) => {
+        // Only return lines from the reducer index that do not return the reducer
+        // we just destroyed. Check for semi colon and non-semi colon lines
+        return indexLine !== reducerLine && indexLine !== `${reducerLine};`;
+      });
+      fs.writeFileSync(reducerIndexPath, newIndexLines.join("\n"));
+      console.log(chalk.red(`${name} removed`) + ` from reducer index ${reducerIndexPath}`);
     }
     catch (e) {
       console.log(chalk.red(`ERROR: Unable to modify reducers index. Reducer not removed from index`));
@@ -85,7 +110,7 @@ module.exports = function () {
   }
 
   // Step 7: Remove the test file for a component
-  if(command === "component") {
+  if (command === "component") {
     var testPath = path.join(process.cwd(), "/test/", availableCommands[command], `/${name}.test.js`);
     var testFileExists = true;
     try {

--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -108,7 +108,7 @@ module.exports = function () {
   }
 
   // Step 8: Write test file for component
-  if(["component"].indexOf(command) !== -1) {
+  if(command === "component") {
     var testPath = path.join(process.cwd(), "/test/", availableCommands[command], `/${name}.test.js`);
     var testTemplate;
     var testFileExists = true;

--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -87,18 +87,13 @@ module.exports = function () {
   if (command === "reducer") {
     var reducerIndexPath = path.resolve(process.cwd(), "src/reducers/index.js");
     try {
-      var indexLines = fs.readFileSync(reducerIndexPath, {encoding: "utf8"}).split("\n");
-      var lastLineIndex = indexLines.length - 1;
-      var newLine = `export { default as ${name} } from "./${name}"`;
-      if (indexLines[lastLineIndex] === "") {
-        indexLines.splice(lastLineIndex, 1, newLine);
-        indexLines.push("");
-      }
-      else {
-        indexLines.push(newLine);
-        indexLines.push("");
-      }
-      fs.writeFileSync(reducerIndexPath, indexLines.join("\n"));
+      // Get the file contents, but strip off any trailing whitespace. This sets us up
+      // to place the new export on the last line, followed by a blank whitespace line at the end
+      var indexFileContents = fs.readFileSync(reducerIndexPath, {encoding: "utf8"}).replace(/\s*$/, "");
+      var newLine = `export { default as ${name} } from "./${name}";`;
+
+      // Write back to the index file with the previous contents in addition to our new line and a blank line for git
+      fs.writeFileSync(reducerIndexPath, `${indexFileContents}\n${newLine}\n\n`);
       console.log(chalk.yellow(`${name} added to reducer index ${reducerIndexPath}`));
     }
     catch (e) {
@@ -143,4 +138,3 @@ module.exports = function () {
     console.log(chalk.green(`New file created: ${testPath}`));
   }
 };
-

--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -91,7 +91,7 @@ module.exports = function () {
       var lastLineIndex = indexLines.length - 1;
       var newLine = `export { default as ${name} } from "./${name}"`;
       if (indexLines[lastLineIndex] === "") {
-        indexLines.splice(lastLineIndex - 1, 1, newLine);
+        indexLines.splice(lastLineIndex, 1, newLine);
         indexLines.push("");
       }
       else {


### PR DESCRIPTION
I went to create a container, accidentally did `gluestick generate component something` and realized it would be nice to have a destroy method like [Rails](http://guides.rubyonrails.org/command_line.html#rails-destroy). I more or less copied what is in `src/commands/generate.js` but modified it as needed. 

Something to consider:
Steps 1 - 4 in `destroy` and `generate` are the same aside from the messages they log. Does that warrant possible extraction?
