### PR TITLE
Bundle Size Optimization Updates

### DIFF
--- a/src/commands/start-client.js
+++ b/src/commands/start-client.js
@@ -1,3 +1,4 @@
+const fs = require("fs");
 const path = require("path");
 const webpack = require("webpack");
 const process = require("process");
@@ -7,7 +8,7 @@ const WebpackIsomorphicToolsPlugin = require("webpack-isomorphic-tools/plugin");
 const webpackSharedConfig = require("../config/webpack-shared-config");
 const detectEnvironmentVariables = require("../lib/detectEnvironmentVariables");
 const getWebpackAdditions = require("../lib/getWebpackAdditions").default;
-const { additionalLoaders, additionalPreLoaders, vendor } = getWebpackAdditions();
+const { additionalLoaders, additionalPreLoaders, vendor, plugins } = getWebpackAdditions();
 const logger = require("../lib/logger");
 const logsColorScheme = require("../lib/logsColorScheme");
 
@@ -100,7 +101,7 @@ const compiler = webpack({
     new webpack.IgnorePlugin(/\.server(\.js)?$/),
     new webpack.optimize.CommonsChunkPlugin("vendor", "vendor.bundle.js"),
     new webpack.optimize.AggressiveMergingPlugin()
-  ].concat(environmentPlugins, webpackSharedConfig.plugins),
+  ].concat(environmentPlugins, webpackSharedConfig.plugins, plugins),
   resolve: {
     ...webpackSharedConfig.resolve
   }
@@ -137,6 +138,7 @@ module.exports = function (buildOnly) {
   else {
     logger.info("Bundling assets…");
     compiler.run((error, stats) => {
+      fs.writeFileSync("webpack-bundle-stats.json", JSON.stringify(stats.toJson()));
       const errors = stats.toJson().errors;
       if (errors.length) {
         errors.forEach((e) => {

--- a/src/lib/getWebpackAdditions.js
+++ b/src/lib/getWebpackAdditions.js
@@ -42,7 +42,8 @@ export default function (isomorphic=false) {
   let userAdditions = {
     additionalLoaders: [],
     additionalPreLoaders: [],
-    vendor: []
+    vendor: [],
+    plugins: []
   };
 
   // Babel will try to resolve require statements ahead of time which will cause an error
@@ -51,11 +52,12 @@ export default function (isomorphic=false) {
   try {
     const webpackAdditionsPath = path.join(process.cwd(), "src", "config", "webpack-additions.js");
     fs.statSync(webpackAdditionsPath);
-    const { additionalLoaders, additionalPreLoaders, vendor } = require(webpackAdditionsPath);
+    const { additionalLoaders, additionalPreLoaders, vendor, plugins } = require(webpackAdditionsPath);
     userAdditions = {
       additionalLoaders: isomorphic ? additionalLoaders : prepareUserAdditionsForWebpack(additionalLoaders),
       additionalPreLoaders: isomorphic ? additionalPreLoaders : prepareUserAdditionsForWebpack(additionalPreLoaders),
-      vendor: vendor || []
+      vendor: vendor || [],
+      plugins: plugins || []
     };
   }
   catch (e) {

--- a/templates/new/_gitignore
+++ b/templates/new/_gitignore
@@ -1,5 +1,6 @@
 # Output from webpack asset bunlding
 webpack-assets.json
+webpack-bundle-stats.json
 
 # Logs
 logs

--- a/templates/new/src/config/.entry.js
+++ b/templates/new/src/config/.entry.js
@@ -7,7 +7,8 @@ import { render } from "react-dom";
 import "../../Index.js";
 
 import { Root, getHttpClient } from "gluestick-shared";
-import { match, browserHistory as history } from "react-router";
+import match from "react-router/lib/match";
+import browserHistory from "react-router/lib/browserHistory";
 import routes from "./routes";
 import store from "./.store";
 import { StyleRoot } from "radium";
@@ -44,7 +45,7 @@ export default class Entry extends Component {
 
 Entry.start = function () {
   const newStore = store(httpClient);
-  match({ history, routes: getRoutes(newStore) }, (error, redirectLocation, renderProps) => {
+  match({ history: browserHistory, routes: getRoutes(newStore) }, (error, redirectLocation, renderProps) => {
     render(<Entry radiumConfig={{userAgent: window.navigator.userAgent}} store={newStore} {...renderProps} />, document.getElementById("main"));
   });
 };


### PR DESCRIPTION
1. Add support for webpack plugins. This allows us to use things like webpack's `IgnorePlugin` plugin and/or the `ContextReplacementPlugin`. (http://stackoverflow.com/questions/25384360/how-to-prevent-moment-js-from-loading-locales-with-webpack)
2. To better understand the bundle size, the webpack stats are now output to webpack-bundle-stats.json This file can be piped to `webpack-bundle-size-analyzer` like `cat webpack-bundle-stats.json | webpack-bundle-size-analyzer` for more detailed results.
3. Made `react-router` imports more specific as to not include parts of the library we are not using.
