### PR TITLE
Fix bug with `webpack-additions` missing file

### DIFF
--- a/src/auto-upgrade.js
+++ b/src/auto-upgrade.js
@@ -56,9 +56,9 @@ module.exports = async function () {
   // Check for certain files that we've added to new Gluestick applications. If those files don't exist, add them
   // for the user.
   const newFiles = [
-    "src/config/application.js",      //-> prior to 0.1.6
-    "src/config/webpack-additions.js"  //-> prior to 0.1.12
-    "src/config/redux-middleware.js"  //-> prior to 0.1.12
+    "src/config/application.js",        //-> prior to 0.1.6
+    "src/config/webpack-additions.js",  //-> prior to 0.1.12
+    "src/config/redux-middleware.js"    //-> prior to 0.1.12
   ];
   newFiles.forEach((filePath) => {
     try {

--- a/src/lib/get-webpack-additions.js
+++ b/src/lib/get-webpack-additions.js
@@ -27,7 +27,7 @@ function prepareUserAdditionsForWebpack (additions) {
   });
 }
 
-export default function () {
+export default function (isomorphic=false) {
   let userAdditions = {
     additionalLoaders: [],
     additionalPreLoaders: []
@@ -41,8 +41,8 @@ export default function () {
     fs.statSync(webpackAdditionsPath);
     const { additionalLoaders, additionalPreLoaders } = require(webpackAdditionsPath);
     userAdditions = {
-      additionalLoaders: prepareUserAdditionsForWebpack(additionalLoaders),
-      additionalPreLoaders: prepareUserAdditionsForWebpack(additionalPreLoaders)
+      additionalLoaders: isomorphic ? additionalLoaders : prepareUserAdditionsForWebpack(additionalLoaders),
+      additionalPreLoaders: isomorphic ? additionalPreLoaders : prepareUserAdditionsForWebpack(additionalPreLoaders)
     };
   }
   catch (e) {}

--- a/webpack-isomorphic-tools-configuration.js
+++ b/webpack-isomorphic-tools-configuration.js
@@ -1,7 +1,18 @@
 var path = require("path");
 var process = require("process");
 var WebpackIsomorphicToolsPlugin = require("webpack-isomorphic-tools/plugin");
-const { additionalLoaders, additionalPreLoaders } = require(path.join(process.cwd(), "src/config/webpack-additions.js"));
+
+// We use `get-webpack-additions` to get the data back because it will first
+// check if the file exists before trying to include it, falling back to empty
+// arrays for defaults. Requiring get-webpack-additions will return a function
+// instead of the result so we can execute the check asynchronously vs making
+// it part of the initial build. If it were a simple require it would throw an
+// error when babel or webpack try to resolve missing dependencies. We then
+// call this method with `true` as the first and only argument because that is
+// how we tell the method we are requiring for the purpose of the isomorphic
+// tools, not the webpack config file.
+const { additionalLoaders, additionalPreLoaders } = require("./src/lib/get-webpack-additions")(true);
+
 
 let userExtensions = [];
 [...additionalLoaders, ...additionalPreLoaders].forEach((loader) => {


### PR DESCRIPTION
We use `get-webpack-additions` to get the data back because it will first
check if the file exists before trying to include it, falling back to empty
arrays for defaults. Requiring get-webpack-additions will return a function
instead of the result so we can execute the check asynchronously vs making
it part of the initial build. If it were a simple require it would throw an
error when babel or webpack try to resolve missing dependencies. We then
call this method with `true` as the first and only argument because that is
how we tell the method we are requiring for the purpose of the isomorphic
tools, not the webpack config file.
