### PR TITLE
Improve font support

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "webpack": "1.12.8",
     "webpack-dev-middleware": "1.3.0",
     "webpack-hot-middleware": "2.5.0",
-    "webpack-isomorphic-tools": "2.2.21"
+    "webpack-isomorphic-tools": "2.2.37"
   },
   "peerDependencies": {},
   "devDependencies": {

--- a/src/lib/webpack-isomorphic-tools-configuration.js
+++ b/src/lib/webpack-isomorphic-tools-configuration.js
@@ -36,7 +36,8 @@ let userExtensions = [];
 module.exports = {
   assets: {
     images: {
-      extensions: ["png", "jpg", "gif", "ico", "svg"]
+      extensions: ["png", "jpg", "gif", "ico", "svg"],
+      regular_expression: /\.(png|jpg|gif|ico|svg)(\?v=\d+\.\d+\.\d+)?$/
     },
     styles: {
       extensions: ["css", "scss", "sass"],

--- a/src/lib/webpack-isomorphic-tools-configuration.js
+++ b/src/lib/webpack-isomorphic-tools-configuration.js
@@ -1,9 +1,9 @@
 import logger from "./logger";
 import { highlight } from "./logsColorScheme";
 
-var path = require("path");
-var process = require("process");
-var WebpackIsomorphicToolsPlugin = require("webpack-isomorphic-tools/plugin");
+const path = require("path");
+const process = require("process");
+const WebpackIsomorphicToolsPlugin = require("webpack-isomorphic-tools/plugin");
 
 // We use `get-webpack-additions` to get the data back because it will first
 // check if the file exists before trying to include it, falling back to empty
@@ -16,14 +16,14 @@ var WebpackIsomorphicToolsPlugin = require("webpack-isomorphic-tools/plugin");
 // tools, not the webpack config file.
 const { additionalLoaders, additionalPreLoaders } = require("./get-webpack-additions").default(true);
 
-let userExtensions = [];
+const userExtensions = [];
 [...additionalLoaders, ...additionalPreLoaders].forEach((loader) => {
   // Bail out when a test regexp has been supplied.
-  if (loader.test && toString.call(loader.test) === "[object RegExp]") return;
+  if (loader.test && toString.call(loader.test) === "[object RegExp]") { return; }
 
   // If someone wants to include a custom .js loader, we do not want the isomorphic tools to treat it as an asset
   // because .js imports are a native part of how node works. We do want webpack to receive the loader though.
-  if (loader.extensions.includes("js")) return;
+  if (loader.extensions.includes("js")) { return; }
 
   if (!loader.extensions || loader.extensions.length === 0) {
     logger.info(`An additional loader is missing the ${highlight("extensions")} property and is being ignored!`);
@@ -43,7 +43,7 @@ module.exports = {
       extensions: ["css", "scss", "sass"],
       filter: function(module, regex, options, log) {
         if (options.development) {
-          return WebpackIsomorphicToolsPlugin.style_loader_filter(module, regex, options, log)
+          return WebpackIsomorphicToolsPlugin.style_loader_filter(module, regex, options, log);
         }
       },
       path: WebpackIsomorphicToolsPlugin.style_loader_path_extractor,

--- a/src/lib/webpack-isomorphic-tools-configuration.js
+++ b/src/lib/webpack-isomorphic-tools-configuration.js
@@ -50,6 +50,7 @@ module.exports = {
     },
     fonts: {
       extensions: ["woff", "woff2", "ttf", "eot"],
+      regular_expression: /\.(woff|woff2|ttf|eot)(\?v=\d+\.\d+\.\d+)?$/,
       parser: WebpackIsomorphicToolsPlugin.url_loader_parser
     },
     json: {


### PR DESCRIPTION
This PR addresses the issue of not being able to properly load font-awesome assets, as some font urls have an additional query parameter with version information appended to them. Example:

```
url(../fonts/myfont.woff?v=1.1.1). 
```
- Upgrade webpack-isomorphic-tools to latest version to get regular expression support
- Add regular expression to Gluestick's configuration file support fonts with versions
- Add the same for images, as I was seeing a lingering issue with svg's that have versions on them. **Side note**: I'm unsure if this should _only_ apply to svg files or if this should apply to all image types. I made it support all for now but we can change this if that doesn't seem right.
- Lint

To test this, I created a sample repo and made sure it loaded assets with `gluestick start`: https://github.com/cybrass/test-font-awesome-gs 
