### PR TITLE
Custom redux middleware

### DIFF
--- a/new/src/config/.store.js
+++ b/new/src/config/.store.js
@@ -1,7 +1,7 @@
 /** DO NOT MODIFY **/
 // The following lines create the store and properly sets up hot module replacement for reducers
 import { createStore } from "gluestick-shared";
+import middleware from "./redux-middleware";
 export default function () {
-  return createStore(() => require("../reducers"), (cb) => module.hot && module.hot.accept("../reducers", cb), !!module.hot);
+  return createStore(() => require("../reducers"), middleware, (cb) => module.hot && module.hot.accept("../reducers", cb), !!module.hot);
 }
-

--- a/new/src/config/redux-middleware.js
+++ b/new/src/config/redux-middleware.js
@@ -1,0 +1,9 @@
+// Gluestick has already included thunk and a custom Promise middleware; any
+// middleware added here will be added after those.
+//
+// Example:
+// import createLogger from 'redux-logger';
+// const logger = createLogger();
+// export default [logger];
+
+export default [];

--- a/src/auto-upgrade.js
+++ b/src/auto-upgrade.js
@@ -53,13 +53,20 @@ module.exports = async function () {
     }
   });
 
-  // If there is no src/config/application.js file make one now (This is to upgrade apps created prior to 0.1.6)
-  try {
-    fs.statSync(path.join(process.cwd(), "src/config/application.js"))
-  }
-  catch (e) {
-    const newApplicationConfigFile = fs.readFileSync(path.join(__dirname, "..", "new", "src", "config", "application.js"), "utf8");
-    replaceFile("application.js", newApplicationConfigFile);
-  }
+  // Check for certain files that we've added to new Gluestick applications. If those files don't exist, add them
+  // for the user.
+  const newFiles = [
+    "src/config/application.js",      //-> prior to 0.1.6
+    "src/config/redux-middleware.js"  //-> prior to 0.1.12
+  ];
+  newFiles.forEach((filePath) => {
+    try {
+      fs.statSync(path.join(process.cwd(), filePath));
+    }
+    catch (e) {
+      const fileName = path.parse(filePath).base;
+      const newFile = fs.readFileSync(path.join(__dirname, "..", "new", filePath), "utf8");
+      replaceFile(fileName, newFile);
+    }
+  });
 };
-


### PR DESCRIPTION
User's of Gluestick may need to add custom redux middleware. This provides them with a way to do so. This also provides auto-upgrade support for this feature.

A precursor to this request is: https://github.com/TrueCar/gluestick-shared/pull/1
