### PR TITLE
Add --debug, -D mode for server side debugging

### DIFF
--- a/new/package.json
+++ b/new/package.json
@@ -33,6 +33,7 @@
     "babel-plugin-react-transform": "1.1.1",
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^3.15.0",
+    "node-inspector": "0.12.6",
     "react-hot-loader": "1.3.0",
     "react-transform-catch-errors": "1.0.0",
     "react-transform-hmr": "1.0.1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -43,11 +43,17 @@ commander
   .arguments("<name>")
   .action(destroy);
 
+const debugOption = {
+  command: "-D, --debug",
+  description: "debug server side rendering with node-inspector"
+};
+
 commander
   .command("start")
   .description("start everything")
   .option("-T, --no_tests", "ignore test hook")
-  .action((options) => startAll(options.no_tests));
+  .option(debugOption.command, debugOption.description)
+  .action((options) => startAll(options.no_tests, options.debug));
 
 commander
   .command("build")
@@ -68,7 +74,8 @@ commander
 commander
   .command("start-server", null, {noHelp: true})
   .description("start server")
-  .action(() => startServer());
+  .option(debugOption.command, debugOption.description)
+  .action((options) => startServer(options.debug));
 
 const firefoxOption = {
   command: "-F, --firefox",
@@ -122,11 +129,11 @@ function spawnProcess (type, args=[]) {
   return childProcess;
 }
 
-async function startAll(withoutTests=false) {
+async function startAll(withoutTests=false, debug=false) {
   await autoUpgrade();
 
   var client = spawnProcess("client");
-  var server = spawnProcess("server");
+  var server = spawnProcess("server", (debug ? ["--debug"] : []));
 
   // Start tests unless they asked us not to or we are in production mode
   if (!isProduction && !withoutTests) {


### PR DESCRIPTION
Use case: `gluestick start -D` or `gluestick start --debug`

Client side debugging is much easier because you can use the browser's
developer tools. In a universal app, sometimes you will need to debug
code that will be rendered on the server. `node-inspector` is a great
tool for letting you debug server side code in Blink web developer
tools. It's a little slow to start up but it can really save you a lot
of time debugging server side code.

[Node Inspector](https://github.com/node-inspector/node-inspector)

![screen shot 2016-02-11 at 3 02 57 pm](https://cloud.githubusercontent.com/assets/140000/12993747/f28457f8-d0d0-11e5-850f-b28f6b176fc1.png)
