### PR TITLE
add support for vendor bundle

### DIFF
--- a/src/commands/start-client.js
+++ b/src/commands/start-client.js
@@ -7,7 +7,7 @@ const WebpackIsomorphicToolsPlugin = require("webpack-isomorphic-tools/plugin");
 const webpackSharedConfig = require("../config/webpack-shared-config");
 const detectEnvironmentVariables = require("../lib/detectEnvironmentVariables");
 const getWebpackAdditions = require("../lib/getWebpackAdditions").default;
-const { additionalLoaders, additionalPreLoaders } = getWebpackAdditions();
+const { additionalLoaders, additionalPreLoaders, vendor } = getWebpackAdditions();
 const logger = require("../lib/logger");
 const logsColorScheme = require("../lib/logsColorScheme");
 
@@ -18,7 +18,7 @@ if (assetPath.substr(-1) !== "/") {
 
 const PORT = 8888;
 const OUTPUT_PATH = path.join(process.cwd(), "build");
-const OUTPUT_FILE = "main-bundle.js";
+const OUTPUT_FILE = "main.bundle.js";
 const PUBLIC_PATH = assetPath;
 
 const webpackIsomorphicToolsPlugin = new WebpackIsomorphicToolsPlugin(require("../config/webpack-isomorphic-tools-config"))
@@ -73,7 +73,8 @@ const compiler = webpack({
   context: process.cwd(),
   devtool: isProduction ? null : "cheap-module-eval-source-map",
   entry: {
-    "main": entry
+    main: entry,
+    vendor: vendor
   },
   module: {
     loaders: [
@@ -96,7 +97,9 @@ const compiler = webpack({
       "__PATH_TO_ENTRY__": JSON.stringify(path.join(process.cwd(), "src/config/.entry")),
       "process.env": exposedEnvironmentVariables
     }),
-    new webpack.IgnorePlugin(/\.server(\.js)?$/)
+    new webpack.IgnorePlugin(/\.server(\.js)?$/),
+    new webpack.optimize.CommonsChunkPlugin("vendor", "vendor.bundle.js"),
+    new webpack.optimize.AggressiveMergingPlugin()
   ].concat(environmentPlugins, webpackSharedConfig.plugins),
   resolve: {
     ...webpackSharedConfig.resolve

--- a/src/lib/getWebpackAdditions.js
+++ b/src/lib/getWebpackAdditions.js
@@ -41,7 +41,8 @@ function prepareUserAdditionsForWebpack (additions) {
 export default function (isomorphic=false) {
   let userAdditions = {
     additionalLoaders: [],
-    additionalPreLoaders: []
+    additionalPreLoaders: [],
+    vendor: []
   };
 
   // Babel will try to resolve require statements ahead of time which will cause an error
@@ -50,10 +51,11 @@ export default function (isomorphic=false) {
   try {
     const webpackAdditionsPath = path.join(process.cwd(), "src", "config", "webpack-additions.js");
     fs.statSync(webpackAdditionsPath);
-    const { additionalLoaders, additionalPreLoaders } = require(webpackAdditionsPath);
+    const { additionalLoaders, additionalPreLoaders, vendor } = require(webpackAdditionsPath);
     userAdditions = {
       additionalLoaders: isomorphic ? additionalLoaders : prepareUserAdditionsForWebpack(additionalLoaders),
-      additionalPreLoaders: isomorphic ? additionalPreLoaders : prepareUserAdditionsForWebpack(additionalPreLoaders)
+      additionalPreLoaders: isomorphic ? additionalPreLoaders : prepareUserAdditionsForWebpack(additionalPreLoaders),
+      vendor: vendor || []
     };
   }
   catch (e) {
@@ -62,3 +64,4 @@ export default function (isomorphic=false) {
 
   return userAdditions;
 }
+

--- a/src/lib/server/Body.js
+++ b/src/lib/server/Body.js
@@ -18,7 +18,8 @@ export default class Body extends Component {
       <div>
         <div id="main" dangerouslySetInnerHTML={{__html: this.props.html}} />
         <script type="text/javascript" dangerouslySetInnerHTML={{__html: `window.__INITIAL_STATE__=${serialize(initialState)};`}}></script>
-        <script type="text/javascript" src={`${config.assetPath}/main-bundle.js`}></script>
+        <script type="text/javascript" src={`${config.assetPath}/vendor.bundle.js`}></script>
+        <script type="text/javascript" src={`${config.assetPath}/main.bundle.js`}></script>
       </div>
     );
   }


### PR DESCRIPTION
This allows us to specify which node_modules we want to be included in a vendor bundle by adding an array of module names in the webpack-additions file. `vendor: ["react", "react-router"]`

http://webpack.github.io/docs/code-splitting.html#split-app-and-vendor-code
