### PR TITLE
Generate cobertura reports for CI

### DIFF
--- a/src/lib/karmaConfig.js
+++ b/src/lib/karmaConfig.js
@@ -80,6 +80,10 @@ export default {
       {
         type: "html",
         subdir: "html"
+      },
+      {
+        type: "cobertura",
+        subdir: "xml"
       }
     ]
   }


### PR DESCRIPTION
Eventually we want to parameterize these, so users can generate whatever flavors of reports works for them. For now, I'd like to create cobertura reports for integration with our build servers.

Coverage directory after running `gluestick test`:

```
coverage
├── html
│   └── index.html
│   └── ...
└── xml
    └── cobertura-coverage.xml
```
