### PR TITLE
CLI tests for the `generate` command: Part 2

### DIFF
--- a/test/commands/generate.test.js
+++ b/test/commands/generate.test.js
@@ -1,8 +1,39 @@
 import { expect } from "chai";
 import fs from "fs";
+import path from "path";
+import mkdirp from "mkdirp";
+import glob from "glob";
 import temp from "temp";
 import rimraf from "rimraf";
 import generate from "../../src/commands/generate";
+
+function stubProject(type) {
+    // Generate files that are already expected to exist
+    fs.closeSync(fs.openSync(".gluestick", "w"));
+    const srcDir = path.join(process.cwd(), "src", `${type}s`);
+    mkdirp.sync(srcDir);
+    if (type == "reducer") {
+      fs.closeSync(fs.openSync(path.join(srcDir, "index.js"), "w"));
+    }
+}
+
+function makeGeneratedFilesAssertion(dir, type, name, done) {
+  const expectedFiles = [
+    ".gluestick",
+    "src",
+    `src/${type}s`,
+    `src/${type}s/${name}.js`,
+    "test",
+    `test/${type}s`,
+    `test/${type}s/${name}.test.js`
+  ];
+  const generatedFiles = new Set(glob.sync('**', {
+      dot: true,
+      cwd: path.resolve(dir)
+  }));
+  expect(expectedFiles.filter(f => !generatedFiles.has(f))).to.be.empty;
+  done();
+}
 
 describe("cli: gluestick generate", function () {
 
@@ -43,6 +74,33 @@ describe("cli: gluestick generate", function () {
     fs.closeSync(fs.openSync(".gluestick", "w"));
     generate("container", "f##@", (err) => {
       expect(err).to.contain("is not a valid name");
+    });
+  });
+
+  it("should capitalize the name if the type is `container`", done => {
+    const type = "container";
+    stubProject(type);
+    generate(type, "mycontainer", (err) => {
+      expect(err).to.be.undefined;
+      makeGeneratedFilesAssertion(process.cwd(), type, "Mycontainer", done);
+    });
+  });
+
+  it("should capitalize the name if the type is `component`", done => {
+    const type = "component";
+    stubProject(type);
+    generate(type, "mycomponent", (err) => {
+      expect(err).to.be.undefined;
+      makeGeneratedFilesAssertion(process.cwd(), type, "Mycomponent", done);
+    });
+  });
+
+  it("should lowercase the name if the type is `reducer`", done => {
+    const type = "reducer";
+    stubProject(type);
+    generate(type, "Myreducer", (err) => {
+      expect(err).to.be.undefined;
+      makeGeneratedFilesAssertion(process.cwd(), type, "myreducer", done);
     });
   });
 

--- a/test/commands/generate.test.js
+++ b/test/commands/generate.test.js
@@ -9,10 +9,10 @@ import generate from "../../src/commands/generate";
 
 function stubProject(type) {
     // Generate files that are already expected to exist
+    const srcDir = path.join(process.cwd(), `src/${type}s`);
     fs.closeSync(fs.openSync(".gluestick", "w"));
-    const srcDir = path.join(process.cwd(), "src", `${type}s`);
     mkdirp.sync(srcDir);
-    if (type == "reducer") {
+    if (type === "reducer") {
       fs.closeSync(fs.openSync(path.join(srcDir, "index.js"), "w"));
     }
 }
@@ -101,6 +101,17 @@ describe("cli: gluestick generate", function () {
     generate(type, "Myreducer", (err) => {
       expect(err).to.be.undefined;
       makeGeneratedFilesAssertion(process.cwd(), type, "myreducer", done);
+    });
+  });
+
+  it("should not generate a container if it already exists", done => {
+    const type = "container";
+    stubProject(type);
+    fs.closeSync(fs.openSync(path.join(process.cwd(), `src/${type}s/Mycontainer.js`), "w"));
+    generate(type, "mycontainer", (err) => {
+      expect(err).to.not.be.undefined;
+      expect(err).to.contain("already exists");
+      done();
     });
   });
 


### PR DESCRIPTION
This PR adds tests that actually assert that files were generated/not generated under the right conditions. 
