### PR TITLE
Clean up and improve generated tests

### DIFF
--- a/generate/component.test.js
+++ b/generate/component.test.js
@@ -1,9 +1,11 @@
 import __$NAME__ from "components/__$NAME__";
+import { shallow } from "enzyme";
 
 describe("components/__$NAME__", () => {
   it("renders without an issue", () => {
     const subject = <__$NAME__ />;
-    const renderedSubject = TestUtils.renderIntoDocument(subject);
-    expect(renderedSubject).to.exist;
+    const wrapper = shallow(subject);
+    expect(wrapper).to.exist;
   });
 });
+

--- a/generate/container.test.js
+++ b/generate/container.test.js
@@ -1,9 +1,11 @@
 import { __$NAME__ } from "containers/__$NAME__";
+import { shallow } from "enzyme";
 
 describe("containers/__$NAME__", () => {
   it("renders without an issue", () => {
     const subject = <__$NAME__ />;
-    const renderedSubject = TestUtils.renderIntoDocument(subject);
-    expect(renderedSubject).to.exist;
+    const wrapper = shallow(subject);
+    expect(wrapper).to.exist;
   });
 });
+

--- a/new/test/components/MasterLayout.test.js
+++ b/new/test/components/MasterLayout.test.js
@@ -1,9 +1,9 @@
-import Home from "components/Home";
+import MasterLayout from "components/MasterLayout";
 import { shallow } from "enzyme";
 
