### PR TITLE
Integrate react-helmet for document head changes

### DIFF
--- a/generate/container.js
+++ b/generate/container.js
@@ -2,6 +2,7 @@
 import React, { Component } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
+import Helmet from "react-helmet";
 
 export class __$NAME__ extends Component {
   /**
@@ -22,7 +23,10 @@ export class __$NAME__ extends Component {
 
   render () {
     return (
-      <div>__$NAME__</div>
+      <div>
+        <Helmet title="__$NAME__"/>
+        __$NAME__
+      </div>
     );
   }
 }

--- a/new/Index.js
+++ b/new/Index.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from "react";
+import Helmet from "react-helmet";
 import "assets/css/normalize.css";
 
 /**
@@ -17,10 +18,17 @@ export default class Index extends Component {
       head,
       body
     } = this.props;
+
+    const helmet = Helmet.rewind();
+
     return (
       <html lang="en-us">
         <head>
-          <title>Welcome</title>
+          {helmet.base.toComponent()}
+          {helmet.title.toComponent()}
+          {helmet.meta.toComponent()}
+          {helmet.link.toComponent()}
+          {helmet.script.toComponent()}
           {head /* DO NOT REMOVE */}
         </head>
         <body>

--- a/new/package.json
+++ b/new/package.json
@@ -23,7 +23,7 @@
     "radium": "0.17.1",
     "react": "15.0.1",
     "react-dom": "15.0.1",
-    "react-helmet": "3.0.1",
+    "react-helmet": "3.0.2",
     "react-redux": "4.4.2",
     "react-router": "2.1.0",
     "redux": "3.4.0",

--- a/new/package.json
+++ b/new/package.json
@@ -23,6 +23,7 @@
     "radium": "0.17.1",
     "react": "15.0.1",
     "react-dom": "15.0.1",
+    "react-helmet": "3.0.1",
     "react-redux": "4.4.2",
     "react-router": "2.1.0",
     "redux": "3.4.0",

--- a/new/src/components/MasterLayout.js
+++ b/new/src/components/MasterLayout.js
@@ -1,5 +1,7 @@
 /* @flow */
 import React, { Component, PropTypes } from "react";
