### PR TITLE
Add caching support to Routes for server side rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,25 @@ images and font files will automatically be handled as well.
 
 _If you would like to see better css support, please submit a pull request :)_
 
+## Caching
+Caching support has been added for server side rendering. This lets you cache
+entire page responses on pages where it makes sense like a home or landing
+page.
+
+Example:
+```
+<Route path="/" component={HomeApp} cache={true} />
+```
+
+*Route property:*
+`cache` - boolean
+
+*Additional optional cache properties:*
+`cacheTTL` - number of seconds to store the cache for a particular route
+`cacheKey` - If you do not want to use the URL as the key, you can specify a
+key. For advanced setups, you could access the store and create a key based
+on data in the store.
+
 ## Hot Loading
 GlueStick's development environment utilizing hotloading so your changes will
 show up in the browser as you go. This is sort of experimental but it works

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "match-media": "0.2.0",
     "mkdirp": "0.5.1",
     "mocha": "2.5.3",
+    "node-cache": "3.2.1",
     "node-inspector": "0.12.8",
     "node-sass": "3.7.0",
     "oy-vey": "0.7.0",

--- a/src/lib/server/requestHandler.js
+++ b/src/lib/server/requestHandler.js
@@ -56,7 +56,7 @@ module.exports = async function (req, res) {
         else if (renderProps) {
           // Check if the route has cache preferences
           const currentRoute = renderProps.routes[renderProps.routes.length - 1];
-          const cacheKey = currentRoute.cacheKey || `${req.host}/${req.url}`;
+          const cacheKey = currentRoute.cacheKey || `${req.host}${req.url}`;
           if (currentRoute.cache) {
             logger.debug(`Cache is on for route ${cacheKey}`);
             const cachedResponse = cache.get(cacheKey);

--- a/src/lib/server/requestHandler.js
+++ b/src/lib/server/requestHandler.js
@@ -56,7 +56,7 @@ module.exports = async function (req, res) {
         else if (renderProps) {
           // Check if the route has cache preferences
           const currentRoute = renderProps.routes[renderProps.routes.length - 1];
-          const cacheKey = currentRoute.cacheKey || `${req.host}${req.url}`;
+          const cacheKey = currentRoute.cacheKey || `h:${req.host} u:${req.url}`;
           if (currentRoute.cache) {
             logger.debug(`Cache is on for route ${cacheKey}`);
             const cachedResponse = cache.get(cacheKey);


### PR DESCRIPTION
## Caching

Caching support has been added for server side rendering. This lets you cache
entire page responses on pages where it makes sense like a home or landing
page.

Example:

```
<Route path="/" component={HomeApp} cache={true} />
```

_Route property:_
`cache` - boolean

_Additional optional cache properties:_
`cacheTTL` - number of seconds to store the cache for a particular route
`cacheKey` - If you do not want to use the URL as the key, you can specify a
key. For advanced setups, you could access the store and create a key based
on data in the store.
