### PR TITLE
Fix version update

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,8 +1,6 @@
 const commander = require("commander");
-const fs = require("fs");
-const path = require("path");
 const process = require("process");
-const {exec, spawn} = require("cross-spawn");
+const { spawn } = require("cross-spawn");
 const lazyMethodRequire = require("./lib/LazyMethodRequire").default(__dirname);
 
 const newApp = lazyMethodRequire("./commands/new");
@@ -23,9 +21,7 @@ const utils = require("./lib/utils");
 const { quitUnlessGluestickProject } = utils;
 
 const autoUpgrade = require("./auto-upgrade");
-const chokidar = require("chokidar");
 
-const command = process.argv[2];
 const isProduction = process.env.NODE_ENV === "production";
 
 const IS_WINDOWS = process.platform === "win32";
@@ -37,7 +33,7 @@ commander
   .command("touch")
   .description("update project version")
   .action(checkGluestickProject)
-  .action(updateLastVersionUsed)
+  .action(updateLastVersionUsed);
 
 commander
   .command("new")
@@ -55,9 +51,9 @@ commander
   .arguments("<name>")
   .action(checkGluestickProject)
   .action((type, name) => generate(type, name, (err) => {
-    if (err) logger.error(err);
+    if (err) { logger.error(err); }
   }))
-  .action(updateLastVersionUsed)
+  .action(updateLastVersionUsed);
 
 commander
   .command("destroy <container|component|reducer>")
@@ -94,14 +90,14 @@ commander
   .arguments("<name>")
   .action(checkGluestickProject)
   .action(upgradeAndDockerize)
-  .action(()=> updateLastVersionUsed());
+  .action(updateLastVersionUsed);
 
 commander
   .command("start-client", null, {noHelp: true})
   .description("start client")
   .action(checkGluestickProject)
   .action(() => startClient(false))
-  .action(()=> updateLastVersionUsed());
+  .action(updateLastVersionUsed);
 
 
 commander
@@ -110,7 +106,7 @@ commander
   .option(debugOption.command, debugOption.description)
   .action(checkGluestickProject)
   .action((options) => startServer(options.debug))
-  .action(()=> updateLastVersionUsed());
+  .action(updateLastVersionUsed);
 
 const firefoxOption = {
   command: "-F, --firefox",
@@ -123,7 +119,7 @@ commander
   .description("start test")
   .action(checkGluestickProject)
   .action((options) => startTest(options))
-  .action(()=> updateLastVersionUsed());
+  .action(updateLastVersionUsed);
 
 commander
   .command("test")
@@ -131,15 +127,15 @@ commander
   .description("start tests")
   .action(checkGluestickProject)
   .action(() => spawnProcess("test", process.argv.slice(3)))
-  .action(()=> updateLastVersionUsed());
+  .action(updateLastVersionUsed);
 
 // This is a catch all command. DO NOT PLACE ANY COMMANDS BELOW THIS
 commander
-  .command('*', null, {noHelp: true})
+  .command("*", null, {noHelp: true})
   .action(function(cmd){
     logger.error(`Command '${highlight(cmd)}' not recognized`);
     commander.help();
-});
+  });
 
 commander.parse(process.argv);
 
