### PR TITLE
Fix import path of generated tests

### DIFF
--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -10,8 +10,12 @@ const availableCommands = {
   "reducer": "reducers"
 };
 
-function replaceName (input, name) {
-  return input.replace(/__\$NAME__/g, name);
+function replaceName (input, name, localpath=null) {
+  const replacedName = input.replace(/__\$NAME__/g, name);
+  if (!localpath) {
+    return replacedName;
+  }
+  return replacedName.replace(/__\$PATH__/g, localpath);
 }
 
 module.exports = function (command, name, cb) {
@@ -60,7 +64,8 @@ module.exports = function (command, name, cb) {
   template = replaceName(template, generatedFileName);
 
   // Check if the file already exists before we write to it
-  const generateRoot = path.join(CWD, "src", availableCommands[command]);
+  const srcRoot = path.join(CWD, "src");
+  const generateRoot = path.join(srcRoot, availableCommands[command]);
   const destinationRoot = path.resolve(generateRoot, dirname);
   const destinationPath = path.join(destinationRoot, generatedFileName + ".js");
 
@@ -132,7 +137,8 @@ module.exports = function (command, name, cb) {
   }
 
   try {
-    fs.writeFileSync(testPath, replaceName(testTemplate, generatedFileName));
+    const generatedComponentPath = destinationPath.replace(srcRoot, "").replace(".js", "").slice(1);
+    fs.writeFileSync(testPath, replaceName(testTemplate, generatedFileName, generatedComponentPath));
   }
   catch (e) {
     return cb("Couldn't create test file");

--- a/templates/generate/component.test.js
+++ b/templates/generate/component.test.js
@@ -1,10 +1,10 @@
 /*global React*/
 /*global describe it*/
 /*global expect*/
-import __$NAME__ from "components/__$NAME__";
+import __$NAME__ from "__$PATH__";
 import { shallow } from "enzyme";
 
-describe("components/__$NAME__", () => {
+describe("__$PATH__", () => {
   it("renders without an issue", () => {
     const subject = <__$NAME__ />;
     const wrapper = shallow(subject);

--- a/templates/generate/container.test.js
+++ b/templates/generate/container.test.js
@@ -1,10 +1,10 @@
 /*global React*/
 /*global describe it*/
 /*global expect*/
-import { __$NAME__ } from "containers/__$NAME__";
+import { __$NAME__ } from "__$PATH__";
 import { shallow } from "enzyme";
 
-describe("containers/__$NAME__", () => {
+describe("__$PATH__", () => {
   it("renders without an issue", () => {
     const subject = <__$NAME__ />;
     const wrapper = shallow(subject);

--- a/templates/generate/reducer.test.js
+++ b/templates/generate/reducer.test.js
@@ -1,8 +1,8 @@
 /*global describe it*/
 /*global expect*/
-import reducer from "reducers/__$NAME__";
+import reducer from "__$PATH__";
 
-describe("reducers/__$NAME__", () => {
+describe("__$PATH__", () => {
   it("returns the initial state", () => {
     const state = void 0;
     expect(

--- a/test/commands/generate.test.js
+++ b/test/commands/generate.test.js
@@ -147,6 +147,19 @@ describe("cli: gluestick generate", function () {
     });
   });
 
+  describe("when reducers are generated", function () {
+    it("references the correct import path within reducer tests", done => {
+      const type = "reducer";
+      const testFilePath = path.join(tmpDir, "test", "reducers", "myreducer.test.js");
+      stubProject(type);
+      generate(type, "myreducer", (err) => {
+        expect(err).to.be.undefined;
+        assertImportPath(testFilePath, `${type}s/myreducer`);
+        done();
+      });
+    });
+  });
+
   describe("when directories are provided", function () {
     it("creates the generated component inside a specified directory", done => {
       const type = "component";
@@ -185,7 +198,7 @@ describe("cli: gluestick generate", function () {
       });
     });
 
-    it("references the correct directory path within tests", done => {
+    it("references the correct import path within component tests", done => {
       const type = "component";
       const testFilePath = path.join(tmpDir, "test", "components", "common", "Mycomponent.test.js");
       stubProject(type);
@@ -196,7 +209,7 @@ describe("cli: gluestick generate", function () {
       });
     });
 
-    it("references the correct (resolved) directory path within tests", done => {
+    it("references the correct (resolved) import path within container tests", done => {
       const type = "container";
       const testFilePath = path.join(tmpDir, "test", "containers", "common", "Mycontainer.test.js");
       stubProject(type);


### PR DESCRIPTION
Generated tests for containers and components were being generated with
the wrong import path to the container or component. Make sure the
correct relative path is being included in tests.
