### PR TITLE
Allow gluestick projects to define their own `test` regexp in `webpack-additions.js`

### DIFF
--- a/new/src/config/webpack-additions.js
+++ b/new/src/config/webpack-additions.js
@@ -17,6 +17,8 @@
  * import myData from "assets/xml/my-file.xml";
  *
  * Loaders also support `include`, `exclude` and `query`.
+ * Additionally, you can provide a `test` regex instead of `extensions`
+ * in order to bypass webpack-isomorphic-tools when needed.
  */
 module.exports = {
   additionalLoaders: [],

--- a/src/lib/get-webpack-additions.js
+++ b/src/lib/get-webpack-additions.js
@@ -15,6 +15,7 @@ import WebpackIsomorphicToolsPlugin from "webpack-isomorphic-tools/plugin";
  * @param {Array<Object>} additions array of loaders or preloaders formatted for webpack-isomorphic-tools
  * @param {Array<String>} additions[n].extensions array of strings representing file extensions
  * @param {String} additions[n].loader name of the loader to use
+ * @param {RegExp} additions[n].test - test regex for webpack
  *
  * @return {Object}
  */

--- a/src/lib/get-webpack-additions.js
+++ b/src/lib/get-webpack-additions.js
@@ -20,9 +20,11 @@ import WebpackIsomorphicToolsPlugin from "webpack-isomorphic-tools/plugin";
  */
 function prepareUserAdditionsForWebpack (additions) {
   return additions.map((addition) => {
+    let test = addition.test && toString.call(addition.test) === "[object RegExp]" ?
+      addition.test : WebpackIsomorphicToolsPlugin.regular_expression(addition.extensions);
     let webpackAddition = {
       loader: addition.loader,
-      test: WebpackIsomorphicToolsPlugin.regular_expression(addition.extensions)
+      test: test
     };
 
     ['include', 'exclude', 'query'].forEach((optionalAddition) => {

--- a/src/lib/webpack-isomorphic-tools-configuration.js
+++ b/src/lib/webpack-isomorphic-tools-configuration.js
@@ -18,13 +18,17 @@ const { additionalLoaders, additionalPreLoaders } = require("./get-webpack-addit
 
 let userExtensions = [];
 [...additionalLoaders, ...additionalPreLoaders].forEach((loader) => {
+  // Bail out when a test regexp has been supplied.
+  if (loader.test && toString.call(loader.test) === "[object RegExp]") return;
+
   // If someone wants to include a custom .js loader, we do not want the isomorphic tools to treat it as an asset
   // because .js imports are a native part of how node works. We do want webpack to receive the loader though.
+  if (loader.extensions.includes("js")) return;
+
   if (!loader.extensions || loader.extensions.length === 0) {
     logger.info(`An additional loader is missing the ${highlight("extensions")} property and is being ignored!`);
     return;
   }
-  if (loader.extensions.includes("js")) return;
 
   userExtensions.splice(userExtensions.length, 0, ...loader.extensions);
 });


### PR DESCRIPTION
There are some cases where you wish to define your own webpack configs. Right now there isn't any real way to do that. This will at least allow some control over that.

Potential use case:

```
// package.json
{
...
  "dependencies": {
    ...
    "bourbon": "^4.2.6",
    "bourbon-neat": "^1.7.3"
    ...
  }
...
}

// index.scss
@import 'bourbon';
@import 'neat';

// webpack-additions.js
import bourbon from "bourbon";
import neat from "bourbon-neat";

module.exports = {
  additionalLoaders: [
    {
      test: /\.scss$/,
      loader: `sass-loader?includePaths[]=${bourbon.includePaths}&includePaths[]=${neat.includePaths}&sourceMap`
    }
  ],
  additionalPreLoaders: []
};
```