@@ -148,8 +144,8 @@ function checkGluestickProject () {
 }
 
 function spawnProcess (type, args=[]) {
-  var childProcess;
-  var postFix = IS_WINDOWS ? ".cmd" : "";
+  let childProcess;
+  const postFix = IS_WINDOWS ? ".cmd" : "";
   switch (type) {
     case "client":
       childProcess = spawn("gluestick" + postFix, ["start-client", ...args], {stdio: "inherit", env: Object.assign({}, process.env)});
@@ -161,7 +157,7 @@ function spawnProcess (type, args=[]) {
       childProcess = spawn("gluestick" + postFix, ["start-test", ...args], {stdio: "inherit", env: Object.assign({}, process.env, {NODE_ENV: isProduction ? "production": "development-test"})});
       break;
   }
-  childProcess.on("error", function (data) { logger.error(JSON.stringify(arguments)) });
+  childProcess.on("error", function (data) { logger.error(JSON.stringify(arguments)); });
   return childProcess;
 }
 
@@ -174,12 +170,12 @@ async function startAll(withoutTests=false, debug=false) {
     process.exit();
   }
 
-  var client = spawnProcess("client");
-  var server = spawnProcess("server", (debug ? ["--debug"] : []));
+  const client = spawnProcess("client");
+  const server = spawnProcess("server", (debug ? ["--debug"] : []));
 
   // Start tests unless they asked us not to or we are in production mode
   if (!isProduction && !withoutTests) {
-    var testProcess = spawnProcess("test");
+    const testProcess = spawnProcess("test");
   }
 }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,7 +11,7 @@ const generate = lazyMethodRequire("./commands/generate");
 const destroy = lazyMethodRequire("./commands/destroy");
 const dockerize = lazyMethodRequire("./commands/dockerize");
 
-const updateLastVersionUsed = require("./lib/updateVersion.js");
+const updateLastVersionUsed = require("./lib/updateVersion");
 const getVersion = require("./lib/getVersion");
 const logger = require("./lib/logger");
 const logsColorScheme = require("./lib/logsColorScheme");
@@ -26,14 +26,16 @@ const isProduction = process.env.NODE_ENV === "production";
 
 const IS_WINDOWS = process.platform === "win32";
 
+const currentGluestickVersion = getVersion();
+
 commander
-  .version(getVersion());
+  .version(currentGluestickVersion);
 
 commander
   .command("touch")
   .description("update project version")
   .action(checkGluestickProject)
-  .action(updateLastVersionUsed);
+  .action(() => updateLastVersionUsed(currentGluestickVersion));
 
 commander
   .command("new")
@@ -41,7 +43,7 @@ commander
   .arguments("<app_name>")
   .action((app_name) => {
     if(newApp(app_name)) {
-      updateLastVersionUsed(false);
+      updateLastVersionUsed(currentGluestickVersion, false);
     }
   });
 
@@ -53,7 +55,7 @@ commander
   .action((type, name) => generate(type, name, (err) => {
     if (err) { logger.error(err); }
   }))
-  .action(updateLastVersionUsed);
+  .action(() => updateLastVersionUsed(currentGluestickVersion));
 
 commander
   .command("destroy <container|component|reducer>")
@@ -61,7 +63,7 @@ commander
   .arguments("<name>")
   .action(checkGluestickProject)
   .action(destroy)
