### PR TITLE
Fix css assets in dev and prod

### DIFF
--- a/new/package.json
+++ b/new/package.json
@@ -15,7 +15,7 @@
     "babel-preset-react": "6.5.0",
     "css-loader": "0.23.0",
     "file-loader": "0.8.5",
-    "gluestick-shared": "0.3.0",
+    "gluestick-shared": "0.3.1",
     "history": "2.0.0",
     "json-loader": "0.5.4",
     "node-sass": "3.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gluestick",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "",
   "main": "src/cli-harmony.js",
   "bin": "src/cli-harmony.js",
@@ -47,7 +47,7 @@
     "extract-text-webpack-plugin": "0.9.1",
     "file-loader": "0.8.5",
     "fs-extra": "0.26.2",
-    "gluestick-shared": "0.3.0",
+    "gluestick-shared": "0.3.1",
     "history": "2.0.0",
     "inquirer": "0.11.0",
     "json-loader": "0.5.4",

--- a/src/commands/start-client.js
+++ b/src/commands/start-client.js
@@ -137,7 +137,15 @@ module.exports = function (buildOnly) {
   }
   else {
     logger.info("Bundling assets…");
-    compiler.run(() => {
+    compiler.run((error, stats) => {
+      const errors = stats.toJson().errors;
+      if (errors.length) {
+        errors.forEach((e) => {
+          logger.error(e);
+        });
+        return;
+      }
+
       logger.success(`Assets have been prepared for production.`);
       logger.success(`Assets can be served from the ${logsColorScheme.filename("/assets")} route but it is recommended that you serve the generated ${logsColorScheme.filename("build")} folder from a Content Delivery Network`);
     });

--- a/src/shared/components/getHead.js
+++ b/src/shared/components/getHead.js
@@ -21,7 +21,7 @@ export default (config, assets) => {
   else {
     // Resolve style flicker on page load in dev mode
     Object.keys(assets.assets).forEach(assetPath => {
-      if (!assetPath.endsWith(".css")) return;
+      if (!/\.(css|scss|sass|less)$/.test(assetPath)) return;
 
       // webpack isomorphic tools converts `node_modules` to `~` in these
       // paths. This means any css files imported directly out of a node_module


### PR DESCRIPTION
1. In development, we were only loading .css files but we want to
   support .scss, .sass as well… This adds support for that.
2. In production, we use an UglifyJS webpack plugin in our bundle. For
   some reason, the last published version of `gluestick-shared` had ES6+
   code in it which was causing the Uglify plugin to fail.
3. We were not reporting build errors so the failed build was failing
   silently.
