### PR TITLE
(temp) pin eslint to 2.2.0 to avoid buggy version

### DIFF
--- a/new/package.json
+++ b/new/package.json
@@ -35,7 +35,7 @@
     "babel-eslint": "^5.0.0",
     "babel-plugin-react-transform": "2.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
-    "eslint": "^2.2.0",
+    "eslint": "2.2.0",
     "eslint-plugin-react": "^4.2.0",
     "isparta-loader": "2.0.0",
     "node-inspector": "0.12.6",


### PR DESCRIPTION
see https://github.com/eslint/eslint/issues/5476