+import Helmet from "react-helmet";
+import config from "../config/application";
 
 export default class MasterLayout extends Component {
   static propTypes = {
@@ -9,6 +11,7 @@ export default class MasterLayout extends Component {
   render () {
     return (
       <div>
+        <Helmet {...config.head}/>
         {this.props.children}
       </div>
     );

--- a/new/src/config/application.js
+++ b/new/src/config/application.js
@@ -1,12 +1,23 @@
 // WARNING: The contents of this file _including process.env variables_ will be
 // exposed in the client code.
+
+const headContent = {
+  title: "My Gluestick App",
+  titleTemplate: "%s | Gluestick Application",
+  meta: [
+    {name: "description", content: "Gluestick application"}
+  ]
+};
+
 const config = {
   development: {
-    assetPath: "http://localhost:8888/assets"
+    assetPath: "http://localhost:8888/assets",
+    head: headContent
   },
   production: {
     // This should be a CDN in development
-    assetPath: process.env.ASSET_URL || "http://localhost:8888/assets"
+    assetPath: process.env.ASSET_URL || "http://localhost:8888/assets",
+    head: headContent
   }
 };
 

--- a/new/src/containers/HomeApp.js
+++ b/new/src/containers/HomeApp.js
@@ -2,6 +2,7 @@
 import React, { Component } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
+import Helmet from "react-helmet";
 
 import Home from "../components/Home";
 
@@ -24,7 +25,10 @@ export class HomeApp extends Component {
 
   render () {
     return (
-      <Home />
+      <div>
+        <Helmet title="Home"/>
+        <Home />
+      </div>
     );
   }
 }

--- a/new/src/containers/NoMatchApp.js
+++ b/new/src/containers/NoMatchApp.js
@@ -1,5 +1,6 @@
 /* @flow */
 import React, { Component } from "react";
+import Helmet from "react-helmet";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 
@@ -22,7 +23,10 @@ export class NoMatchApp extends Component {
 
   render () {
     return (
-      <div><h2>404 - Not Found</h2></div>
+      <div>
+        <Helmet title="Not Found"/>
+        <h2>404 - Not Found</h2>
+      </div>
     );
   }
 }

--- a/src/auto-upgrade/updateConfig.js
+++ b/src/auto-upgrade/updateConfig.js
@@ -22,20 +22,19 @@ export default function updateConfig () {
     const expectedLastLine = 'export default (config[process.env.NODE_ENV] || config["development"]);';
 
     const hasExportUpgrade = lastAppConfigLine === expectedLastLine;
-    const hasHeadUpgrade = appConfig.indexOf('const headContent = {') != -1;
+    const hasHeadUpgrade = appConfig.indexOf("const headContent = {") !== -1;
     if (hasExportUpgrade && hasHeadUpgrade) {
       resolve();
       return;
     }
 
     const exampleContents = fs.readFileSync(path.join(__dirname, "..", "..", "new", "src", "config", "application.js"), "utf8");
-    let message = "The format of src/config/application.js is out of date.";
+    logger.warn("The format of src/config/application.js is out of date.");
     if (hasExportUpgrade) {
-      message += " You should manually update it to get new config values for document head changes.";
+      logger.warn("You should *manually* update it to include the new document head content as seen in the example below.");
     } else {
-      message += " You should export the correct config object based on the environment.";
+      logger.warn("You should export the correct config object based on the environment.");
     }
-    logger.warn(message);
     logger.info(`Example:\n${chalk.cyan(exampleContents)}`);
 
     if (hasExportUpgrade) {

--- a/src/auto-upgrade/updateConfig.js
+++ b/src/auto-upgrade/updateConfig.js
@@ -19,7 +19,7 @@ export default function updateConfig () {
     const appConfig = readFileSyncStrip(appConfigPath);
     const lastAppConfigLine = appConfig.split("\n").pop();
     const expectedLastLine = 'export default (config[process.env.NODE_ENV] || config["development"]);';
-    if (lastAppConfigLine === expectedLastLine) {
+    if (lastAppConfigLine === expectedLastLine && appConfig.hasOwnProperty("head")) {
       resolve();
       return;
     }
@@ -28,12 +28,14 @@ export default function updateConfig () {
     const question = {
       type: "confirm",
       name: "confirm",
-      message: `${chalk.red("The format of src/config/application.js is out of date. You should export the correct config object based on the environment.")}
+      message: `${chalk.red("The format of src/config/application.js is out of date. Please consider updating it to get important changes.")}
 ${chalk.yellow("Example:")}\n${chalk.cyan(exampleContents)}
 Would you like to try to automatically update it?`
     };
     inquirer.prompt([question]).then(function (answers) {
-      if (!answers.confirm) return resolve();
+      if (!answers.confirm) {
+        return resolve();
+      }
       doUpgrade(appConfig, expectedLastLine, appConfigPath);
       resolve();
     });

--- a/src/cli.js
+++ b/src/cli.js
@@ -163,11 +163,11 @@ function notifyUpdates () {
   if (data.indexOf("Helmet.rewind()") === -1) {
     logger.info(`
 ##########################################################################
-Upgrade Notice: Newer versions of src/Index.js now include react-helmet
+Upgrade Notice: Newer versions of Index.js now include react-helmet
 for allowing dynamic changes to document header data. You will need to 
-manually update your src/Index.js file to receive this change.
+manually update your Index.js file to receive this change.
 For a simple example see:
-https://github.com/TrueCar/gluestick/blob/develop/new/src/Index.js
+https://github.com/TrueCar/gluestick/blob/develop/new/Index.js
 ##########################################################################
     `);
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,8 @@
 const commander = require("commander");
 const process = require("process");
 const { spawn } = require("cross-spawn");
+const fs = require("fs-extra");
+const path = require("path");
 const lazyMethodRequire = require("./lib/LazyMethodRequire").default(__dirname);
 
 const newApp = lazyMethodRequire("./commands/new");
@@ -76,6 +78,7 @@ commander
   .option("-T, --no_tests", "ignore test hook")
   .option(debugOption.command, debugOption.description)
   .action(checkGluestickProject)
+  .action(() => notifyUpdates())
   .action((options) => startAll(options.no_tests, options.debug))
   .action(() => updateLastVersionUsed(currentGluestickVersion));
 
@@ -152,6 +155,22 @@ commander.parse(process.argv);
 
 function checkGluestickProject () {
   quitUnlessGluestickProject(commander.rawArgs[2]);
+}
+
+function notifyUpdates () {
+  const indexFilePath = path.join(process.cwd(), "Index.js");
+  const data = fs.readFileSync(indexFilePath);
+  if (data.indexOf("Helmet.rewind()") === -1) {
+    logger.info(`
+##########################################################################
+Upgrade Notice: Newer versions of src/Index.js now include react-helmet
+for allowing dynamic changes to document header data. You will need to 
+manually update your src/Index.js file to receive this change.
+For a simple example see:
+https://github.com/TrueCar/gluestick/blob/develop/new/src/Index.js
+##########################################################################
+    `);
+  }
 }
 
 function spawnProcess (type, args=[]) {

--- a/test/commands/generate.test.js
+++ b/test/commands/generate.test.js
@@ -109,4 +109,14 @@ describe("cli: gluestick generate", function () {
     });
   });
 
+  it("should generate a container that sets the document title", done => {
+    const type = "container";
+    stubProject(type);
+    generate(type, "mycontainer", (err) => {
+      const contents = fs.readFileSync(path.join(process.cwd(), `src/${type}s/Mycontainer.js`), "utf8");
+      expect(contents).to.contain("<Helmet title=\"Mycontainer\"/>");
+      done();
+    });
+  });
+
 });

--- a/test/commands/generate.test.js
+++ b/test/commands/generate.test.js
@@ -9,12 +9,12 @@ import generate from "../../src/commands/generate";
 
 function stubProject(type) {
     // Generate files that are already expected to exist
-    const srcDir = path.join(process.cwd(), `src/${type}s`);
-    fs.closeSync(fs.openSync(".gluestick", "w"));
-    mkdirp.sync(srcDir);
-    if (type === "reducer") {
-      fs.closeSync(fs.openSync(path.join(srcDir, "index.js"), "w"));
-    }
+  const srcDir = path.join(process.cwd(), `src/${type}s`);
+  fs.closeSync(fs.openSync(".gluestick", "w"));
+  mkdirp.sync(srcDir);
+  if (type === "reducer") {
+    fs.closeSync(fs.openSync(path.join(srcDir, "index.js"), "w"));
+  }
 }
 
 function makeGeneratedFilesAssertion(dir, type, name, done) {
@@ -27,9 +27,9 @@ function makeGeneratedFilesAssertion(dir, type, name, done) {
     `test/${type}s`,
     `test/${type}s/${name}.test.js`
   ];
-  const generatedFiles = new Set(glob.sync('**', {
-      dot: true,
-      cwd: path.resolve(dir)
+  const generatedFiles = new Set(glob.sync("**", {
+    dot: true,
+    cwd: path.resolve(dir)
   }));
   expect(expectedFiles.filter(f => !generatedFiles.has(f))).to.be.empty;
   done();
@@ -37,7 +37,7 @@ function makeGeneratedFilesAssertion(dir, type, name, done) {
 
 describe("cli: gluestick generate", function () {
 
-  let originalCwd, tmpDir, sandbox;
+  let originalCwd, tmpDir;
 
   beforeEach(() => {
     originalCwd = process.cwd();


### PR DESCRIPTION
This PR integrates react-helmet into new Gluestick projects and allows a base set of document head tags to be configured via the application's config file:
https://github.com/cybrass/helmet-gluestick/blob/master/src/config/application.js#L4-L10 

I also added react-helmet to generated containers by default so users of Gluestick could immediately take advantage of it: 
https://github.com/cybrass/helmet-gluestick/blob/master/src/containers/Mycontainer.js#L27

Full working example here: https://github.com/cybrass/helmet-gluestick
