### PR TITLE
Specify GlueStick version in Dockerfile

### DIFF
--- a/new/src/config/.Dockerfile
+++ b/new/src/config/.Dockerfile
@@ -7,7 +7,9 @@ FROM node:5.5.0
 RUN apt-get update && \
     apt-get -y install libjpeg62-turbo-dev libpango1.0-dev libgif-dev build-essential g++
 
-RUN npm install -g gluestick
+ARG GLUESTICK_VERSION
+
+RUN npm install -g gluestick@$GLUESTICK_VERSION
 
 RUN mkdir /app
 ADD . /app

--- a/src/commands/dockerize.js
+++ b/src/commands/dockerize.js
@@ -1,8 +1,10 @@
 import { spawn } from "child_process";
 import path from "path";
 import process from "process";
+import fs from "fs";
 
 export default function (name) {
-  spawn("docker", ["build", "-t", name, "-f", path.join(process.cwd(), "src", "config", ".Dockerfile"), process.cwd()], {stdio: "inherit"});
+  const { version: gluestickVersion } = JSON.parse(fs.readFileSync(path.join(__dirname, "../../package.json"), "utf-8"));
+  spawn("docker", ["build", "-t", name, "--build-arg", `GLUESTICK_VERSION=${gluestickVersion}`, "-f", path.join(process.cwd(), "src", "config", ".Dockerfile"), process.cwd()], {stdio: "inherit"});
 }
 


### PR DESCRIPTION
Simply having `npm install gluestick -g` in the Dockerfile does not work
because your machine could cache the image up to that point and future
images could end up with outdated versions of GlueStick. Not only that
but it forces you to use the latest version of GlueStick on new
non-cached images when maybe you built it with an older version and
haven't upgraded yet.

This update ensures that the Docker image will install the version of
GlueStick that was used to create the image.
