### PR TITLE
Added a catch all command to the CLI 

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -70,6 +70,14 @@ commander
   .description("start tests")
   .action(() => spawnProcess("test", process.argv.slice(3)));
 
+// This is a catch all command. DO NOT PLACE ANY COMMANDS BELOW THIS
+commander
+  .command('*')
+  .action(function(cmd){
+    console.log(`Error: Command '${cmd}' not recognized`);
+    commander.help();
+});
+
 commander.parse(process.argv);
 
 function getVersion () {
@@ -108,4 +116,3 @@ async function startAll(withoutTests=false) {
     var testProcess = spawnProcess("test");
   }
 }
-

--- a/src/cli.js
+++ b/src/cli.js
@@ -72,7 +72,7 @@ commander
 
 // This is a catch all command. DO NOT PLACE ANY COMMANDS BELOW THIS
 commander
-  .command('*')
+  .command('*', null, {noHelp: true})
   .action(function(cmd){
     console.log(`Error: Command '${cmd}' not recognized`);
     commander.help();


### PR DESCRIPTION
Sometimes we mistype commands but Gluestick was just silently doing nothing. Users should be informed that they attempted to perform an unknown command and then shown the help to provide them with known commands.
![screen shot 2016-01-26 at 9 35 30 am](https://cloud.githubusercontent.com/assets/1280586/12588963/3113850c-c410-11e5-91e1-c935819a91d6.png)
