### PR TITLE
Set Mocha/Node to be the default test runner.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -32,7 +32,7 @@ const currentGluestickVersion = getVersion();
 
 const debugServerOption = ["-D, --debug-server", "debug server side rendering with node-inspector"];
 const debugTestOption = ["-B, --debug-test", "debug tests with node-inspector"];
-const nodeTestOption = ["-m, --mocha-only", "run tests in Node.js"];
+const karmaTestOption = ["-k, --karma", "run tests in Karma"];
 const mochaReporterOption = ["-r, --reporter [type]", "run tests in Node.js"];
 const firefoxOption = ["-F, --firefox", "Use Firefox with test runner"];
 const singleRunOption = ["-S, --single", "Run test suite only once"];
@@ -81,7 +81,7 @@ commander
   .option(...debugServerOption)
   .option(...debugTestOption)
   .option(...mochaReporterOption)
-  .option(...nodeTestOption)
+  .option(...karmaTestOption)
   .action(checkGluestickProject)
   .action(() => notifyUpdates())
   .action(startAll)
@@ -123,7 +123,7 @@ commander
   .command("start-test", null, {noHelp: true})
   .option(...firefoxOption)
   .option(...singleRunOption)
-  .option(...nodeTestOption)
+  .option(...karmaTestOption)
   .option(...debugTestOption)
   .option(...mochaReporterOption)
   .description("start test")
@@ -135,7 +135,7 @@ commander
   .command("test")
   .option(...firefoxOption)
   .option(...singleRunOption)
-  .option(...nodeTestOption)
+  .option(...karmaTestOption)
   .option(...debugTestOption)
   .option(...mochaReporterOption)
   .description("start tests")

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -186,9 +186,9 @@ function useKarma(options) {
 
 module.exports = function(options) {
   // override to run tests in Node without Karma/Webpack
-  if (options.mochaOnly) {
-    useMocha(options);
-  } else {
+  if (options.karma) {
     useKarma(options);
+  } else {
+    useMocha(options);
   }
 };


### PR DESCRIPTION
Override with --karma option.

Setting now that mocha/node is at feature parity with the existing Karma setup (watch, coverage, debugging).
