### PR TITLE
Update gluestick-shared dependency version

### DIFF
--- a/templates/new/package.json
+++ b/templates/new/package.json
@@ -17,7 +17,7 @@
     "babel-preset-react": "6.5.0",
     "css-loader": "0.23.1",
     "file-loader": "0.8.5",
-    "gluestick-shared": "0.3.5",
+    "gluestick-shared": "0.3.6",
     "history": "2.1.1",
     "json-loader": "0.5.4",
     "node-sass": "3.7.0",


### PR DESCRIPTION
Without this patch, Gluestick will re-prompt to update dependencies for each `gluestick start` command. 
