### PR TITLE
Have webpack ignore server files

### DIFF
--- a/src/commands/start-client.js
+++ b/src/commands/start-client.js
@@ -93,7 +93,8 @@ var compiler = webpack({
     new webpack.DefinePlugin({
       "__PATH_TO_ENTRY__": JSON.stringify(path.join(process.cwd(), "src/config/.entry")),
       "process.env": exposedEnvironmentVariables
-    })
+    }),
+    new webpack.IgnorePlugin(/\.server(\.js)?$/)
   ].concat(environmentPlugins, shared.plugins),
   resolve: {
     ...shared.resolve


### PR DESCRIPTION
We needed a way to have a require statement that only works on the
server side but we don't want webpack to try to bundle it.

Example:

```
if (typeof window === "undefined") {
  // webpack will ignore this line. The code in this conditional block
  // is not relevant to the browser side code anyways.
  var serverRequire = require("./require.server");
  serverRequire("./serverVersionOfFile");
}
else {
  require("./clientVersionOfFile");
}
```
