### PR TITLE
add support for isomorphic http client that forwards cookies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "author": "Todd Williams <toddsurfs@icloud.com>",
   "dependencies": {
     "app-module-path": "1.0.6",
+    "axios": "0.11.0",
     "babel-cli": "6.8.0",
     "babel-core": "6.8.0",
     "babel-istanbul": "0.8.0",
@@ -54,7 +55,7 @@
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.8.5",
     "fs-extra": "0.30.0",
-    "gluestick-shared": "0.3.4",
+    "gluestick-shared": "0.3.5",
     "history": "2.1.1",
     "inquirer": "1.0.2",
     "jsdom": "9.0.0",

--- a/src/lib/server/requestHandler.js
+++ b/src/lib/server/requestHandler.js
@@ -1,8 +1,10 @@
 /*global webpackIsomorphicTools*/
 import path from "path";
+import axios from "axios";
 import { createElement } from "react";
 import { renderToString } from "react-dom/server";
-import { runBeforeRoutes, ROUTE_NAME_404_NOT_FOUND, prepareRoutesWithTransitionHooks } from "gluestick-shared";
+import { runBeforeRoutes, ROUTE_NAME_404_NOT_FOUND,
+  prepareRoutesWithTransitionHooks } from "gluestick-shared";
 import { match, RouterContext } from "react-router";
 import errorHandler from "./errorHandler";
 import Body from "./Body";
@@ -17,9 +19,16 @@ process.on("unhandledRejection", (reason, promise) => {
 
 module.exports = async function (req, res) {
   try {
+
+    // Forward all request headers from the browser into http requests made by
+    // node
+    const httpClient = axios.create({
+      headers: req.headers
+    });
+
     const Index = require(path.join(process.cwd(), "Index")).default;
     const Entry = require(path.join(process.cwd(), "src/config/.entry")).default;
-    const store = require(path.join(process.cwd(), "src/config/.store")).default();
+    const store = require(path.join(process.cwd(), "src/config/.store")).default(httpClient);
     let originalRoutes = require(path.join(process.cwd(), "src/config/routes")).default;
 
     // @TODO: Remove this in the future when people have had enough time to

--- a/templates/new/package.json
+++ b/templates/new/package.json
@@ -8,6 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "axios": "0.11.0",
     "babel-core": "6.8.0",
     "babel-loader": "6.2.4",
     "babel-runtime": "6.6.1",
@@ -16,7 +17,7 @@
     "babel-preset-react": "6.5.0",
     "css-loader": "0.23.1",
     "file-loader": "0.8.5",
-    "gluestick-shared": "0.3.4",
+    "gluestick-shared": "0.3.5",
     "history": "2.1.1",
     "json-loader": "0.5.4",
     "node-sass": "3.7.0",

--- a/templates/new/src/config/.entry.js
+++ b/templates/new/src/config/.entry.js
@@ -6,7 +6,7 @@ import { render } from "react-dom";
 // file
 import "../../Index.js";
 
-import { Root, getHTTPClient } from "gluestick-shared";
+import { Root } from "gluestick-shared";
 import { match, browserHistory as history } from "react-router";
 import routes from "./routes";
 import store from "./.store";

--- a/templates/new/src/config/.entry.js
+++ b/templates/new/src/config/.entry.js
@@ -6,11 +6,12 @@ import { render } from "react-dom";
 // file
 import "../../Index.js";
 
-import { Root } from "gluestick-shared";
+import { Root, getHTTPClient } from "gluestick-shared";
 import { match, browserHistory as history } from "react-router";
 import routes from "./routes";
 import store from "./.store";
 import { StyleRoot } from "radium";
+import axios from "axios";
 
 // @deprecated 0.3.9
 // Returning routes directly, not through method is deprecated as of 0.3.9
@@ -21,7 +22,7 @@ if (typeof routes !== "function") { getRoutes = () => routes; }
 
 export default class Entry extends Component {
   static defaultProps = {
-    store: store()
+    store: store(axios)
   };
 
   render () {
@@ -40,7 +41,7 @@ export default class Entry extends Component {
 }
 
 Entry.start = function () {
-  const newStore = store();
+  const newStore = store(axios);
   match({ history, routes: getRoutes(newStore) }, (error, redirectLocation, renderProps) => {
     render(<Entry radiumConfig={{userAgent: window.navigator.userAgent}} store={newStore} {...renderProps} />, document.getElementById("main"));
   });

--- a/templates/new/src/config/.store.js
+++ b/templates/new/src/config/.store.js
@@ -2,6 +2,6 @@
 // The following lines create the store and properly sets up hot module replacement for reducers
 import { createStore } from "gluestick-shared";
 import middleware from "./redux-middleware";
-export default function () {
-  return createStore(() => require("../reducers"), middleware, (cb) => module.hot && module.hot.accept("../reducers", cb), !!module.hot);
+export default function (httpClient) {
+  return createStore(httpClient, () => require("../reducers"), middleware, (cb) => module.hot && module.hot.accept("../reducers", cb), !!module.hot);
 }


### PR DESCRIPTION
# Depends on https://github.com/TrueCar/gluestick-shared/pull/9 being merged and new version of Gluestick-Shared being released first

> When doing HTTP requests from the browser, the browser's cookies are automatically included in the request. When doing HTTP requests from node, the browsers cookies will not be automatically included. To resolve this issue, we added proxy support to GlueStick, by putting API urls behind a proxy the host for the API and the client can be shared and thus share the same cookies. When we are going to be making an HTTP request from the node app, we simply forward all of the headers from the original browser request. This means we have a split where code run in the browser should use a plain `axios` client and the requests from the server need a custom instance of `axios` where the headers from the initial request are injected automatically.
