### PR TITLE
Fix update-package

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-transform-catch-errors": "1.0.0",
     "react-transform-hmr": "1.0.1",
     "redbox-react": "1.2.0",
+    "rimraf": "2.5.1",
     "secure-handlebars": "1.2.0",
     "serialize-javascript": "1.1.2",
     "sha1": "1.1.1",
@@ -82,7 +83,6 @@
   },
   "peerDependencies": {},
   "devDependencies": {
-    "rimraf": "2.5.1",
     "temp": "0.8.3"
   }
 }

--- a/src/update-package.js
+++ b/src/update-package.js
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import rimraf from "rimraf";
 import chalk from "chalk";
 import inquirer from "inquirer";
 import { spawn } from "child_process";
@@ -171,9 +172,13 @@ function performModulesUpdate (mismatchedModules, done) {
   fs.writeFileSync(PROJECT_PACKAGE_LOCATION, JSON.stringify(projectPackageData, null, "  "), "utf8");
 
   const postFix = process.platform === "win32" ? ".cmd" : "";
+
+  // wipe the existing node_modules folder so we can have a clean start
+  rimraf.sync(path.join(process.cwd(), "node_modules"));
   const npmInstall = spawn("npm" + postFix, ["install"], {stdio: "inherit"});
 
   npmInstall.on("close", () => {
+    console.log(chalk.green("node_modules have been updated."));
     done();
   });
 }


### PR DESCRIPTION
When there is a mismatch between dependencies in the gluestick cli and
the app code, update-package prompts the user asking for permisson to
update the package file. It then runs `npm install` to update things.
This wasn't proving to be very reliable, instead we have to first wipe
the `node_modules` folder, then we run `npm install` this works better.

I was tempted to call `process.exit()` and make the user re-run
`gluestick start` but after running several tests with the wiped
`node_modules` folder, I no longer think that will be necessary.
