### PR TITLE
Enable css hotloading in development mode

### DIFF
--- a/src/commands/start-client.js
+++ b/src/commands/start-client.js
@@ -59,7 +59,7 @@ var compiler = webpack({
       // only place client specific loaders here
       {
         test: webpackIsomorphicToolsPlugin.regular_expression("styles"),
-        loader: ExtractTextPlugin.extract("style", "css!sass")
+        loader: isProduction ? ExtractTextPlugin.extract("style", "css!sass") : "style!css!sass"
       }
     ].concat(shared.loaders, additionalLoaders),
     preLoaders: [

--- a/webpack-isomorphic-tools-configuration.js
+++ b/webpack-isomorphic-tools-configuration.js
@@ -25,7 +25,14 @@ module.exports = {
       extensions: ["png", "jpg", "gif", "ico", "svg"]
     },
     styles: {
-      extensions: ["css", "scss", "sass"]
+      extensions: ["css", "scss", "sass"],
+      filter: function(module, regular_expression, options, log) {
+        if (options.development) {
+          return WebpackIsomorphicToolsPlugin.style_loader_filter(module, regular_expression, options, log)
+        }
+      },
+      path: WebpackIsomorphicToolsPlugin.style_loader_path_extractor,
+      parser: WebpackIsomorphicToolsPlugin.css_loader_parser
     },
     fonts: {
       extensions: ["woff", "woff2", "ttf", "eot"],


### PR DESCRIPTION
We want to use ExtractTextPlugin in prod mode, but in dev mode just use the normal style loader.
