### PR TITLE
Expose specified environment variables to client

### DIFF
--- a/new/src/config/application.js
+++ b/new/src/config/application.js
@@ -1,4 +1,6 @@
-export default {
+// WARNING: The contents of this file _including process.env variables_ will be
+// exposed in the client code.
+const config = {
   development: {
     assetPath: "http://localhost:8888/assets"
   },
@@ -6,5 +8,7 @@ export default {
     // This should be a CDN in development
     assetPath: process.env.ASSET_URL || "http://localhost:8888/assets"
   }
-}
+};
+
+export default (config[process.env.NODE_ENV] || config["development"])
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "chalk": "1.1.1",
     "chokidar": "1.4.1",
     "commander": "2.9.0",
+    "estraverse": "4.1.1",
     "express": "4.13.3",
     "express-http-proxy": "0.6.0",
     "extract-text-webpack-plugin": "0.9.1",

--- a/src/auto-upgrade.js
+++ b/src/auto-upgrade.js
@@ -3,6 +3,9 @@ import path from "path";
 import chalk from "chalk";
 import sha1 from "sha1";
 import updatePackage from "./update-package";
+import updateConfig from "./update-config";
+
+const CWD = process.cwd();
 
 /**
  * Let the user know that we are updating the file and copy the contents over.
@@ -24,7 +27,7 @@ function replaceFile (name, data) {
  * @param {String} name the file name we are looking for
  */
 function getCurrentFilePath (name) {
-  return path.join(process.cwd(), "src", "config", name);
+  return path.join(CWD, "src", "config", name);
 }
 
 module.exports = async function () {
@@ -32,7 +35,7 @@ module.exports = async function () {
 
   // Make sure we are in a gluestick project
   try {
-    fs.statSync(path.join(process.cwd(), ".gluestick"))
+    fs.statSync(path.join(CWD, ".gluestick"))
   }
   catch (e) {
     console.log(chalk.red("This does not appear to be a valid GlueStick project. Please run this command inside of a gluestick project"));
@@ -49,7 +52,7 @@ module.exports = async function () {
   ];
   newFiles.forEach((filePath) => {
     try {
-      fs.statSync(path.join(process.cwd(), filePath));
+      fs.statSync(path.join(CWD, filePath));
     }
     catch (e) {
       const fileName = path.parse(filePath).base;
@@ -75,4 +78,8 @@ module.exports = async function () {
       replaceFile(fileName, newFile);
     }
   });
+
+
+  // -> prior to 0.2.2
+  await updateConfig();
 };

--- a/src/cli.js
+++ b/src/cli.js
@@ -123,7 +123,13 @@ function spawnProcess (type, args=[]) {
 }
 
 async function startAll(withoutTests=false) {
-  await autoUpgrade();
+  try {
+    await autoUpgrade();
+  }
+  catch (e) {
+    console.log(chalk.red("ERROR during auto upgrade"), e);
+    process.exit();
+  }
 
   var client = spawnProcess("client");
   var server = spawnProcess("server");

--- a/src/lib/detectEnvironmentVariables.js
+++ b/src/lib/detectEnvironmentVariables.js
@@ -1,0 +1,34 @@
+var fs = require("fs");
+var babel = require("babel-core");
+var traverse = require("estraverse").traverse;
+
+/**
+ * Read the contents of a file, convert it to an abstract syntax tree and
+ * figure out how many process.env.X properties are accessed. Return an array
+ * of environment variables.
+ *
+ * @param {String} pathToFile absolute path to the file to analyze
+ */
+module.exports = function detectEnvironmentVariables (pathToFile) {
+  var contents = fs.readFileSync(pathToFile, "utf8");
+
+  if (!contents) return [];
+
+  var ast = babel.transform(contents).ast;
+  var environmentVariables = [];
+  traverse(ast.program, {
+    enter: function (path) {
+      if (path.type === "MemberExpression") {
+        try {
+          if (path.object.object.name === "process" && path.object.property.name === "env") {
+            environmentVariables.push(path.property.name);
+          }
+        }
+        catch (e) {}
+      }
+    }
+  });
+
+  return environmentVariables;
+};
+

--- a/src/lib/server-request-handler.js
+++ b/src/lib/server-request-handler.js
@@ -20,8 +20,7 @@ module.exports = async function (req, res) {
     const Entry = require(path.join(process.cwd(), "src/config/.entry"));
     const store = require(path.join(process.cwd(), "src/config/.store"))();
     const originalRoutes = require(path.join(process.cwd(), "src/config/routes"));
-    const rawConfig = require(path.join(process.cwd(), "src/config/application"));
-    const config = rawConfig[process.env.NODE_ENV] || rawConfig.development;
+    const config = require(path.join(process.cwd(), "src/config/application"));
     const routes = prepareRoutesWithTransitionHooks(originalRoutes);
     match({routes: routes, location: req.path}, async (error, redirectLocation, renderProps) => {
       try {

--- a/src/shared/components/getHead.js
+++ b/src/shared/components/getHead.js
@@ -3,8 +3,7 @@ import serialize from "serialize-javascript";
 import path from "path";
 import process from "process";
 
-var rawConfig = require(path.join(process.cwd(), "src", "config", "application"));
-var {assetPath} = rawConfig[process.env.NODE_ENV] || rawConfig["development"];
+var { assetPath } = require(path.join(process.cwd(), "src", "config", "application"));
 
 // Make sure path ends in forward slash
 if (assetPath.substr(-1) !== "/") {

--- a/src/update-config.js
+++ b/src/update-config.js
@@ -29,7 +29,7 @@ export default function updateConfig () {
       name: "confirm",
       message: `${chalk.red("The format of src/config/application.js is out of date. You should export the correct config object based on the environment.")}
 ${chalk.yellow("Example:")}\n${chalk.cyan(exampleContents)}
-Would you like to try to automaticaly update it?`
+Would you like to try to automatically update it?`
     };
     inquirer.prompt([question], function (answers) {
       if (!answers.confirm) return resolve();

--- a/src/update-config.js
+++ b/src/update-config.js
@@ -1,0 +1,54 @@
+import fs from "fs";
+import path from "path";
+import inquirer from "inquirer";
+import chalk from "chalk";
+
+const CWD = process.cwd();
+
+/**
+ * The configuration file located at src/config/application.js has been
+ * modified so that it returns only the configuration relevant to the current
+ * node environment `process.env.NODE_ENV`. Since this file can not be
+ * completely swapped, we will attempt to update the file for the developer so
+ * that it meets the new requirements.
+ */
+export default function updateConfig () {
+  return new Promise((resolve) => {
+    const appConfigPath = path.join(CWD, "src", "config", "application.js");
+    const appConfig = fs.readFileSync(appConfigPath, "utf8").replace(/\s*$/, "");
+    const lastAppConfigLine = appConfig.split("\n").pop();
+    const expectedLastLine = 'export default (config[process.env.NODE_ENV] || config["development"])';
+    if (lastAppConfigLine === expectedLastLine) {
+      resolve();
+      return;
+    }
+
+    const exampleContents = fs.readFileSync(path.join(__dirname, "..", "new", "src", "config", "application.js"), "utf8");
+    const question = {
+      type: "confirm",
+      name: "confirm",
+      message: `${chalk.red("The format of src/config/application.js is out of date. You should export the correct config object based on the environment.")}
+${chalk.yellow("Example:")}\n${chalk.cyan(exampleContents)}
+Would you like to try to automaticaly update it?`
+    };
+    inquirer.prompt([question], function (answers) {
+      if (!answers.confirm) return resolve();
+      doUpgrade(appConfig, expectedLastLine, appConfigPath);
+      resolve();
+    });
+  });
+}
+
+function doUpgrade (appConfig, expectedLastLine, appConfigPath) {
+  const newAppConfig = appConfig.split("\n").map((line) => {
+    if (line === "export default {") {
+      return "const config = {";
+    }
+    return line;
+  });
+
+  newAppConfig.push("");
+  newAppConfig.push(expectedLastLine);
+  fs.writeFileSync(appConfigPath, newAppConfig.join("\n") + "\n\n");
+}
+


### PR DESCRIPTION
The application config file wasn't very useful because passing
environment variables into it made it so that it could only work on the
server side. If we wanted the environment variables to work on the
client side then webpack would need to know to expose them. **You
definitely don't want to just expose all environment variables or you
could leak things like api secrets**. It would also be annoying to have
to make an array of the variables that you wanted to expose.

To solve the problem, I decided to run static code analysis over the
config/application.js file to determine which environment variables the
developer was trying to use in the config/application.js file. I use
that to tell webpack which environment variables it needs to expose.

This was almost a complete solution until I realized that importing
config variables from this file in your application code would return
the entire object. So new projects will be generated with a slightly
modified application configuration file. I have also added an auto
upgrade script for backwards compatibility on all of the previously
generated applications.
