### PR TITLE
Support directories in `gluestick destroy` arguments

### DIFF
--- a/src/commands/destroy.js
+++ b/src/commands/destroy.js
@@ -20,28 +20,35 @@ module.exports = async function (command, name) {
     return;
   }
 
+  const dirname = path.dirname(name);
+  const basename = path.basename(name);
+
   // Validate the name by stripping out unwanted characters
-  if (!name || name.length === 0) {
+  if (!basename || basename.length === 0) {
     logger.error("invalid arguments. You must specify a name.");
     return;
   }
 
-  if (/\W/.test(name)) {
-    logger.error(`${highlight(name)} is not a valid name.`);
+  if (/\W/.test(basename)) {
+    logger.error(`${highlight(basename)} is not a valid name.`);
     return;
   }
 
   // Possibly mutate the name by converting it to Pascal Case (only for container and component for now)
-  const originalName = name; // store original name for later
+  const originalName = basename; // store original name for later
+  let generatedFileName = basename;
   if (["container", "component"].indexOf(command) !== -1) {
-    name = name.substr(0, 1).toUpperCase() + name.substr(1);
+    generatedFileName = generatedFileName.substr(0, 1).toUpperCase() + generatedFileName.substr(1);
   }
   if (["reducer", "action-creator"].indexOf(command) !== -1) {
-    name = name.substr(0, 1).toLowerCase() + name.substr(1);
+    generatedFileName = generatedFileName.substr(0, 1).toLowerCase() + generatedFileName.substr(1);
   }
 
   // Remove the file
-  const destinationPath = path.join(process.cwd(), "/src/", availableCommands[command] + "/" + name + ".js");
+  const CWD = process.cwd();
+  const generateRoot = path.join(CWD, "src", availableCommands[command]);
+  const destinationRoot = path.resolve(generateRoot, dirname);
+  const destinationPath = path.join(destinationRoot, generatedFileName + ".js");
   let fileExists = true;
   try {
     fs.statSync(destinationPath);
@@ -52,13 +59,13 @@ module.exports = async function (command, name) {
 
   if (fileExists) {
     // If they typed a name that would normally be mutated, check with the user first before deleting the files
-    if (originalName !== name) {
+    if (originalName !== generatedFileName) {
       // @NOTE: We are using await so that we can wait for the result of the promise before moving on
       const continueDestroying = await new Promise((resolve) => {
         const question = {
           type: "confirm",
           name: "confirm",
-          message: `You wanted to destroy ${filename(originalName)} but the generated name is ${filename(name)}.\nWould you like to continue with destroying ${filename(name)}?`
+          message: `You wanted to destroy ${filename(originalName)} but the generated name is ${filename(generatedFileName)}.\nWould you like to continue with destroying ${filename(generatedFileName)}?`
         };
         inquirer.prompt([question]).then(function (answers) {
           resolve(!!answers.confirm);
@@ -82,14 +89,14 @@ module.exports = async function (command, name) {
     const reducerIndexPath = path.resolve(process.cwd(), "src/reducers/index.js");
     try {
       const indexLines = fs.readFileSync(reducerIndexPath, {encoding: "utf8"}).split("\n");
-      const reducerLine = `export { default as ${name} } from "./${name}"`;
+      const reducerLine = `export { default as ${generatedFileName} } from "./${generatedFileName}"`;
       const newIndexLines = indexLines.filter((indexLine) => {
         // Only return lines from the reducer index that do not return the reducer
         // we just destroyed. Check for semi colon and non-semi colon lines
         return indexLine !== reducerLine && indexLine !== `${reducerLine};`;
       });
       fs.writeFileSync(reducerIndexPath, newIndexLines.join("\n"));
-      logger.success(`${highlight(name)} removed from reducer index ${filename(reducerIndexPath)}`);
+      logger.success(`${highlight(generatedFileName)} removed from reducer index ${filename(reducerIndexPath)}`);
     }
     catch (e) {
       logger.error("Unable to modify reducers index. Reducer not removed from index");
@@ -97,7 +104,8 @@ module.exports = async function (command, name) {
   }
 
   // Remove the test file
-  const testPath = path.join(process.cwd(), "/test/", availableCommands[command], `/${name}.test.js`);
+  const testFolder = path.resolve(path.join(CWD, "test", availableCommands[command]), dirname);
+  const testPath = path.join(testFolder, `${generatedFileName}.test.js`);
   let testFileExists = true;
   try {
     fs.statSync(testPath);

--- a/test/commands/destroy.test.js
+++ b/test/commands/destroy.test.js
@@ -40,17 +40,6 @@ describe("cli: gluestick destroy", function () {
     fs.closeSync(fs.openSync(".gluestick", "w"));
     createDirectories(tmpDir, "components", "reducers", "containers");
 
-    const componentPath = path.join(tmpDir, "src/components/TestComponent.js");
-    const componentTestPath = path.join(tmpDir, "test/components/TestComponent.test.js");
-
-    const containerPath = path.join(tmpDir, "src/containers/TestContainer.js");
-    const containerTestPath = path.join(tmpDir, "test/containers/TestContainer.test.js");
-
-    const reducerPath = path.join(tmpDir, "src/reducers/testReducer.js");
-    const reducerTestPath = path.join(tmpDir, "test/reducers/testReducer.test.js");
-
-    createFiles(componentPath, componentTestPath, containerPath, containerTestPath, reducerPath, reducerTestPath);
-
     sandbox = sinon.sandbox.create();
     sandbox.spy(logger, "error");
   });
@@ -61,58 +50,90 @@ describe("cli: gluestick destroy", function () {
     rimraf(tmpDir, done);
   });
 
-  it("should throw an error when (container|component|reducer) is not specified", () => {
-    destroy("blah","");
-    expect(logger.error.calledWithMatch("is not a valid destroy command.")).to.be.true;
-  });
-
-  it("should throw an error when a name not specified", () => {
-    destroy("component","");
-    expect(logger.error.calledWithMatch("invalid arguments. You must specify a name.")).to.be.true;
-  });
-
-  it("should throw an error when a name only consists of whitespace", () => {
-    destroy("component"," ");
-    expect(logger.error.calledWithMatch("is not a valid name.")).to.be.true;
-  });
-
-  it("should throw an error when the specified name does not exist", () => {
-    destroy("component","somethingthatdoesnotexist");
-    expect(logger.error.calledWithMatch("does not exist")).to.be.true;
-  });
-
-  it("should ask whether to continue if the name does not match (case sensitive)", done => {
-    sandbox.stub(inquirer, "prompt", (questions, cb) => {
-      setTimeout(() => {
-        cb({confirm: true});
-      }, 0);
+  describe("when files are generated without sub-directories", function() {
+    beforeEach(() => {
+      const componentPath = path.join(tmpDir, "src/components/TestComponent.js");
+      const componentTestPath = path.join(tmpDir, "test/components/TestComponent.test.js");
+      const containerPath = path.join(tmpDir, "src/containers/TestContainer.js");
+      const containerTestPath = path.join(tmpDir, "test/containers/TestContainer.test.js");
+      const reducerPath = path.join(tmpDir, "src/reducers/testReducer.js");
+      const reducerTestPath = path.join(tmpDir, "test/reducers/testReducer.test.js");
+      createFiles(componentPath, componentTestPath, containerPath, containerTestPath, reducerPath, reducerTestPath);
     });
-    destroy("component","testComponent");
-    expect(inquirer.prompt.called).to.be.true;
-    done();
+
+    describe("when invalid arguments are provided", function() {
+      it("reports an error when (container|component|reducer) is not specified", () => {
+        destroy("blah","");
+        expect(logger.error.calledWithMatch("is not a valid destroy command.")).to.be.true;
+      });
+
+      it("reports an error when a name not specified", () => {
+        destroy("component","");
+        expect(logger.error.calledWithMatch("invalid arguments. You must specify a name.")).to.be.true;
+      });
+
+      it("reports an error when a name only consists of whitespace", () => {
+        destroy("component"," ");
+        expect(logger.error.calledWithMatch("is not a valid name.")).to.be.true;
+      });
+
+      it("reports an error when the specified name does not exist", () => {
+        destroy("component","somethingthatdoesnotexist");
+        expect(logger.error.calledWithMatch("does not exist")).to.be.true;
+      });
+
+      it("should ask whether to continue if the name does not match (case sensitive)", done => {
+        sandbox.stub(inquirer, "prompt", (questions, cb) => {
+          setTimeout(() => {
+            cb({confirm: true});
+          }, 0);
+        });
+        destroy("component","testComponent");
+        expect(inquirer.prompt.called).to.be.true;
+        done();
+      });
+    });
+
+    describe("when removing files", function() {
+      it("removes the specified component and its associated test", () => {
+        expect(fileExists("src/components/TestComponent.js")).to.be.true;
+        expect(fileExists("test/components/TestComponent.test.js")).to.be.true;
+        destroy("component","TestComponent");
+        expect(fileExists("src/components/TestComponent.js")).to.be.false;
+        expect(fileExists("test/components/TestComponent.test.js")).to.be.false;
+      });
+
+      it("removes the specified reducer and its associated test", () => {
+        expect(fileExists("src/reducers/testReducer.js")).to.be.true;
+        expect(fileExists("test/reducers/testReducer.test.js")).to.be.true;
+        destroy("reducer","testReducer");
+        expect(fileExists("src/reducers/testReducer.js")).to.be.false;
+        expect(fileExists("test/reducers/testReducer.test.js")).to.be.false;
+      });
+
+      it("removes the specified container and its associated test", () => {
+        expect(fileExists("src/containers/TestContainer.js")).to.be.true;
+        expect(fileExists("test/containers/TestContainer.test.js")).to.be.true;
+        destroy("container","TestContainer");
+        expect(fileExists("src/containers/TestContainer.js")).to.be.false;
+        expect(fileExists("test/containers/TestContainer.test.js")).to.be.false;
+      });
+    });
   });
 
-  it("should destroy the specified component and its associated test", () => {
-    expect(fileExists("/src/components/TestComponent.js")).to.be.true;
-    expect(fileExists("/test/components/TestComponent.test.js")).to.be.true;
-    destroy("component","TestComponent");
-    expect(fileExists("/src/components/TestComponent.js")).to.be.false;
-    expect(fileExists("/test/components/TestComponent.test.js")).to.be.false;
-  });
+  describe("when sub-directories are provided", function() {
+    beforeEach(() => {
+      const componentPath = path.join(tmpDir, "src/components/mydirectory/TestComponent.js");
+      const componentTestPath = path.join(tmpDir, "test/components/mydirectory/TestComponent.test.js");
+      createFiles(componentPath, componentTestPath);
+    });
 
-  it("should destroy the specified reducer and its associated test", () => {
-    expect(fileExists("/src/reducers/testReducer.js")).to.be.true;
-    expect(fileExists("/test/reducers/testReducer.test.js")).to.be.true;
-    destroy("reducer","testReducer");
-    expect(fileExists("/src/reducers/testReducer.js")).to.be.false;
-    expect(fileExists("/test/reducers/testReducer.test.js")).to.be.false;
-  });
-
-  it("should destroy the specified container and its associated test", () => {
-    expect(fileExists("/src/containers/TestContainer.js")).to.be.true;
-    expect(fileExists("/test/containers/TestContainer.test.js")).to.be.true;
-    destroy("container","TestContainer");
-    expect(fileExists("/src/containers/TestContainer.js")).to.be.false;
-    expect(fileExists("/test/containers/TestContainer.test.js")).to.be.false;
+    it("removes the files under the directory", () => {
+      expect(fileExists("src/components/mydirectory/TestComponent.js")).to.be.true;
+      expect(fileExists("test/components/mydirectory/TestComponent.test.js")).to.be.true;
+      destroy("component", "TestComponent");
+      expect(fileExists("src/components/mydirectory/TestComponent.js")).to.be.false;
+      expect(fileExists("test/components/mydirectory/TestComponent.test.js")).to.be.false;
+    });
   });
 });

--- a/test/commands/destroy.test.js
+++ b/test/commands/destroy.test.js
@@ -123,6 +123,7 @@ describe("cli: gluestick destroy", function () {
 
   describe("when sub-directories are provided", function() {
     beforeEach(() => {
+      createDirectories(tmpDir, path.join("components", "mydirectory"));
       const componentPath = path.join(tmpDir, "src/components/mydirectory/TestComponent.js");
       const componentTestPath = path.join(tmpDir, "test/components/mydirectory/TestComponent.test.js");
       createFiles(componentPath, componentTestPath);
@@ -131,7 +132,8 @@ describe("cli: gluestick destroy", function () {
     it("removes the files under the directory", () => {
       expect(fileExists("src/components/mydirectory/TestComponent.js")).to.be.true;
       expect(fileExists("test/components/mydirectory/TestComponent.test.js")).to.be.true;
-      destroy("component", "TestComponent");
+      destroy("component", "mydirectory/TestComponent");
+      expect(logger.error.called).to.be.false;
       expect(fileExists("src/components/mydirectory/TestComponent.js")).to.be.false;
       expect(fileExists("test/components/mydirectory/TestComponent.test.js")).to.be.false;
     });


### PR DESCRIPTION
Resolves #165 
- Parse the dirname and basename from the provided path and use that during file generation
- Add tests for the new functionality
- Organize all tests by grouping them by context
