### PR TITLE
Better support for api proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.8.5",
     "fs-extra": "0.30.0",
-    "gluestick-shared": "0.3.8",
+    "gluestick-shared": "0.3.9",
     "history": "2.1.1",
     "http-proxy-middleware": "0.15.0",
     "inquirer": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.8.5",
     "fs-extra": "0.30.0",
-    "gluestick-shared": "0.3.9",
+    "gluestick-shared": "0.3.10",
     "history": "2.1.1",
     "http-proxy-middleware": "0.15.0",
     "inquirer": "1.0.2",

--- a/src/commands/start-client.js
+++ b/src/commands/start-client.js
@@ -114,7 +114,7 @@ module.exports = function (buildOnly) {
 
     // Proxy http requests from server to client in development mode
     app.use(proxy({
-      changeOrigin: true,
+      changeOrigin: false,
       target: "http://localhost:8880",
       onError: (err, req, res) => {
         // When the client is restarting, show our polling message

--- a/templates/new/package.json
+++ b/templates/new/package.json
@@ -17,7 +17,7 @@
     "babel-preset-react": "6.5.0",
     "css-loader": "0.23.1",
     "file-loader": "0.8.5",
-    "gluestick-shared": "0.3.9",
+    "gluestick-shared": "0.3.10",
     "history": "2.1.1",
     "json-loader": "0.5.4",
     "node-sass": "3.7.0",

--- a/templates/new/package.json
+++ b/templates/new/package.json
@@ -17,7 +17,7 @@
     "babel-preset-react": "6.5.0",
     "css-loader": "0.23.1",
     "file-loader": "0.8.5",
-    "gluestick-shared": "0.3.8",
+    "gluestick-shared": "0.3.9",
     "history": "2.1.1",
     "json-loader": "0.5.4",
     "node-sass": "3.7.0",


### PR DESCRIPTION
In the previous version of `gluestick-shared` when you made a request to
"/api" without a base URL, node had no idea what the actual URL to
request was. 0.3.9 resolves this by setting baseURL on http clients that
are set up with a request object.

We were also setting `changeOrigin:true` on the dev mode proxy. This was
making it so that the HTTP_HOST that the server would get would be
localhost:8880 instead of the url that you are hitting with. Now the
proper HTTP_HOST will be sent through
