### PR TITLE
Fix generator bug, create folders if missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "karma-spec-reporter": "0.0.23",
     "karma-webpack": "1.7.0",
     "match-media": "0.2.0",
+    "mkdirp": "0.5.1",
     "mocha": "2.3.4",
     "node-sass": "3.4.2",
     "pm2": "1.0.0",

--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -1,6 +1,7 @@
 var fs = require("fs");
 var path = require("path");
 var chalk = require("chalk");
+var mkdirp = require("mkdirp");
 
 var availableCommands = {
   "container": "containers",
@@ -103,7 +104,12 @@ module.exports = function () {
   }
 
   // Step 8: Write test file
-  var testPath = path.join(process.cwd(), "/test/", availableCommands[command], `/${name}.test.js`);
+  var testFolder = path.join(process.cwd(), "/test/", availableCommands[command]);
+
+  // Older generated projects don't have test/reducers or test/containers
+  mkdirp.sync(testFolder);
+
+  var testPath = path.join(testFolder, `/${name}.test.js`);
   var testTemplate;
   var testFileExists = true;
 


### PR DESCRIPTION
I used `mkdirp` instead of `fs.mkdir` since it will ignore folders that already exist.
