### PR TITLE
Add lint check to build step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_deploy:
 - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 
 script:
+- npm run lint
 - npm run test-coverage #run full tests and coverage
 
 deploy:

--- a/src/lib/server/index.js
+++ b/src/lib/server/index.js
@@ -1,6 +1,5 @@
 import express from "express";
 import logger from "../logger";
-import { filename } from "../logsColorScheme";
 import requestHandler from "./requestHandler";
 import addProxies from "./addProxies";
 import path from "path";
@@ -10,9 +9,7 @@ const config = require(path.join(process.cwd(), "src", "config", "application"))
 
 const isProduction = process.env.NODE_ENV === "production";
 // @TODO: allow host and port to be set elsewhere (https://github.com/TrueCar/gluestick/issues/129)
-const host = "localhost";
 const port = process.env.PORT || (isProduction? 8888 : 8880);
-const address = `http://${host}:${port}`;
 
 const app = express();
 
@@ -21,7 +18,7 @@ addProxies(app, config.proxies);
 
 if (isProduction) {
   app.use("/assets", express.static("build"));
-  logger.success(`Server side rendering server running`);
+  logger.success("Server side rendering server running");
 }
 else {
   app.get("/gluestick-proxy-poll", function(req, res) {
@@ -30,7 +27,7 @@ else {
     res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
     res.status(200).json({up: true});
   });
-  logger.success(`Server side rendering proxy running`);
+  logger.success("Server side rendering proxy running");
 }
 
 app.use(requestHandler);


### PR DESCRIPTION
1. Add `npm run lint` to the list of Travis build tasks and verify that the check is performed: https://travis-ci.org/TrueCar/gluestick/builds/136942359
2. Fix lint issues to get the build to pass

Currently, tests will still be run by Travis even if the lint check fails. This is the default behavior set by Travis, with the reason being that we may still want to know whether or not tests passed: https://docs.travis-ci.com/user/customizing-the-build/#Customizing-the-Build-Step. We can change this behavior if we decide to later.
