### PR TITLE
Extendable Webpack

### DIFF
--- a/new/src/config/webpack-additions.js
+++ b/new/src/config/webpack-additions.js
@@ -1,0 +1,22 @@
+/**
+ * GlueStick uses webpack-isomorphic-tools to support server side rendering.
+ * The syntax for this is slightly different than the webpack config file.
+ * Instead of defining a `test` regex, you supply an array of extensions.
+ * For more information see: https://github.com/halt-hammerzeit/webpack-isomorphic-tools
+ *
+ * Example:
+ * additionalLoaders: [
+ *   {
+ *     extensions: ["xml"],
+ *     loader: "xml-loader"
+ *   }
+ * ]
+ *
+ * For the previous example to work, you would need to install `xml-loader` via npm. Then
+ * you can use this loader by simply using the `import` syntax like:
+ * import myData from "assets/xml/my-file.xml";
+ */
+module.exports = {
+  additionalLoaders: [],
+  additionalPreLoaders: []
+};

--- a/src/auto-upgrade.js
+++ b/src/auto-upgrade.js
@@ -53,13 +53,20 @@ module.exports = async function () {
     }
   });
 
-  // If there is no src/config/application.js file make one now (This is to upgrade apps created prior to 0.1.6)
-  try {
-    fs.statSync(path.join(process.cwd(), "src/config/application.js"))
-  }
-  catch (e) {
-    const newApplicationConfigFile = fs.readFileSync(path.join(__dirname, "..", "new", "src", "config", "application.js"), "utf8");
-    replaceFile("application.js", newApplicationConfigFile);
-  }
+  // Check for certain files that we've added to new Gluestick applications. If those files don't exist, add them
+  // for the user.
+  const newFiles = [
+    "src/config/application.js",      //-> prior to 0.1.6
+    "src/config/webpack-additions.js"  //-> prior to 0.1.12
+  ];
+  newFiles.forEach((filePath) => {
+    try {
+      fs.statSync(path.join(process.cwd(), filePath));
+    }
+    catch (e) {
+      const fileName = path.parse(filePath).base;
+      const newFile = fs.readFileSync(path.join(__dirname, "..", "new", filePath), "utf8");
+      replaceFile(fileName, newFile);
+    }
+  });
 };
-

--- a/src/commands/shared.js
+++ b/src/commands/shared.js
@@ -1,0 +1,50 @@
+var path = require("path");
+var process = require("process");
+var WebpackIsomorphicToolsPlugin = require("webpack-isomorphic-tools/plugin");
+
+const isProduction = process.env.NODE_ENV === "production";
+var webpackIsomorphicToolsPlugin = new WebpackIsomorphicToolsPlugin(require('../../webpack-isomorphic-tools-configuration'))
+.development(process.env.NODE_ENV !== "production");
+
+module.exports = {
+  resolve: {
+    extensions: ["", ".js", ".css"],
+    alias: {
+      "assets": path.join(process.cwd(), "assets")
+    }
+  },
+  loaders: [
+    {
+      test: /\.js$/,
+      loaders: ["babel-loader?stage=0&optional[]=runtime"],
+      include: [
+        path.join(process.cwd(), "Index.js"),
+        path.join(process.cwd(), "src"),
+        path.join(process.cwd(), "test"),
+        path.join(__dirname, "../shared")
+      ]
+    },
+    {
+      test: webpackIsomorphicToolsPlugin.regular_expression("images"),
+      loader: "file-loader",
+      include: [
+        path.join(process.cwd(), "assets"),
+        path.join(__dirname, "../shared/assets")
+      ]
+    },
+    {
+      test: webpackIsomorphicToolsPlugin.regular_expression("fonts"),
+      loader: "file-loader",
+      include: [
+        path.join(process.cwd(), "assets"),
+        path.join(__dirname, "../shared/assets")
+      ]
+    },
+    {
+      test: webpackIsomorphicToolsPlugin.regular_expression("json"),
+      loader: "json-loader"
+    }
+  ],
+  plugins: [],
+  preLoaders: []
+};

--- a/src/lib/get-webpack-additions.js
+++ b/src/lib/get-webpack-additions.js
@@ -1,0 +1,51 @@
+import fs from "fs";
+import process from "process";
+import path from "path";
+import WebpackIsomorphicToolsPlugin from "webpack-isomorphic-tools/plugin";
+
+/**
+ * GlueStick uses webpack-isomorphic-tools to support server side rendering.
+ * The syntax for this is slightly different than the webpack config file.
+ * Instead of defining a `test` regex, you supply an array of extensions.
+ * For more information see: https://github.com/halt-hammerzeit/webpack-isomorphic-tools.
+ *
+ * In order for the webpack-isomorphic-tools format to work with our webpack config, we
+ * need to convert the `extensions` array to a regex.
+ *
+ * @param {Array<Object>} additions array of loaders or preloaders formatted for webpack-isomorphic-tools
+ * @param {Array<String>} additions[n].extensions array of strings representing file extensions
+ * @param {String} additions[n].loader name of the loader to use
+ *
+ * @return {Object}
+ */
+function prepareUserAdditionsForWebpack (additions) {
+  return additions.map((addition) => {
+    return {
+      loader: addition.loader,
+      test: WebpackIsomorphicToolsPlugin.regular_expression(addition.extensions)
+    }
+  });
+}
+
+export default function () {
+  let userAdditions = {
+    additionalLoaders: [],
+    additionalPreLoaders: []
+  };
+
+  // Babel will try to resolve require statements ahead of time which will cause an error
+  // when you run any commands outside of a GlueStick project since the webpack-additions file
+  // has not been created yet. This way, we include the additions only if they exist.
+  try {
+    const webpackAdditionsPath = path.join(process.cwd(), "src", "config", "webpack-additions.js");
+    fs.statSync(webpackAdditionsPath);
+    const { additionalLoaders, additionalPreLoaders } = require(webpackAdditionsPath);
+    userAdditions = {
+      additionalLoaders: prepareUserAdditionsForWebpack(additionalLoaders),
+      additionalPreLoaders: prepareUserAdditionsForWebpack(additionalPreLoaders)
+    };
+  }
+  catch (e) {}
+
+  return userAdditions;
+}

--- a/webpack-isomorphic-tools-configuration.js
+++ b/webpack-isomorphic-tools-configuration.js
@@ -1,5 +1,12 @@
 var path = require("path");
+var process = require("process");
 var WebpackIsomorphicToolsPlugin = require("webpack-isomorphic-tools/plugin");
+const { additionalLoaders, additionalPreLoaders } = require(path.join(process.cwd(), "src/config/webpack-additions.js"));
+
+let userExtensions = [];
+[...additionalLoaders, ...additionalPreLoaders].forEach((loader) => {
+  userExtensions.splice(userExtensions.length, 0, ...loader.extensions);
+});
 
 module.exports = {
   assets: {
@@ -16,10 +23,12 @@ module.exports = {
     json: {
       extensions: ["json"],
       include: [process.cwd()]
+    },
+    other: {
+      extensions: userExtensions
     }
   },
   alias: {
     "assets": path.join(process.cwd(), "assets")
   }
 };
-


### PR DESCRIPTION
Some users may want to extend the Webpack settings that have been defined in Gluestick with their own Preloaders and Loaders. This change allows them to specify those Preloaders and Loaders in `webpack-additions.js` and then Gluestick will add them.

Plugins not currently supported.