-  .action(updateLastVersionUsed);
+  .action(() => updateLastVersionUsed(currentGluestickVersion));
 
 const debugOption = {
   command: "-D, --debug",
@@ -75,14 +77,14 @@ commander
   .option(debugOption.command, debugOption.description)
   .action(checkGluestickProject)
   .action((options) => startAll(options.no_tests, options.debug))
-  .action(()=> updateLastVersionUsed());
+  .action(() => updateLastVersionUsed(currentGluestickVersion));
 
 commander
   .command("build")
   .description("create production asset build")
   .action(checkGluestickProject)
   .action(() => startClient(true))
-  .action(()=> updateLastVersionUsed());
+  .action(() => updateLastVersionUsed(currentGluestickVersion));
 
 commander
   .command("dockerize")
@@ -90,15 +92,14 @@ commander
   .arguments("<name>")
   .action(checkGluestickProject)
   .action(upgradeAndDockerize)
-  .action(updateLastVersionUsed);
+  .action(() => updateLastVersionUsed(currentGluestickVersion));
 
 commander
   .command("start-client", null, {noHelp: true})
   .description("start client")
   .action(checkGluestickProject)
   .action(() => startClient(false))
-  .action(updateLastVersionUsed);
-
+  .action(() => updateLastVersionUsed(currentGluestickVersion));
 
 commander
   .command("start-server", null, {noHelp: true})
@@ -106,7 +107,7 @@ commander
   .option(debugOption.command, debugOption.description)
   .action(checkGluestickProject)
   .action((options) => startServer(options.debug))
-  .action(updateLastVersionUsed);
+  .action(() => updateLastVersionUsed(currentGluestickVersion));
 
 const firefoxOption = {
   command: "-F, --firefox",
@@ -119,7 +120,7 @@ commander
   .description("start test")
   .action(checkGluestickProject)
   .action((options) => startTest(options))
-  .action(updateLastVersionUsed);
+  .action(() => updateLastVersionUsed(currentGluestickVersion));
 
 commander
   .command("test")
@@ -127,7 +128,7 @@ commander
   .description("start tests")
   .action(checkGluestickProject)
   .action(() => spawnProcess("test", process.argv.slice(3)))
-  .action(updateLastVersionUsed);
+  .action(() => updateLastVersionUsed(currentGluestickVersion));
 
 // This is a catch all command. DO NOT PLACE ANY COMMANDS BELOW THIS
 commander

--- a/src/lib/getVersion.js
+++ b/src/lib/getVersion.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("path");
 
 module.exports = function getVersion () {
-  var packageFileContents = fs.readFileSync(path.join(__dirname, "..", "..", "package.json"));
-  var packageObject = JSON.parse(packageFileContents);
+  const packageFileContents = fs.readFileSync(path.join(__dirname, "..", "..", "package.json"));
+  const packageObject = JSON.parse(packageFileContents);
   return packageObject.version;
-}
+};

--- a/test/lib/updateVersion.test.js
+++ b/test/lib/updateVersion.test.js
@@ -1,36 +1,30 @@
 import sinon from "sinon";
 import { expect } from "chai";
 import fs from "fs";
+import path from "path";
 import temp from "temp";
 import rimraf from "rimraf";
-import mkdirp from "mkdirp";
-import path from "path";
-import updateLastVersionUsed from "./../../src/lib/updateVersion";
-import getVersion from "./../../src/lib/getVersion";
+import logger from "../../src/lib/logger";
+import updateLastVersionUsed from "../../src/lib/updateVersion";
 
 
 describe("cli: gluestick touch", function () {
 
   let originalCwd, tmpDir, sandbox, dotFile;
 
-  let fileExists = function(path) {
-      return fs.existsSync(tmpDir + path);
+  const newDotFileContents = function(contents) {
+    fs.writeFileSync(dotFile, contents);
   };
 
-  let newDotFileContents = function(contents) {
-    fs.writeFileSync(dotFile, contents);
-  }
-  
   beforeEach(() => {
     originalCwd = process.cwd();
     tmpDir = temp.mkdirSync("gluestick-touch");
     process.chdir(tmpDir);
     fs.closeSync(fs.openSync(".gluestick", "w"));
-    dotFile = tmpDir + "/.gluestick";
+    dotFile = path.join(tmpDir, ".gluestick");
 
     sandbox = sinon.sandbox.create();
-    sandbox.spy(console, "log");
-    sandbox.spy(console, "error");
+    sandbox.spy(logger, "warn");
   });
 
   afterEach(done => {
@@ -38,38 +32,54 @@ describe("cli: gluestick touch", function () {
     process.chdir(originalCwd);
     rimraf(tmpDir, done);
   });
-  
-  it("should not error if the old \"DO NOT MODIFY\" header is in the .gluestick file", () => {
-    newDotFileContents("DO NOT MODIFY\n" + JSON.stringify({version: getVersion()})); 
-    updateLastVersionUsed();
-    sinon.assert.notCalled(console.log)
+
+  it("does not error if the old \"DO NOT MODIFY\" header is in the .gluestick file", () => {
+    const gluestickVersion = "0.1.0";
+    newDotFileContents("DO NOT MODIFY\n");
+    updateLastVersionUsed(gluestickVersion);
+    sinon.assert.notCalled(logger.warn);
   });
 
-  it("should display a warning when version is different by default", () => {
-    newDotFileContents("DO NOT MODIFY\n" + JSON.stringify({version: "0.0.0"})); 
-    updateLastVersionUsed();
-    expect(console.log.calledOnce).to.be.true;
+  it("displays a warning when the project version is greater than the gluestick version", () => {
+    const projectVersion = "0.2.0";
+    const gluestickVersion = "0.1.0";
+    newDotFileContents(JSON.stringify({version: projectVersion}));
+    updateLastVersionUsed(gluestickVersion);
+    expect(logger.warn.calledOnce).to.be.true;
   });
 
-  it("should not display a warning when version is different, but flag is set to false", () => {
-    newDotFileContents("DO NOT MODIFY\n" + JSON.stringify({version: "0.0.0"})); 
-    updateLastVersionUsed(false);
-    sinon.assert.notCalled(console.log)
+  it("does not display a warning when the flag is set to false", () => {
+    const projectVersion = "0.2.0";
+    const gluestickVersion = "0.1.0";
+    newDotFileContents(JSON.stringify({version: projectVersion}));
+    updateLastVersionUsed(gluestickVersion, false);
+    sinon.assert.notCalled(logger.warn);
   });
 
-  it("should remove the \"DO NOT MODIFY\" header from the .gluestick file", () => {
-    newDotFileContents("DO NOT MODIFY\n" + JSON.stringify({version: getVersion()})); 
-    updateLastVersionUsed();
-    var fileContents = fs.readFileSync(dotFile, {encoding: "utf8"});
-    expect(fileContents.indexOf("DO NOT MODIFY")).to.equal(-1); 
+  it("does not display a warning when the project version is less than the gluestick version", () => {
+    const projectVersion = "0.1.0";
+    const gluestickVersion = "0.2.0";
+    newDotFileContents(JSON.stringify({version: projectVersion}));
+    updateLastVersionUsed(gluestickVersion);
+    sinon.assert.notCalled(logger.warn);
   });
 
-  
-  it("should update project version to devs version", () => {
-    newDotFileContents("DO NOT MODIFY\n" + JSON.stringify({version: getVersion()}));
-    updateLastVersionUsed();
-    var fileContents = fs.readFileSync(dotFile, {encoding: "utf8"});
-    var json = JSON.parse(fileContents);
-    expect(json.version).to.equal(getVersion()); 
+  it("removes the \"DO NOT MODIFY\" header from the .gluestick file", () => {
+    const projectVersion = "0.1.0";
+    const gluestickVersion = "0.1.0";
+    newDotFileContents("DO NOT MODIFY\n" + JSON.stringify({version: projectVersion}));
+    updateLastVersionUsed(gluestickVersion);
+    const fileContents = fs.readFileSync(dotFile, {encoding: "utf8"});
+    expect(fileContents.indexOf("DO NOT MODIFY")).to.equal(-1);
+  });
+
+  it("updates the project version to current gluestick version", () => {
+    const projectVersion = "0.1.0";
+    const gluestickVersion = "0.2.0";
+    newDotFileContents(JSON.stringify({version: projectVersion}));
+    updateLastVersionUsed(gluestickVersion);
+    const fileContents = fs.readFileSync(dotFile, {encoding: "utf8"});
+    const project = JSON.parse(fileContents);
+    expect(project.version).to.equal(gluestickVersion);
   });
 });


### PR DESCRIPTION
This PR addresses the minor issue where a warning is displayed to the user when his gluestick version is more recent than the project version. That's a normal case, so we don't need to display the warning. 

I also took the opportunity to lint the files and refactor for easier testing. Specifically, we are now passing the gluestick version to the update function so we can test behaviors for different versions.
