### PR TITLE
Proxy error logging changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "oy-vey": "0.6.1",
     "pino": "2.7.1",
     "pm2": "1.1.3",
-    "pretty-error": "2.0.0",
     "radium": "0.17.1",
     "react": "15.1.0",
     "react-addons-test-utils": "15.1.0",

--- a/src/lib/server/addProxies.js
+++ b/src/lib/server/addProxies.js
@@ -2,6 +2,10 @@ import httpProxyMiddleware from "http-proxy-middleware";
 import { getLogger } from "./logger";
 const logger = getLogger();
 
+const onError = ("error", (err, req, res) => {
+  res.log.error(err, "Proxy error:");
+});
+
 /**
  * The array of proxy objects follow the following pattern
  * @typedef ProxyConfig
@@ -25,7 +29,7 @@ const logger = getLogger();
 export default function addProxies (app, proxyConfigs=[], proxy=httpProxyMiddleware) {
   proxyConfigs.forEach((proxyConfig) => {
     const { path, destination, options } = proxyConfig;
-    app.use(path, proxy({
+    const proxyObj = proxy({
       logLevel: logger.level,
       logProvider: () => {
         return logger;
@@ -34,8 +38,10 @@ export default function addProxies (app, proxyConfigs=[], proxy=httpProxyMiddlew
       pathRewrite: {
         [`^${path}`]: ""
       },
+      onError: onError,
       ...options
-    }));
+    });
+    app.use(path, proxyObj);
   });
 }
 

--- a/src/lib/server/errorHandler.js
+++ b/src/lib/server/errorHandler.js
@@ -1,16 +1,6 @@
 import fs from "fs";
 import path from "path";
-import PrettyError from "pretty-error";
 import * as secureHandlebars from "secure-handlebars";
-import logger from "../cliLogger";
-
-const pretty = new PrettyError();
-if (["1", "true"].includes(process.env.PRETTY_PRINT_WITHOUT_COLORS)) {
-  pretty.withoutColors();
-}
-else {
-  pretty.withColors();
-}
 
 /**
  * Register handlebars helper that allows condition blocks for non production
@@ -36,14 +26,14 @@ secureHandlebars.registerHelper("notForProduction", function (options) {
 export default function serverErrorHandler(req, res, error) {
   res.status(500);
   const custom505FilePath = path.join(process.cwd(), "505.hbs");
-  logger.error(pretty.render(error));
+  res.log.error(error);
 
   // Check if we have a custom 505 error page
   fs.stat(custom505FilePath, (statError, stats) => {
 
     // If we don't have a custom 505 error page then just throw the stack trace
     if(statError || !stats.isFile()) {
-      logger.info(`No custom 505 page found. You can create a custom 505 page at ${path.join(process.cwd(), "505.hbs")}`);
+      res.log.info(`No custom 505 page found. You can create a custom 505 page at ${path.join(process.cwd(), "505.hbs")}`);
       return res.send({error: error});
     }
 

--- a/src/lib/server/index.js
+++ b/src/lib/server/index.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { getLogger, getRequestLogger } from "./logger";
+import { getLogger, getLoggerMiddleware } from "./logger";
 const logger = getLogger();
 import requestHandler from "./requestHandler";
 import addProxies from "./addProxies";
@@ -13,6 +13,7 @@ const isProduction = process.env.NODE_ENV === "production";
 const port = process.env.PORT || (isProduction? 8888 : 8880);
 
 const app = express();
+app.use(getLoggerMiddleware());
 
 // Hook up all of the API proxies
 addProxies(app, config.proxies);
@@ -31,7 +32,6 @@ else {
   logger.info("Server side rendering proxy running");
 }
 
-app.use(getRequestLogger());
 app.use(requestHandler);
 app.listen(port);
 

--- a/src/lib/server/logger.js
+++ b/src/lib/server/logger.js
@@ -56,6 +56,6 @@ export function getLogger(middleware=false) {
   return middleware ? expressPinoLogger(logConfig, prettyConfig) : pino(logConfig, prettyConfig);
 }
 
-export function getRequestLogger() {
+export function getLoggerMiddleware() {
   return getLogger(true);
 }


### PR DESCRIPTION
- Move request logging middleware up middleware chain so that proxy errors can be caught and logged
- Remove pretty-error now that we are using pino for logging
