### PR TITLE
Add flow header to generated files and update containers

### DIFF
--- a/generate/component.js
+++ b/generate/component.js
@@ -1,3 +1,4 @@
+/* @flow */
 import React, { Component, PropTypes } from "react";
 
 export default class __$NAME__ extends Component {

--- a/generate/container.js
+++ b/generate/container.js
@@ -1,3 +1,4 @@
+/* @flow */
 import React, { Component, PropTypes } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";

--- a/generate/reducer.js
+++ b/generate/reducer.js
@@ -1,3 +1,4 @@
+/* @flow */
 const INITIAL_STATE = null;
 
 export default (state=INITIAL_STATE, action) => {

--- a/new/src/components/Home.js
+++ b/new/src/components/Home.js
@@ -1,3 +1,4 @@
+/* @flow */
 import React, { Component, PropTypes } from "react";
 
 export default class Home extends Component {

--- a/new/src/components/MasterLayout.js
+++ b/new/src/components/MasterLayout.js
@@ -1,3 +1,4 @@
+/* @flow */
 import React, { Component } from "react";
 import { Link } from "react-router";
 

--- a/new/src/config/routes.js
+++ b/new/src/config/routes.js
@@ -1,3 +1,4 @@
+/* @flow */
 import React from "react";
 import { Route, IndexRoute } from "react-router";
 import { ROUTE_NAME_404_NOT_FOUND } from "gluestick-shared";

--- a/new/src/containers/HomeApp.js
+++ b/new/src/containers/HomeApp.js
@@ -1,14 +1,11 @@
+/* @flow */
 import React, { Component, PropTypes } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 
 import Home from "../components/Home";
 
-@connect(
-  (state) => ({/** _INSERT_STATE_  **/}),
-    (dispatch) => bindActionCreators({/** _INSERT_ACTION_CREATORS_ **/}, dispatch)
-)
-export default class HomeApp extends Component {
+export class HomeApp extends Component {
   /**
    * Called by ReactRouter before loading the container. Called prior to the
    * React life cycle so doesn't have access to component's props or state.
@@ -31,4 +28,9 @@ export default class HomeApp extends Component {
     );
   }
 }
+
+export default connect(
+  (state) => ({/** _INSERT_STATE_  **/}),
+  (dispatch) => bindActionCreators({/** _INSERT_ACTION_CREATORS_ **/}, dispatch)
+)(HomeApp);
 

--- a/new/src/containers/NoMatchApp.js
+++ b/new/src/containers/NoMatchApp.js
@@ -1,12 +1,9 @@
+/* @flow */
 import React, { Component, PropTypes } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 
-@connect(
-  (state) => ({/** _INSERT_STATE_  **/}),
-    (dispatch) => bindActionCreators({/** _INSERT_ACTION_CREATORS_ **/}, dispatch)
-)
-export default class NotMatchApp extends Component {
+export class NotMatchApp extends Component {
   /**
    * Called by ReactRouter before loading the container. Called prior to the
    * React life cycle so doesn't have access to component's props or state.
@@ -29,4 +26,9 @@ export default class NotMatchApp extends Component {
     );
   }
 }
+
+export default connect(
+  (state) => ({/** _INSERT_STATE_  **/}),
+  (dispatch) => bindActionCreators({/** _INSERT_ACTION_CREATORS_ **/}, dispatch)
+)(NoMatchApp);
 


### PR DESCRIPTION
Added `/* @flow */` to generated files to better support flow.

While in there I noticed that containers/HomeApp.js and
containers/NoMatchApp.js no longer matched the output that `gluestick
generate container …` creates. So I updated those two files while I was
in there
