### PR TITLE
change devtool from `eval` to `cheap-module-eval-source-map`

### DIFF
--- a/src/commands/start-client.js
+++ b/src/commands/start-client.js
@@ -71,7 +71,7 @@ configEnvVariables.forEach((v) => {
 
 var compiler = webpack({
   context: process.cwd(),
-  devtool: isProduction ? undefined : "eval",
+  devtool: isProduction ? undefined : "cheap-module-eval-source-map",
   entry: {
     "main": entry
   },


### PR DESCRIPTION
`eval` doesn't give us the original code `cheap-module-eval-source-map`
does
