### PR TITLE
Add option to run test suite only once

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -114,9 +114,15 @@ const firefoxOption = {
   description: "Use Firefox with test runner"
 };
 
+const singleRunOption = {
+  command: "-S, --single",
+  description: "Run test suite only once"
+};
+
 commander
   .command("start-test", null, {noHelp: true})
   .option(firefoxOption.command, firefoxOption.description)
+  .option(singleRunOption.command, singleRunOption.description)
   .description("start test")
   .action(checkGluestickProject)
   .action((options) => startTest(options))
@@ -125,6 +131,7 @@ commander
 commander
   .command("test")
   .option(firefoxOption.command, firefoxOption.description)
+  .option(singleRunOption.command, singleRunOption.description)
   .description("start tests")
   .action(checkGluestickProject)
   .action(() => spawnProcess("test", process.argv.slice(3)))

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -11,6 +11,10 @@ module.exports = function (options) {
     config.browsers = ["Firefox"];
   }
 
+  if (options.single) {
+    config.singleRun = options.single;
+  }
+
   const server = new Server(config);
 
   server.start();


### PR DESCRIPTION
By default we run app tests in continuous mode; add an option to exit after running the test suite once.
