### PR TITLE
Better app coverage reports

### DIFF
--- a/new/package.json
+++ b/new/package.json
@@ -33,11 +33,11 @@
   "license": "ISC",
   "devDependencies": {
     "babel-eslint": "^5.0.0",
+    "babel-istanbul-loader": "0.1.0",
     "babel-plugin-react-transform": "2.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "eslint": "2.2.0",
     "eslint-plugin-react": "^4.2.0",
-    "isparta-loader": "2.0.0",
     "node-inspector": "0.12.6",
     "react-hot-loader": "1.3.0",
     "react-transform-catch-errors": "1.0.0",

--- a/src/lib/karmaConfig.js
+++ b/src/lib/karmaConfig.js
@@ -33,13 +33,15 @@ export default {
           test: webpackIsomorphicToolsPlugin.regular_expression("styles"),
           loader: "file-loader"
         },
+      ].concat(shared.loaders).concat(
+        // babel-istanbul must be defined after the babel loader
         {
           test: /\.js$/,
-          loader: "isparta",
+          loader: "babel-istanbul",
           exclude: /test/,
           include: path.resolve(CWD, "src")
         }
-      ].concat(shared.loaders, additionalLoaders),
+      ).concat(additionalLoaders),
       preLoaders: [
         // only place test specific preLoaders here
       ].concat(shared.preLoaders, additionalPreLoaders),


### PR DESCRIPTION
Using babel-istanbul reconciles babel output against sourcemaps, providing apps with better coverage reports.

We use this for Gluesick itself, now let's use it for Gluestick-generated apps.
