### PR TITLE
Changes test coverage reporting to lcov.

### DIFF
--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -77,9 +77,9 @@ function useMocha(options) {
         "--root",
         "src",
         "--report",
-        "html",
+        "lcov",
         "--dir",
-        "coverage/html",
+        "coverage/lcov",
         MOCHA_COVERAGE_PATH,
         ...createMochaArgs(options, true)
       ],


### PR DESCRIPTION
It looks like the lcov report type outputs html as well as lcov.info, which can be used by CI code coverage integration tools such as coveralls.io and codeclimate. It is slightly deeper nested, and with a different name, so if we have anything referencing that directly, that could be an issue.

The other thing to note is that this only changes the output type for `coverage`. We also have a definition for `single`, which uses cobertura. Since I'm not sure if there's a reason they're different, I didn't touch that one. However, for CI purposes, that is probably the more useful place to be generating lcov data since the coverage folder is gitignore'd and (I assume) would have to be regenerated on the build server.
### Html coverage output

![html-coverage-output](https://cloud.githubusercontent.com/assets/693730/16534336/d86a30c2-3f93-11e6-9524-ab599e711d51.png)
### Lcov coverage output

![lcov-coverage-output](https://cloud.githubusercontent.com/assets/693730/16534338/dc843c7a-3f93-11e6-93f3-e9c1d6123614.png)
