### PR TITLE
Add support for filters on proxies

### DIFF
--- a/src/lib/server/addProxies.js
+++ b/src/lib/server/addProxies.js
@@ -28,8 +28,8 @@ const onError = ("error", (err, req, res) => {
  */
 export default function addProxies (app, proxyConfigs=[], proxy=httpProxyMiddleware) {
   proxyConfigs.forEach((proxyConfig) => {
-    const { path, destination, options } = proxyConfig;
-    const proxyObj = proxy({
+    const { filter, path, destination, options } = proxyConfig;
+    const actualConfig = {
       logLevel: logger.level,
       logProvider: () => {
         return logger;
@@ -40,7 +40,15 @@ export default function addProxies (app, proxyConfigs=[], proxy=httpProxyMiddlew
       },
       onError: onError,
       ...options
-    });
+    };
+
+    let proxyObj;
+    if (typeof(filter) === "function") {
+      proxyObj = proxy(filter, actualConfig);
+    }
+    else {
+      proxyObj = proxy(actualConfig);
+    }
     app.use(path, proxyObj);
   });
 }

--- a/test/lib/server/addProxies.js
+++ b/test/lib/server/addProxies.js
@@ -77,5 +77,31 @@ describe("lib/server/addProxies", function () {
     addProxies(mockApp, [proxyConfig], mockExpressHttpProxy);
     expect(mockExpressHttpProxy.lastCall.args[0].pathRewrite).to.equal(pathRewrite);
   });
+
+  it("should allow you to supply a filter function", () => {
+    const mockExpressHttpProxy = sinon.spy();
+    const proxyConfig = {
+      filter: (pathname) => {
+        return !!(pathname.match("/api") && !pathname.match("/api/foo"));
+      },
+      path: "/api",
+      destination: "http://www.test.com/api"
+    };
+    addProxies(mockApp, [proxyConfig], mockExpressHttpProxy);
+    expect(mockExpressHttpProxy.lastCall.args[0]).to.be.a("function");
+    expect(mockExpressHttpProxy.lastCall.args[0]).to.equal(proxyConfig.filter);
+  });
+
+  it("should not add the filter if it is not a function", () => {
+    const mockExpressHttpProxy = sinon.spy();
+    const proxyConfig = {
+      filter: "this is the wrong type for filter",
+      path: "/api",
+      destination: "http://www.test.com/api"
+    };
+    addProxies(mockApp, [proxyConfig], mockExpressHttpProxy);
+    expect(mockExpressHttpProxy.lastCall.args[0]).to.not.be.a("function");
+    expect(mockExpressHttpProxy.lastCall.args[0]).to.be.a("Object");
+  });
 });
 


### PR DESCRIPTION
Expose the `filter` option on proxies to GlueStick apps.
