### PR TITLE
Alias `s` to `start` command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -77,6 +77,7 @@ commander
 
 commander
   .command("start")
+  .alias("s")
   .description("start everything")
   .option("-T, --skip-tests", "ignore test hook")
   .option(...debugServerOption)


### PR DESCRIPTION
Because typing is hard.
