### PR TITLE
update eslint-plugin-react version

### DIFF
--- a/new/package.json
+++ b/new/package.json
@@ -36,7 +36,7 @@
     "babel-plugin-react-transform": "2.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "eslint": "^2.2.0",
-    "eslint-plugin-react": "^3.15.0",
+    "eslint-plugin-react": "^4.2.0",
     "isparta-loader": "2.0.0",
     "node-inspector": "0.12.6",
     "react-hot-loader": "1.3.0",


### PR DESCRIPTION
eslint crashes with the old version of eslint-plugin-react when it tries to load the recommended settings from the eslintrc file. This fixes it.
