### PR TITLE
Move webpack-isomorphic-tools-configuration inside src/

### DIFF
--- a/src/commands/shared.js
+++ b/src/commands/shared.js
@@ -3,7 +3,7 @@ var process = require("process");
 var WebpackIsomorphicToolsPlugin = require("webpack-isomorphic-tools/plugin");
 
 const isProduction = process.env.NODE_ENV === "production";
-var webpackIsomorphicToolsPlugin = new WebpackIsomorphicToolsPlugin(require('../../webpack-isomorphic-tools-configuration'))
+var webpackIsomorphicToolsPlugin = new WebpackIsomorphicToolsPlugin(require('../lib/webpack-isomorphic-tools-configuration'))
 .development(process.env.NODE_ENV !== "production");
 
 module.exports = {

--- a/src/commands/start-client.js
+++ b/src/commands/start-client.js
@@ -15,7 +15,7 @@ var OUTPUT_PATH = path.join(process.cwd(), "build");
 var OUTPUT_FILE = "main-bundle.js";
 var PUBLIC_PATH = "http://localhost:" + PORT + "/assets/";
 
-var webpackIsomorphicToolsPlugin = new WebpackIsomorphicToolsPlugin(require('../../webpack-isomorphic-tools-configuration'))
+var webpackIsomorphicToolsPlugin = new WebpackIsomorphicToolsPlugin(require('../lib/webpack-isomorphic-tools-configuration'))
 .development(process.env.NODE_ENV !== "production");
 
 process.env.NODE_PATH = path.join(__dirname, "../..");

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -16,7 +16,7 @@ const preprocessors = {};
 const helperPath = path.resolve(__dirname, "../lib/test-helper.js");
 preprocessors[helperPath] = ["webpack", "sourcemap"];
 
-var webpackIsomorphicToolsPlugin = new WebpackIsomorphicToolsPlugin(require('../../webpack-isomorphic-tools-configuration')).development(true);
+var webpackIsomorphicToolsPlugin = new WebpackIsomorphicToolsPlugin(require('../lib/webpack-isomorphic-tools-configuration')).development(true);
 
 const config = {
   browsers: ["Chrome"],

--- a/src/lib/server-side-rendering.js
+++ b/src/lib/server-side-rendering.js
@@ -11,7 +11,7 @@ var isProduction = process.env.NODE_ENV === "production";
 var PORT = process.env.PORT || (isProduction ? 8888 : 8880);
 
 (function () {
-  global.webpackIsomorphicTools = new WebpackIsomorphicTools(require("../../webpack-isomorphic-tools-configuration"))
+  global.webpackIsomorphicTools = new WebpackIsomorphicTools(require("./webpack-isomorphic-tools-configuration"))
   .development(process.NODE_ENV !== "production")
   .server(process.cwd(), function () {
     var app = express();
@@ -36,4 +36,3 @@ var PORT = process.env.PORT || (isProduction ? 8888 : 8880);
     app.listen(PORT);
   });
 })();
-

--- a/src/lib/webpack-isomorphic-tools-configuration.js
+++ b/src/lib/webpack-isomorphic-tools-configuration.js
@@ -11,8 +11,7 @@ var WebpackIsomorphicToolsPlugin = require("webpack-isomorphic-tools/plugin");
 // call this method with `true` as the first and only argument because that is
 // how we tell the method we are requiring for the purpose of the isomorphic
 // tools, not the webpack config file.
-const { additionalLoaders, additionalPreLoaders } = require("./src/lib/get-webpack-additions")(true);
-
+const { additionalLoaders, additionalPreLoaders } = require("./get-webpack-additions")(true);
 
 let userExtensions = [];
 [...additionalLoaders, ...additionalPreLoaders].forEach((loader) => {


### PR DESCRIPTION
Someone reported that running the latest `develop` branch by running `npm install -g .` causes the following error.

```
/usr/local/lib/node_modules/gluestick/webpack-isomorphic-tools-configuration.js:14
const { additionalLoaders, additionalPreLoaders } = require("./src/lib/get-webpack-additions")(true);
^

SyntaxError: Unexpected token {
```

This was because webpack-isomorphic-tools-configuration.js wasn't being run through Babel so the use the const was not supported. Moving the file inside the `src` directory ensure that it is included when `run-through-babel.js` is invoked.