-describe("components/Home", () => {
+describe("components/MasterLayout", () => {
   it("renders without an issue", () => {
-    const subject = <Home />;
+    const subject = <MasterLayout />;
     const wrapper = shallow(subject);
     expect(wrapper).to.exist;
   });

--- a/new/test/containers/HomeApp.test.js
+++ b/new/test/containers/HomeApp.test.js
@@ -1,9 +1,9 @@
-import Home from "components/Home";
+import { HomeApp } from "containers/HomeApp";
 import { shallow } from "enzyme";
 
-describe("components/Home", () => {
+describe("containers/HomeApp", () => {
   it("renders without an issue", () => {
-    const subject = <Home />;
+    const subject = <HomeApp />;
     const wrapper = shallow(subject);
     expect(wrapper).to.exist;
   });

--- a/new/test/containers/NoMatchApp.test.js
+++ b/new/test/containers/NoMatchApp.test.js
@@ -1,11 +1,10 @@
-import Home from "components/Home";
+import { NoMatchApp } from "containers/NoMatchApp";
 import { shallow } from "enzyme";
 
-describe("components/Home", () => {
+describe("containers/NoMatchApp", () => {
   it("renders without an issue", () => {
-    const subject = <Home />;
+    const subject = <NoMatchApp />;
     const wrapper = shallow(subject);
     expect(wrapper).to.exist;
   });
 });
-

--- a/new/test/containers/NoMatchApp.test.js
+++ b/new/test/containers/NoMatchApp.test.js
@@ -8,3 +8,4 @@ describe("containers/NoMatchApp", () => {
     expect(wrapper).to.exist;
   });
 });
+

--- a/test/commands/new.test.js
+++ b/test/commands/new.test.js
@@ -80,7 +80,7 @@ describe("cli: gluestick new", function () {
       // written for them. This will help us catch if we add a component or
       // container but we do not add a test.
       generatedFiles.forEach((file) => {
-        if (file.startsWith("src/components/") || file.startsWith("src/containers/")) {
+        if (/^src\/(components|containers)/.test(file)) {
           let testFilename = file.replace(/^src/, "test").replace(/\.js$/, ".test.js");
           expect(index[testFilename]).to.be.true;
         }

--- a/test/commands/new.test.js
+++ b/test/commands/new.test.js
@@ -62,4 +62,33 @@ describe("cli: gluestick new", function () {
     }
   });
 
+  it("should generate a test for all of the initial components and containers", () => {
+    const fakeNpm = sinon.stub(npmDependencies, "install");
+    try {
+      newApp("gs-new-test"); 
+
+      // account for the fact that the gitignore file that gets renamed
+      const generatedFiles = new Set(glob.sync("**", { dot: true }));
+      
+      // create index from array so we can quickly lookup files by name
+      const index = {};
+      generatedFiles.forEach((file) => {
+        index[file] = true;
+      });
+
+      // loop through and make sure components and containers all have tests
+      // written for them. This will help us catch if we add a component or
+      // container but we do not add a test.
+      generatedFiles.forEach((file) => {
+        if (file.startsWith("src/components/") || file.startsWith("src/containers/")) {
+          let testFilename = file.replace(/^src/, "test").replace(/\.js$/, ".test.js");
+          expect(index[testFilename]).to.be.true;
+        }
+      });
+    }
+    finally {
+      fakeNpm.restore();
+    }
+  });
+
 });

--- a/test/commands/new.test.js
+++ b/test/commands/new.test.js
@@ -16,12 +16,13 @@ const newFilesTemplate = glob.sync("**", {
 
 describe("cli: gluestick new", function () {
 
-  let originalCwd, tmpDir, sandbox;
+  let originalCwd, tmpDir, sandbox, fakeNpm;
 
   beforeEach(() => {
     originalCwd = process.cwd();
     tmpDir = temp.mkdirSync("gluestick-new");
     process.chdir(tmpDir);
+    fakeNpm = sinon.stub(npmDependencies, "install");
     sandbox = sinon.sandbox.create();
     sandbox.spy(logger, "info");
     sandbox.spy(logger, "warn");
@@ -31,6 +32,7 @@ describe("cli: gluestick new", function () {
     sandbox.restore();
     process.chdir(originalCwd);
     rimraf(tmpDir, done);
+    fakeNpm.restore();
   });
 
   it("should report an error if the project name has symbols", () => { 
@@ -45,50 +47,37 @@ describe("cli: gluestick new", function () {
   });
 
   it("should copy the contents of `new` upon install", () => {
-    const fakeNpm = sinon.stub(npmDependencies, "install");
-    try {
-      newApp("gs-new-test"); 
+    newApp("gs-new-test"); 
 
-      // account for the fact that the gitignore file that gets renamed
-      const generatedFiles = new Set(glob.sync("**", { dot: true }));
-      const renamedGitFileExists = generatedFiles.delete(".gitignore");
-      expect(renamedGitFileExists).to.be.true;
-      generatedFiles.add("_gitignore");
+    // account for the fact that the gitignore file that gets renamed
+    const generatedFiles = new Set(glob.sync("**", { dot: true }));
+    const renamedGitFileExists = generatedFiles.delete(".gitignore");
+    expect(renamedGitFileExists).to.be.true;
+    generatedFiles.add("_gitignore");
 
-      expect(newFilesTemplate.filter(f => !generatedFiles.has(f))).to.be.empty;
-    }
-    finally {
-      fakeNpm.restore();
-    }
+    expect(newFilesTemplate.filter(f => !generatedFiles.has(f))).to.be.empty;
   });
 
   it("should generate a test for all of the initial components and containers", () => {
-    const fakeNpm = sinon.stub(npmDependencies, "install");
-    try {
-      newApp("gs-new-test"); 
+    newApp("gs-new-test"); 
 
-      // account for the fact that the gitignore file that gets renamed
-      const generatedFiles = new Set(glob.sync("**", { dot: true }));
-      
-      // create index from array so we can quickly lookup files by name
-      const index = {};
-      generatedFiles.forEach((file) => {
-        index[file] = true;
-      });
+    const generatedFiles = new Set(glob.sync("**", { dot: true }));
+    
+    // create index from array so we can quickly lookup files by name
+    const index = {};
+    generatedFiles.forEach((file) => {
+      index[file] = true;
+    });
 
-      // loop through and make sure components and containers all have tests
-      // written for them. This will help us catch if we add a component or
-      // container but we do not add a test.
-      generatedFiles.forEach((file) => {
-        if (/^src\/(components|containers)/.test(file)) {
-          let testFilename = file.replace(/^src/, "test").replace(/\.js$/, ".test.js");
-          expect(index[testFilename]).to.be.true;
-        }
-      });
-    }
-    finally {
-      fakeNpm.restore();
-    }
+    // loop through and make sure components and containers all have tests
+    // written for them. This will help us catch if we add a component or
+    // container but we do not add a test.
+    generatedFiles.forEach((file) => {
+      if (/^src\/(components|containers)/.test(file)) {
+        let testFilename = file.replace(/^src/, "test").replace(/\.js$/, ".test.js");
+        expect(index[testFilename]).to.be.true;
+      }
+    });
   });
 
 });


### PR DESCRIPTION
We want our generated tests from `new` and `generate` to follow the same
pattern. They have gotten inconsistent.
We want to use enzyme in all of the generated tests.
We will now use `wrapper` instead of `renderedSubject`.
We are currently missing tests for HomeApp, NoMatchApp, and MasterLayout
