### PR TITLE
Use the proper exit code for `gluestick test`

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -134,8 +134,11 @@ commander
   .option(singleRunOption.command, singleRunOption.description)
   .description("start tests")
   .action(checkGluestickProject)
-  .action(() => spawnProcess("test", process.argv.slice(3)))
-  .action(() => updateLastVersionUsed(currentGluestickVersion));
+  .action(() => updateLastVersionUsed(currentGluestickVersion))
+  .action(() => {
+    const proc = spawnProcess("test", commander.rawArgs.slice(3));
+    proc.on("close", code => { process.exit(code); });
+  });
 
 // This is a catch all command. DO NOT PLACE ANY COMMANDS BELOW THIS
 commander


### PR DESCRIPTION
When tests are run in single run mode, we want to make sure the test command is providing the exit code returned by Karma. An example reason for this would be for CI, where we want the build process to fail if tests fail.

Sample run:

```
› gluestick test -S; echo "Exit code: $?"
...
Chrome 49.0.2623 (Mac OS X 10.10.5): Executed 173 of 184 (2 FAILED) (0.934 secs / 0.298 secs)
TOTAL: 2 FAILED, 171 SUCCESS
Exit code: 1
```
