### PR TITLE
Support directories in gluestick generate arguments

### DIFF
--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -60,8 +60,14 @@ module.exports = function (command, name, cb) {
   template = replaceName(template, generatedFileName);
 
   // Check if the file already exists before we write to it
-  const destinationRoot = path.resolve(path.join(CWD, "src", availableCommands[command]), dirname);
+  const generateRoot = path.join(CWD, "src", availableCommands[command]);
+  const destinationRoot = path.resolve(generateRoot, dirname);
   const destinationPath = path.join(destinationRoot, generatedFileName + ".js");
+
+  if (destinationPath.indexOf(generateRoot) !== 0) {
+    return cb(`${command} generation is not supported outside of ${path.relative(CWD, generateRoot)}`);
+  }
+
   let fileExists = true;
   try {
     fs.statSync(destinationPath);

--- a/test/commands/generate.test.js
+++ b/test/commands/generate.test.js
@@ -156,6 +156,16 @@ describe("cli: gluestick generate", function () {
         done();
       });
     });
+
+    it("reports an error if the directory path resolves outside of the root path", done => {
+      const type = "component";
+      stubProject(type);
+      generate(type, "../common/mycomponent", (err) => {
+        expect(err).to.not.be.undefined;
+        expect(err).to.contain("not supported");
+        done();
+      });
+    });
   });
 
 });


### PR DESCRIPTION
Resolves #156 
- Parse the dirname and basename from the provided path and use that during file generation
- Add an error message for reducers (they are not supported with this PR)
- Add tests for the new functionality
- Organize all tests by grouping them by context
