### PR TITLE
Use state to set response status codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.8.5",
     "fs-extra": "0.30.0",
-    "gluestick-shared": "0.4.3",
+    "gluestick-shared": "0.4.4",
     "history": "3.0.0",
     "http-proxy-middleware": "0.16.0",
     "inquirer": "1.0.3",

--- a/src/lib/server/requestHandler.js
+++ b/src/lib/server/requestHandler.js
@@ -5,8 +5,9 @@ import { renderToString, renderToStaticMarkup } from "react-dom/server";
 
 import {
   runBeforeRoutes,
-  ROUTE_NAME_404_NOT_FOUND,
-  prepareRoutesWithTransitionHooks } from "gluestick-shared";
+  prepareRoutesWithTransitionHooks,
+  ROUTE_NAME_404_NOT_FOUND
+} from "gluestick-shared";
 
 import { match, RouterContext } from "react-router";
 import errorHandler from "./errorHandler";
@@ -22,13 +23,6 @@ import { getLogger } from "./logger";
 const logger = getLogger();
 import showHelpText, { MISSING_404_TEXT } from "./helpText";
 
-
-function getEmailAttributes (routes) {
-  const lastRoute = routes[routes.length - 1];
-  const email = lastRoute.email || false;
-  const docType = lastRoute.docType || HTML5;
-  return { email, docType };
-}
 
 process.on("unhandledRejection", (reason) => {
   const message = reason.message || reason.statusText || reason;
@@ -78,15 +72,10 @@ module.exports = async function (req, res) {
 
           // grab the react generated body stuff. This includes the
           // script tag that hooks up the client side react code.
-          const body = createElement(Body, {html: reactRenderFunc(main), entryPoint: fileName, config: config, initialState: store.getState(), isEmail: isEmail});
+          const currentState = store.getState();
+          const body = createElement(Body, {html: reactRenderFunc(main), entryPoint: fileName, config: config, initialState: currentState, isEmail: isEmail});
           const head = isEmail ? null : getHead(config, fileName, webpackIsomorphicTools.assets()); // eslint-disable-line webpackIsomorphicTools
 
-          if (renderProps.routes[renderProps.routes.length - 1].name === ROUTE_NAME_404_NOT_FOUND) {
-            res.status(404);
-          }
-          else {
-            res.status(200);
-          }
 
           // Grab the html from the project which is stored in the root
           // folder named Index.js. Pass the body and the head to that
@@ -95,6 +84,22 @@ module.exports = async function (req, res) {
           //
           // Bundle it all up into a string, add the doctype and deliver
           const rootElement = createElement(Index, {body: body, head: head});
+
+          // Set status code
+          if (renderProps.routes[renderProps.routes.length - 1].name === ROUTE_NAME_404_NOT_FOUND) {
+            res.status(404);
+          }
+          else {
+            // Use the error's status code that was set on GlueStick's internal
+            // state object if one exists
+            const error = getError(currentState);
+            if (error !== null) {
+              res.status(error.status);
+            }
+            else {
+              res.status(200);
+            }
+          }
 
           if (isEmail) {
             const generateCustomTemplate = ({bodyContent}) => { return `${bodyContent}`; };
@@ -112,7 +117,14 @@ module.exports = async function (req, res) {
         }
       }
       catch (error) {
-        errorHandler(req, res, error);
+        // Render any error that was set on GlueStick's internal state object if one exists
+        const error = getError(store.getState());
+        if (error !== null) {
+          res.status(error.status).send(error.message || "An error occurred.");
+        }
+        else {
+          errorHandler(req, res, error);
+        }
       }
     });
   }
@@ -120,4 +132,18 @@ module.exports = async function (req, res) {
     errorHandler(req, res, error);
   }
 };
+
+function getEmailAttributes (routes) {
+  const lastRoute = routes[routes.length - 1];
+  const email = lastRoute.email || false;
+  const docType = lastRoute.docType || HTML5;
+  return { email, docType };
+}
+
+function getError (state) {
+  if (state._gluestick.hasOwnProperty("error")) {
+    return state._gluestick.error;
+  }
+  return null;
+}
 

--- a/templates/new/package.json
+++ b/templates/new/package.json
@@ -18,7 +18,7 @@
     "babel-runtime": "6.9.2",
     "css-loader": "0.23.1",
     "file-loader": "0.8.5",
-    "gluestick-shared": "0.4.3",
+    "gluestick-shared": "0.4.4",
     "history": "3.0.0",
     "json-loader": "0.5.4",
     "node-sass": "3.7.0",


### PR DESCRIPTION
Depends on merge of https://github.com/TrueCar/gluestick-shared/pull/22

If a GlueStick error handling action was dispatched, an error object will be available on the state that can be used to appropriately set the response status code.
