### PR TITLE
Add a check for the extensions property

### DIFF
--- a/src/lib/webpack-isomorphic-tools-configuration.js
+++ b/src/lib/webpack-isomorphic-tools-configuration.js
@@ -1,3 +1,5 @@
+import chalk from "chalk";
+
 var path = require("path");
 var process = require("process");
 var WebpackIsomorphicToolsPlugin = require("webpack-isomorphic-tools/plugin");
@@ -17,6 +19,10 @@ let userExtensions = [];
 [...additionalLoaders, ...additionalPreLoaders].forEach((loader) => {
   // If someone wants to include a custom .js loader, we do not want the isomorphic tools to treat it as an asset
   // because .js imports are a native part of how node works. We do want webpack to receive the loader though.
+  if (!loader.extensions || loader.extensions.length === 0) {
+    console.log(chalk.yellow('An additional loader is missing the `extensions` property and is being ignored!'));
+    return;
+  }
   if (loader.extensions.includes("js")) return;
 
   userExtensions.splice(userExtensions.length, 0, ...loader.extensions);


### PR DESCRIPTION
Now the user will get a warning instead of a `property 'extensions' undefined` error
