### PR TITLE
CLI tests for the `generate` command: Part 1

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -35,7 +35,9 @@ commander
   .command("generate <container|component|reducer>")
   .description("generate a new container")
   .arguments("<name>")
-  .action((type, name) => generate(type, name));
+  .action((type, name) => generate(type, name, (err) => {
+    if (err) console.log(chalk.red(`ERROR: ${err}`)); 
+  }));
 
 commander
   .command("destroy <container|component|reducer>")

--- a/src/cli.js
+++ b/src/cli.js
@@ -35,7 +35,7 @@ commander
   .command("generate <container|component|reducer>")
   .description("generate a new container")
   .arguments("<name>")
-  .action(generate);
+  .action((type, name) => generate(type, name));
 
 commander
   .command("destroy <container|component|reducer>")

--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -13,13 +13,12 @@ function replaceName (input, name) {
   return input.replace(/__\$NAME__/g, name);
 }
 
-module.exports = function () {
-  var command = process.argv[3];
-  var name = process.argv[4];
+module.exports = function (command, name) {
+  var CWD = process.cwd();
 
   // Step 1: Check if we are in the root of a gluestick project by looking for the `.gluestick` file
   try {
-    fs.statSync(path.join(process.cwd(), ".gluestick"));
+    fs.statSync(path.join(CWD, ".gluestick"));
   }
   catch (e) {
     console.log(chalk.yellow(".gluestick file not found"));
@@ -66,7 +65,7 @@ module.exports = function () {
   template = replaceName(template, name);
 
   // Step 6: Check if the file already exists before we write to it
-  var destinationPath = path.join(process.cwd(), "/src/", availableCommands[command] + "/" + name + ".js");
+  var destinationPath = path.join(CWD, "/src/", availableCommands[command] + "/" + name + ".js");
   var fileExists = true;
   try {
     fs.statSync(destinationPath);
@@ -86,7 +85,7 @@ module.exports = function () {
 
   // Step 7: If we just generated a reducer, add it to the reducers index
   if (command === "reducer") {
-    var reducerIndexPath = path.resolve(process.cwd(), "src/reducers/index.js");
+    var reducerIndexPath = path.resolve(CWD, "src/reducers/index.js");
     try {
       // Get the file contents, but strip off any trailing whitespace. This sets us up
       // to place the new export on the last line, followed by a blank whitespace line at the end
@@ -104,7 +103,7 @@ module.exports = function () {
   }
 
   // Step 8: Write test file
-  var testFolder = path.join(process.cwd(), "/test/", availableCommands[command]);
+  var testFolder = path.join(CWD, "/test/", availableCommands[command]);
 
   // Older generated projects don't have test/reducers or test/containers
   mkdirp.sync(testFolder);

--- a/test/commands/generate.test.js
+++ b/test/commands/generate.test.js
@@ -1,5 +1,5 @@
-import sinon from "sinon";
 import { expect } from "chai";
+import fs from "fs";
 import temp from "temp";
 import rimraf from "rimraf";
 import generate from "../../src/commands/generate";
@@ -12,20 +12,38 @@ describe("cli: gluestick generate", function () {
     originalCwd = process.cwd();
     tmpDir = temp.mkdirSync("gluestick-generate");
     process.chdir(tmpDir);
-    sandbox = sinon.sandbox.create();
-    sandbox.spy(console, "log");
-    sandbox.spy(console, "error");
   });
 
   afterEach(done => {
-    sandbox.restore();
     process.chdir(originalCwd);
     rimraf(tmpDir, done);
   });
 
   it("should report an error if a .gluestick file is not found in the current directory", () => { 
-    generate("container", "MyContainer");
-    expect(console.log.calledWithMatch("ERROR: `generate` commands must be run from the root of a gluestick project.")).to.be.true;
+    generate("container", "MyContainer", (err) => {
+      expect(err).to.contain("commands must be run from the root of a gluestick project");
+    });
+  });
+
+  it("should report an error if an invalid command type was provided", () => {
+    fs.closeSync(fs.openSync(".gluestick", "w"));
+    generate("invalidtype", "myname", (err) => {
+      expect(err).to.contain("is not a valid generator");
+    });
+  });
+
+  it("should report an error if a blank name is provided", () => {
+    fs.closeSync(fs.openSync(".gluestick", "w"));
+    generate("container", "", (err) => {
+      expect(err).to.contain("must specify a name");
+    });
+  });
+
+  it("should report an error if non-word characters are in the name", () => {
+    fs.closeSync(fs.openSync(".gluestick", "w"));
+    generate("container", "f##@", (err) => {
+      expect(err).to.contain("is not a valid name");
+    });
   });
 
 });

--- a/test/commands/generate.test.js
+++ b/test/commands/generate.test.js
@@ -1,0 +1,31 @@
+import sinon from "sinon";
+import { expect } from "chai";
+import temp from "temp";
+import rimraf from "rimraf";
+import generate from "../../src/commands/generate";
+
+describe("cli: gluestick generate", function () {
+
+  let originalCwd, tmpDir, sandbox;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpDir = temp.mkdirSync("gluestick-generate");
+    process.chdir(tmpDir);
+    sandbox = sinon.sandbox.create();
+    sandbox.spy(console, "log");
+    sandbox.spy(console, "error");
+  });
+
+  afterEach(done => {
+    sandbox.restore();
+    process.chdir(originalCwd);
+    rimraf(tmpDir, done);
+  });
+
+  it("should report an error if a .gluestick file is not found in the current directory", () => { 
+    generate("container", "MyContainer");
+    expect(console.log.calledWithMatch("ERROR: `generate` commands must be run from the root of a gluestick project.")).to.be.true;
+  });
+
+});


### PR DESCRIPTION
Adds a simple/small set of tests for the `gluestick generate` command. Another PR will be submitted for tests that validate that the appropriate files were generated for each type.
