### PR TITLE
Improve production mode

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,5 +66,4 @@ RUN apt-get update && \
 
 EXPOSE 8888
 
-RUN gluestick build
 CMD ["gluestick", "start", "-P"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,4 +66,5 @@ RUN apt-get update && \
 
 EXPOSE 8888
 
-CMD ["gluestick", "start", "-T"]
+RUN gluestick build
+CMD ["gluestick", "start", "-P"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gluestick",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "GlueStick is a command line interface for quickly developing universal web applications using React",
   "main": "src/cli-harmony.js",
   "bin": "src/cli-harmony.js",

--- a/src/cli.js
+++ b/src/cli.js
@@ -36,6 +36,7 @@ const karmaTestOption = ["-k, --karma", "run tests in Karma"];
 const mochaReporterOption = ["-r, --reporter [type]", "run tests in Node.js"];
 const firefoxOption = ["-F, --firefox", "Use Firefox with test runner"];
 const singleRunOption = ["-S, --single", "Run test suite only once"];
+const skipBuildOption = ["-P, --skip-build", "skip build when running in production mode"];
 
 commander
   .version(currentGluestickVersion);
@@ -82,6 +83,7 @@ commander
   .option(...debugTestOption)
   .option(...mochaReporterOption)
   .option(...karmaTestOption)
+  .option(...skipBuildOption)
   .action(checkGluestickProject)
   .action(() => notifyUpdates())
   .action(startAll)
@@ -210,7 +212,14 @@ async function startAll(options) {
     process.exit();
   }
 
-  spawnProcess("client");
+  // in production spawning the client really just creates a build. Our docker
+  // images pre-build and therefor they start with the skip build option as
+  // true.  We only want to start the client in development mode or if
+  // skipBuild is not specified
+  if (!(isProduction && options.skipBuild)) {
+    spawnProcess("client");
+  }
+
   spawnProcess("server", (options.debugServer ? ["--debug-server"] : []));
 
   // Start tests unless they asked us not to or we are in production mode

--- a/src/config/webpack-isomorphic-tools-config.js
+++ b/src/config/webpack-isomorphic-tools-config.js
@@ -42,9 +42,7 @@ module.exports = {
     styles: {
       extensions: ["css", "scss", "sass"],
       filter: function(module, regex, options, log) {
-        if (options.development) {
-          return WebpackIsomorphicToolsPlugin.style_loader_filter(module, regex, options, log);
-        }
+        return WebpackIsomorphicToolsPlugin.style_loader_filter(module, regex, options, log);
       },
       path: WebpackIsomorphicToolsPlugin.style_loader_path_extractor,
       parser: WebpackIsomorphicToolsPlugin.css_loader_parser

--- a/templates/new/src/config/.Dockerfile
+++ b/templates/new/src/config/.Dockerfile
@@ -7,3 +7,4 @@ FROM truecar/gluestick:0.7.0
 ADD . /app
 
 RUN npm install
+RUN gluestick build


### PR DESCRIPTION
1. Perform a clean up before pm2 starts that will make sure there were
   no phantom processes running before kicking off new phones. (This one
   helps both production and development)
2. Run the gluestick build as part of creating a docker image. This way the
   server will be ready as soon as it starts. Added "skip build" option to
   arguments so that the docker image will stop kicking off a build when it
   starts. Kicking off a build is still useful when running locally and you
   haven't run `gluestick build` before running with NODE_ENV as
   production.
