### PR TITLE
Fix bug in store

### DIFF
--- a/new/src/config/.store.js
+++ b/new/src/config/.store.js
@@ -3,5 +3,5 @@
 import { createStore } from "gluestick-shared";
 import middleware from "./redux-middleware";
 export default function () {
-  return createStore(() => require("../reducers").default, middleware, (cb) => module.hot && module.hot.accept("../reducers", cb), !!module.hot);
+  return createStore(() => require("../reducers"), middleware, (cb) => module.hot && module.hot.accept("../reducers", cb), !!module.hot);
 }


### PR DESCRIPTION
We do not want/need the `.default` property on the reducers require
statement. Having it there breaks the store
