### PR TITLE
fix missing stack trace for some 500 errors

### DIFF
--- a/src/lib/server/requestHandler.js
+++ b/src/lib/server/requestHandler.js
@@ -118,9 +118,9 @@ module.exports = async function (req, res) {
       }
       catch (error) {
         // Render any error that was set on GlueStick's internal state object if one exists
-        const error = getError(store.getState());
-        if (error !== null) {
-          res.status(error.status).send(error.message || "An error occurred.");
+        const errorState = getError(store.getState());
+        if (errorState !== null) {
+          res.status(errorState.status).send(errorState.message || "An error occurred.");
         }
         else {
           errorHandler(req, res, error);


### PR DESCRIPTION
In v0.8.6, for some server-rendered 500 errors, I don't see a stack trace when I expect to see one. For example, this code in Home.js from a newly created gluestick project causes a 500 error:

```
/* @flow */
import React, { Component } from "react";

export default class Home extends Component {
  render () {

    asdf;

    return (
      <div>Home</div>
    );
  }
}
```

Before this fix, the browser shows an empty box when hitting the page directly or reloading:

<img width="1399" alt="screen shot 2016-07-11 at 12 16 49 pm" src="https://cloud.githubusercontent.com/assets/25131/16743549/d2215580-4761-11e6-8635-d33219147758.png">

After the fix, it shows the stack trace:

<img width="1401" alt="screen shot 2016-07-11 at 12 17 06 pm" src="https://cloud.githubusercontent.com/assets/25131/16743565/e635a30a-4761-11e6-8707-a259e0b5199b.png">
