### PR TITLE
Upgrade karma version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "gluestick-shared": "0.0.6",
     "history": "1.16.0",
     "inquirer": "0.11.0",
-    "karma": "0.13.15",
+    "karma": "0.13.19",
     "karma-chai": "0.1.0",
     "karma-chrome-launcher": "0.2.1",
     "karma-firefox-launcher": "0.1.7",


### PR DESCRIPTION
Latest karma version fixes sockets.forEach error that is thrown when shutting down Gluestick.
