### PR TITLE
Add support to load css files from npm modules

### DIFF
--- a/src/commands/shared.js
+++ b/src/commands/shared.js
@@ -1,6 +1,7 @@
 var path = require("path");
 var process = require("process");
 var WebpackIsomorphicToolsPlugin = require("webpack-isomorphic-tools/plugin");
+var ExtractTextPlugin = require("extract-text-webpack-plugin");
 
 const isProduction = process.env.NODE_ENV === "production";
 var webpackIsomorphicToolsPlugin = new WebpackIsomorphicToolsPlugin(require('../lib/webpack-isomorphic-tools-configuration'))
@@ -26,25 +27,23 @@ module.exports = {
     },
     {
       test: webpackIsomorphicToolsPlugin.regular_expression("images"),
-      loader: "file-loader?name=[name]-[hash].[ext]",
-      include: [
-        path.join(process.cwd(), "assets"),
-        path.join(__dirname, "../shared/assets")
-      ]
+      loader: "file-loader?name=[name]-[hash].[ext]"
     },
     {
       test: webpackIsomorphicToolsPlugin.regular_expression("fonts"),
-      loader: "file-loader?name=[name]-[hash].[ext]",
-      include: [
-        path.join(process.cwd(), "assets"),
-        path.join(__dirname, "../shared/assets")
-      ]
+      loader: "file-loader?name=[name]-[hash].[ext]"
     },
     {
       test: webpackIsomorphicToolsPlugin.regular_expression("json"),
       loader: "json-loader"
+    },
+    {
+      test: webpackIsomorphicToolsPlugin.regular_expression("styles"),
+      loader: isProduction ? ExtractTextPlugin.extract("style", "css!sass") : "style!css!sass"
     }
   ],
-  plugins: [],
+  plugins: [
+    new ExtractTextPlugin("[name].css"),
+  ],
   preLoaders: []
 };

--- a/src/commands/start-client.js
+++ b/src/commands/start-client.js
@@ -5,7 +5,6 @@ var chalk = require("chalk");
 var express = require("express");
 var proxy = require("express-http-proxy");
 var WebpackIsomorphicToolsPlugin = require("webpack-isomorphic-tools/plugin");
-var ExtractTextPlugin = require("extract-text-webpack-plugin");
 var shared = require("./shared");
 var getWebpackAdditions = require("../lib/get-webpack-additions");
 var { additionalLoaders, additionalPreLoaders } = getWebpackAdditions();
@@ -63,11 +62,6 @@ var compiler = webpack({
   },
   module: {
     loaders: [
-      // only place client specific loaders here
-      {
-        test: webpackIsomorphicToolsPlugin.regular_expression("styles"),
-        loader: isProduction ? ExtractTextPlugin.extract("style", "css!sass") : "style!css!sass"
-      }
     ].concat(shared.loaders, additionalLoaders),
     preLoaders: [
     // only place client specific preLoaders here
@@ -82,7 +76,6 @@ var compiler = webpack({
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.NoErrorsPlugin(),
-    new ExtractTextPlugin("[name].css"),
     new webpack.DefinePlugin({
       "__PATH_TO_ENTRY__": JSON.stringify(path.join(process.cwd(), "src/config/.entry")),
       "process.env": {

--- a/src/shared/components/getHead.js
+++ b/src/shared/components/getHead.js
@@ -24,6 +24,12 @@ export default (config, assets) => {
     // Resolve style flicker on page load in dev mode
     Object.keys(assets.assets).forEach(assetPath => {
       if (!assetPath.endsWith(".css")) return;
+
+      // webpack isomorphic tools converts `node_modules` to `~` in these
+      // paths. This means any css files imported directly out of a node_module
+      // will not be found. Unless we swap `~` back to `node_modules`.
+      assetPath = assetPath.replace("~", "node_modules");
+
       tags.push(<style key={key++} dangerouslySetInnerHTML={{__html: require(path.join(process.cwd(), assetPath))}} />);
     });
   }


### PR DESCRIPTION
Use case: `import 'bootstrap/dist/css/bootstrap.css';`

This was causing problems for 2 reasons.
1. The bootstrap.css file was references fonts outside of the `assets`
   folder. Our loader was limited to only loading fonts from the `assets`
   folder. There is now a good reason why we should not limit it to the
   that folder and I couldn't think of any good reason why we should. So
   that restriction was removed from both the fonts and images. CSS files
   can reference fonts and images and we want those to work.
2. In development mode, we have a really sweet hack that gets rid of the
   flash of unstyled content. You can see it in `getHead.js`. We get a list
   of assets and do some things… but webpack-isomorphic-tools replace
   `node_modules` with `~` which was breaking that. So now it is swapped
   back to `node_modules`. This is only development mode, so don't panic if
   you don't like it but please share if there is a better way.
3. I moved the css loader stuff out of the client only side and put it in shared with all of it's friends. If there is a reason **not** to do this, now would be the time to bring it up.
