### PR TITLE
Add webpack aliases for component and container folders

### DIFF
--- a/src/config/webpack-isomorphic-tools-config.js
+++ b/src/config/webpack-isomorphic-tools-config.js
@@ -63,6 +63,8 @@ module.exports = {
     }
   },
   alias: {
-    "assets": path.join(process.cwd(), "assets")
+    "assets": path.join(process.cwd(), "assets"),
+    "components": path.join(process.cwd(), "src", "components"),
+    "containers": path.join(process.cwd(), "src", "containers")
   }
 };

--- a/src/config/webpack-shared-config.js
+++ b/src/config/webpack-shared-config.js
@@ -13,7 +13,9 @@ module.exports = {
   resolve: {
     extensions: ["", ".js", ".css", ".json"],
     alias: {
-      "assets": path.join(process.cwd(), "assets")
+      "assets": path.join(process.cwd(), "assets"),
+      "components": path.join(process.cwd(), "src", "components"),
+      "containers": path.join(process.cwd(), "src", "containers")
     }
   },
   loaders: [

--- a/templates/new/src/config/routes.js
+++ b/templates/new/src/config/routes.js
@@ -3,9 +3,9 @@ import React from "react";
 import { Route, IndexRoute } from "react-router";
 import { ROUTE_NAME_404_NOT_FOUND } from "gluestick-shared";
 
-import MasterLayout from "../components/MasterLayout";
-import HomeApp from "../containers/HomeApp";
-import NoMatchApp from "../containers/NoMatchApp";
+import MasterLayout from "components/MasterLayout";
+import HomeApp from "containers/HomeApp";
+import NoMatchApp from "containers/NoMatchApp";
 
 export default function routes (/*store:Object*/) {
   return (

--- a/templates/new/src/containers/HomeApp.js
+++ b/templates/new/src/containers/HomeApp.js
@@ -4,7 +4,7 @@ import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import Helmet from "react-helmet";
 
-import Home from "../components/Home";
+import Home from "components/Home";
 
 export class HomeApp extends Component {
   /**


### PR DESCRIPTION
Also update template files so newly-generated Gluestick apps use the simplified path in imports.

Resolves #155
