### PR TITLE
improve chunk names, improve proxy headers

### DIFF
--- a/src/commands/start-client.js
+++ b/src/commands/start-client.js
@@ -84,6 +84,7 @@ var compiler = webpack({
   output: {
     path: OUTPUT_PATH,
     filename: OUTPUT_FILE,
+    chunkFilename: `[name]-${OUTPUT_FILE}`,
     publicPath: PUBLIC_PATH
   },
   plugins: [
@@ -112,7 +113,8 @@ module.exports = function (buildOnly) {
     app.use(proxy("localhost:8880", {
       forwardPath: function (req, res) {
         return require("url").parse(req.url).path;
-      }
+      },
+      preserveHostHdr: true
     }));
     app.use(function(err, req, res, next) {
       if (err && err.code == "ECONNREFUSED") {


### PR DESCRIPTION
1. This gives us the ability to see something from the original names
   in code splits when the chunks are created.
2. `preserveHostHdr` forwards the original host through to the proxy in
   dev mode. This makes it easier to see where a request originated from
   when hitting the development server side rendering through the front-end
   proxy.
