### PR TITLE
Add Gluestick prefix to logging statements

### DIFF
--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,16 +1,18 @@
 /*eslint-disable no-console*/
-const logsColorScheme = require("./logsColorScheme");
+import logsColorScheme from "./logsColorScheme";
+
+const PREFIX = "[Gluestick]";
 
 function success(...args){
-  console.log(...args.map(arg => logsColorScheme.success(arg)));
+  console.log(PREFIX, ...args.map(arg => logsColorScheme.success(arg)));
 }
 
 function info(...args){
-  console.log(...args.map(arg => logsColorScheme.info(arg)));
+  console.log(PREFIX, ...args.map(arg => logsColorScheme.info(arg)));
 }
 
 function warn(...args) {
-  console.log(...args.map(arg => logsColorScheme.warn(arg)));
+  console.log(PREFIX, ...args.map(arg => logsColorScheme.warn(arg)));
 }
 
 function error(...args){

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,7 +1,7 @@
 /*eslint-disable no-console*/
 import logsColorScheme from "./logsColorScheme";
 
-const PREFIX = "[Gluestick]";
+const PREFIX = "[GlueStick]";
 
 function success(...args){
   console.log(PREFIX, ...args.map(arg => logsColorScheme.success(arg)));


### PR DESCRIPTION
So that users know where the logging statements are originating from:

<img width="383" alt="logger" src="https://cloud.githubusercontent.com/assets/59530/15986196/cb07c4a4-2fcf-11e6-8867-4ff89f9f8764.png">
