### PR TITLE
Fix style flicker issue in dev mode

### DIFF
--- a/src/lib/server-request-handler.js
+++ b/src/lib/server-request-handler.js
@@ -48,7 +48,8 @@ module.exports = async function (req, res) {
           // grab the react generated body stuff. This includes the
           // script tag that hooks up the client side react code.
           const body = createElement(Body, {html: renderToString(main), config: config, initialState: store.getState()});
-          const head = getHead(config);
+          const head = getHead(config, webpackIsomorphicTools.assets());
+
 
           if (renderProps.routes[renderProps.routes.length - 1].name === ROUTE_NAME_404_NOT_FOUND) {
             res.status(404);

--- a/src/shared/components/getHead.js
+++ b/src/shared/components/getHead.js
@@ -1,10 +1,28 @@
 import React, { Component } from "react";
 import serialize from "serialize-javascript";
+import path from "path";
 
-export default (config) => {
-  return [
-    <link key={0} rel="stylesheet" type="text/css" href={`${config.assetPath}/main.css`} />,
-    <script type="text/javascript" dangerouslySetInnerHTML={{__html: `window.__GS_ENVIRONMENT__ = ${serialize(process.env.NODE_ENV)}`}}></script>
-  ];
+const isProduction = process.env.NODE_ENV === "production";
+
+export default (config, assets) => {
+  let tags = [];
+  let key = 0;
+
+  if (isProduction) {
+    tags.push(<link key={key++} rel="stylesheet" type="text/css" href={`${config.assetPath}/main.css`} />);
+  }
+  else {
+    // Resolve style flicker on page load in dev mode
+    Object.keys(assets.assets).forEach(assetPath => {
+      if (!assetPath.endsWith(".css")) return;
+      tags.push(<style key={key++} dangerouslySetInnerHTML={{__html: require(path.join(process.cwd(), assetPath))}} />);
+    });
+  }
+
+  tags.push(
+    <script key={key++} type="text/javascript" dangerouslySetInnerHTML={{__html: `window.__GS_ENVIRONMENT__ = ${serialize(process.env.NODE_ENV)}`}}></script>
+  );
+
+  return tags;
 };
 

--- a/webpack-isomorphic-tools-configuration.js
+++ b/webpack-isomorphic-tools-configuration.js
@@ -26,9 +26,9 @@ module.exports = {
     },
     styles: {
       extensions: ["css", "scss", "sass"],
-      filter: function(module, regular_expression, options, log) {
+      filter: function(module, regex, options, log) {
         if (options.development) {
-          return WebpackIsomorphicToolsPlugin.style_loader_filter(module, regular_expression, options, log)
+          return WebpackIsomorphicToolsPlugin.style_loader_filter(module, regex, options, log)
         }
       },
       path: WebpackIsomorphicToolsPlugin.style_loader_path_extractor,


### PR DESCRIPTION
Use the assets that webpack-isomorphic-tools provides to render styles in dev mode, preventing the style flash seen when reloading a page.
