### PR TITLE
Add support for `require.context`

### DIFF
--- a/src/config/webpack-isomorphic-tools-config.js
+++ b/src/config/webpack-isomorphic-tools-config.js
@@ -67,5 +67,6 @@ module.exports = {
     "containers": path.join(process.cwd(), "src", "containers"),
     "reducers": path.join(process.cwd(), "src", "reducers"),
     ...additionalAliases
-  }
+  },
+  patch_require: true
 };


### PR DESCRIPTION
Webpack isomorphic tools has enabled the ability to use `require.context` but you have to flip on the `patch_require` flag in configuration to enable it.

https://github.com/halt-hammerzeit/webpack-isomorphic-tools#configuration

somewhat related discussion about require.context and webpack-isomorphic-tools: https://github.com/halt-hammerzeit/webpack-isomorphic-tools/issues/48
