### PR TITLE
Refactor client-side webpack configuration

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -5,6 +5,7 @@ const fs = require("fs-extra");
 const path = require("path");
 const lazyMethodRequire = require("./lib/LazyMethodRequire").default(__dirname);
 
+const build = lazyMethodRequire("./commands/build");
 const newApp = lazyMethodRequire("./commands/new");
 const startClient = lazyMethodRequire("./commands/start-client");
 const startServer = lazyMethodRequire("./commands/start-server");
@@ -96,7 +97,7 @@ commander
   .command("build")
   .description("create production asset build")
   .action(checkGluestickProject)
-  .action(() => startClient(true))
+  .action(() => build())
   .action(() => updateLastVersionUsed(currentGluestickVersion));
 
 commander

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -9,9 +9,8 @@ const LOGGER = getLogger();
 module.exports = function() {
   const appRoot = process.cwd();
   const appConfigFilePath = path.join(appRoot, "src", "config", "application.js");
-  const appConfig = require(appConfigFilePath).default;
   const isProduction = process.env.NODE_ENV === "production";
-  const compiler = webpack(getWebpackConfig(appRoot, appConfig, appConfigFilePath, isProduction));
+  const compiler = webpack(getWebpackConfig(appRoot, appConfigFilePath, isProduction));
   LOGGER.info("Bundling assets…");
   compiler.run((error, stats) => {
     const statsJson = stats.toJson();

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -1,0 +1,29 @@
+import fs from "fs-extra";
+import path from "path";
+import webpack from "webpack";
+import getWebpackConfig from "../config/getWebpackClientConfig";
+
+import { getLogger } from "../lib/server/logger";
+const LOGGER = getLogger();
+
+module.exports = function() {
+  const appRoot = process.cwd();
+  const appConfigFilePath = path.join(appRoot, "src", "config", "application.js");
+  const appConfig = require(appConfigFilePath).default;
+  const isProduction = process.env.NODE_ENV === "production";
+  const compiler = webpack(getWebpackConfig(appRoot, appConfig, appConfigFilePath, isProduction));
+  LOGGER.info("Bundling assets…");
+  compiler.run((error, stats) => {
+    const statsJson = stats.toJson();
+    fs.writeFileSync("webpack-bundle-stats.json", JSON.stringify(statsJson));
+    const errors = statsJson.errors;
+    if (errors.length) {
+      errors.forEach((e) => {
+        LOGGER.error(e);
+      });
+      return;
+    }
+    LOGGER.info("Assets have been prepared for production.");
+    LOGGER.info("Assets can be served from the \"/assets\" route but it is recommended that you serve the generated \"build\" folder from a Content Delivery Network");
+  });
+};

--- a/src/commands/start-client.js
+++ b/src/commands/start-client.js
@@ -1,120 +1,33 @@
-const fs = require("fs");
 const path = require("path");
 const webpack = require("webpack");
 const process = require("process");
 const express = require("express");
 const proxy = require("http-proxy-middleware");
-const WebpackIsomorphicToolsPlugin = require("webpack-isomorphic-tools/plugin");
-const webpackSharedConfig = require("../config/webpack-shared-config");
-const detectEnvironmentVariables = require("../lib/detectEnvironmentVariables");
-const getWebpackAdditions = require("../lib/getWebpackAdditions").default;
-const buildWebpackEntries = require("../lib/buildWebpackEntries").default;
-const {
-  additionalLoaders,
-  additionalPreLoaders,
-  additionalExternals,
-  vendor,
-  plugins
-} = getWebpackAdditions();
-import { getLogger } from "../lib/server/logger";
-const logger = getLogger();
 
-let assetPath = require(path.join(process.cwd(), "src", "config", "application")).default.assetPath;
-if (assetPath.substr(-1) !== "/") {
-  assetPath = assetPath + "/";
+import getWebpackConfig from "../config/getWebpackClientConfig";
+
+import { getLogger } from "../lib/server/logger";
+const LOGGER = getLogger();
+
+const APP_ROOT = process.cwd();
+const APP_CONFIG_PATH = path.join(APP_ROOT, "src", "config", "application.js");
+const APP_CONFIG = require(APP_CONFIG_PATH).default;
+let ASSET_PATH = APP_CONFIG.assetPath;
+if (ASSET_PATH.substr(-1) !== "/") {
+  ASSET_PATH = ASSET_PATH + "/";
 }
 
+const IS_PRODUCTION = process.env.NODE_ENV === "production";
 const PORT = 8888;
-const OUTPUT_PATH = path.join(process.cwd(), "build");
-const OUTPUT_FILE = "app.bundle.js";
-const PUBLIC_PATH = assetPath;
 
-const webpackIsomorphicToolsPlugin = new WebpackIsomorphicToolsPlugin(require("../config/webpack-isomorphic-tools-config"))
-  .development(process.env.NODE_ENV !== "production");
+// @TODO Make this value a function rather than a global, or better yet, get it passed in
+const PUBLIC_PATH = ASSET_PATH;
 
 process.env.NODE_PATH = path.join(__dirname, "../..");
-const isProduction = process.env.NODE_ENV === "production";
 
-let environmentPlugins = [];
-
-if (isProduction) {
-  environmentPlugins = environmentPlugins.concat([
-    webpackIsomorphicToolsPlugin,
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        warnings: false
-      }
-    })
-  ]);
-}
-else {
-  environmentPlugins = environmentPlugins.concat([
-    webpackIsomorphicToolsPlugin,
-    new webpack.HotModuleReplacementPlugin(),
-  ]);
-}
-
-// The config/application.js file is consumed on both the server side and the
-// client side. However, we want developers to have access to environment
-// variables in there so they can override defaults with an environment
-// variable. For that reason we are going to perform static analysis on that
-// file to determine all of the environment variables that are used in that
-// file and make sure that webpack makes those available in the application.
-const configEnvVariables = detectEnvironmentVariables(path.join(process.cwd(), "src", "config", "application.js"));
-configEnvVariables.push("NODE_ENV");
-const exposedEnvironmentVariables = {};
-configEnvVariables.forEach((v) => {
-  exposedEnvironmentVariables[v] = JSON.stringify(process.env[v]);
-});
-
-const compiler = webpack({
-  context: process.cwd(),
-  devtool: isProduction ? null : "cheap-module-eval-source-map",
-  entry: {
-    ...buildWebpackEntries(isProduction),
-    vendor: vendor
-  },
-  module: {
-    loaders: [
-    ].concat(webpackSharedConfig.loaders, additionalLoaders),
-    preLoaders: [
-    // only place client specific preLoaders here
-    ].concat(webpackSharedConfig.preLoaders, additionalPreLoaders),
-  },
-  node: {
-    fs: "empty"
-  },
-  output: {
-    path: OUTPUT_PATH,
-    filename: `[name]-${OUTPUT_FILE}`,
-    chunkFilename: `[name]-chunk-${OUTPUT_FILE}`,
-    publicPath: PUBLIC_PATH
-  },
-  plugins: [
-    new webpack.optimize.DedupePlugin(),
-    new webpack.optimize.OccurenceOrderPlugin(),
-    new webpack.NoErrorsPlugin(),
-    new webpack.DefinePlugin({
-      "process.env": exposedEnvironmentVariables
-    }),
-
-    // Make it so *.server.js files return empty function in client
-    new webpack.NormalModuleReplacementPlugin(/\.server(\.js)?$/, () => {}),
-
-    new webpack.optimize.CommonsChunkPlugin("vendor", "vendor.bundle.js"),
-    new webpack.optimize.CommonsChunkPlugin("commons", "commons.bundle.js"),
-    new webpack.optimize.AggressiveMergingPlugin()
-  ].concat(environmentPlugins, webpackSharedConfig.plugins, plugins),
-  resolve: {
-    ...webpackSharedConfig.resolve
-  },
-  externals: {
-    ...additionalExternals
-  }
-});
-
-module.exports = function (buildOnly) {
-  if (!buildOnly && !isProduction) {
+module.exports = function () {
+  const compiler = webpack(getWebpackConfig(APP_ROOT, APP_CONFIG, APP_CONFIG_PATH, IS_PRODUCTION));
+  if (!IS_PRODUCTION) {
     const app = express();
     app.use(require("webpack-dev-middleware")(compiler, {
       noInfo: true,
@@ -126,9 +39,9 @@ module.exports = function (buildOnly) {
     app.use(proxy({
       changeOrigin: false,
       target: "http://localhost:8880",
-      logLevel: logger.level,
+      logLevel: LOGGER.level,
       logProvider: () => {
-        return logger;
+        return LOGGER;
       },
       onError: (err, req, res) => {
         // When the client is restarting, show our polling message
@@ -138,27 +51,11 @@ module.exports = function (buildOnly) {
 
     app.listen(PORT, "localhost", function (error) {
       if (error) {
-        logger.error(error);
+        LOGGER.error(error);
         return;
       }
 
-      logger.info(`Server running on http://localhost:${PORT}`);
-    });
-  }
-  else {
-    logger.info("Bundling assets…");
-    compiler.run((error, stats) => {
-      fs.writeFileSync("webpack-bundle-stats.json", JSON.stringify(stats.toJson()));
-      const errors = stats.toJson().errors;
-      if (errors.length) {
-        errors.forEach((e) => {
-          logger.error(e);
-        });
-        return;
-      }
-
-      logger.info("Assets have been prepared for production.");
-      logger.info("Assets can be served from the \"/assets\" route but it is recommended that you serve the generated \"build\" folder from a Content Delivery Network");
+      LOGGER.info(`Server running on http://localhost:${PORT}`);
     });
   }
 };

--- a/src/commands/start-client.js
+++ b/src/commands/start-client.js
@@ -56,9 +56,9 @@ else {
 
 // The config/application.js file is consumed on both the server side and the
 // client side. However, we want developers to have access to environment
-// constiables in there so they can override defaults with an environment
-// constiable. For that reason we are going to perform static analysis on that
-// file to determine all of the environment constiables that are used in that
+// variables in there so they can override defaults with an environment
+// variable. For that reason we are going to perform static analysis on that
+// file to determine all of the environment variables that are used in that
 // file and make sure that webpack makes those available in the application.
 const configEnvVariables = detectEnvironmentVariables(path.join(process.cwd(), "src", "config", "application.js"));
 configEnvVariables.push("NODE_ENV");

--- a/src/commands/start-client.js
+++ b/src/commands/start-client.js
@@ -26,7 +26,7 @@ const PUBLIC_PATH = ASSET_PATH;
 process.env.NODE_PATH = path.join(__dirname, "../..");
 
 module.exports = function () {
-  const compiler = webpack(getWebpackConfig(APP_ROOT, APP_CONFIG, APP_CONFIG_PATH, IS_PRODUCTION));
+  const compiler = webpack(getWebpackConfig(APP_ROOT, APP_CONFIG_PATH, IS_PRODUCTION));
   if (!IS_PRODUCTION) {
     const app = express();
     app.use(require("webpack-dev-middleware")(compiler, {

--- a/src/config/getWebpackClientConfig.js
+++ b/src/config/getWebpackClientConfig.js
@@ -1,0 +1,115 @@
+const path = require("path");
+const webpack = require("webpack");
+const WebpackIsomorphicToolsPlugin = require("webpack-isomorphic-tools/plugin");
+
+const buildWebpackEntries = require("../lib/buildWebpackEntries").default;
+const detectEnvironmentVariables = require("../lib/detectEnvironmentVariables");
+
+const getWebpackAdditions = require("../lib/getWebpackAdditions").default;
+const {
+  additionalLoaders,
+  additionalPreLoaders,
+  additionalExternals,
+  vendor,
+  plugins
+} = getWebpackAdditions();
+
+const webpackSharedConfig = require("./webpack-shared-config");
+
+
+const OUTPUT_FILE = "app.bundle.js";
+
+
+export function getExposedEnvironmentVariables(config) {
+  const exposedEnvironmentVariables = {};
+
+  // The config is consumed on both the server side and the client side.
+  // However, we want developers to have access to environment
+  // variables in there so they can override defaults with an environment
+  // variable. For that reason we are going to perform static analysis on that
+  // file to determine all of the environment variables that are used in that
+  // file and make sure that webpack makes those available in the application.
+  const configEnvVariables = detectEnvironmentVariables(config);
+  configEnvVariables.push("NODE_ENV");
+  configEnvVariables.forEach((v) => {
+    exposedEnvironmentVariables[v] = JSON.stringify(process.env[v]);
+  });
+
+  return exposedEnvironmentVariables;
+}
+
+export function getEnvironmentPlugins(isProduction) {
+  const webpackIsomorphicToolsPlugin = new WebpackIsomorphicToolsPlugin(require("../config/webpack-isomorphic-tools-config"))
+  .development(!isProduction);
+
+  let environmentPlugins = [];
+
+  if (isProduction) {
+    environmentPlugins = environmentPlugins.concat([
+      webpackIsomorphicToolsPlugin,
+      new webpack.optimize.UglifyJsPlugin({
+        compress: {
+          warnings: false
+        }
+      })
+    ]);
+  }
+  else {
+    environmentPlugins = environmentPlugins.concat([
+      webpackIsomorphicToolsPlugin,
+      new webpack.HotModuleReplacementPlugin(),
+    ]);
+  }
+
+  return environmentPlugins;
+}
+
+// @TODO: Fix config vs. configFilePath
+export default function (appRoot, config, configFilePath, isProduction) {
+  return {
+    context: appRoot,
+    devtool: isProduction ? null : "cheap-module-eval-source-map",
+    entry: {
+      ...buildWebpackEntries(isProduction),
+      vendor: vendor
+    },
+    module: {
+      loaders: [
+      ].concat(webpackSharedConfig.loaders, additionalLoaders),
+      preLoaders: [
+      // only place client specific preLoaders here
+      ].concat(webpackSharedConfig.preLoaders, additionalPreLoaders),
+    },
+    node: {
+      fs: "empty"
+    },
+    output: {
+      path: path.join(appRoot, "build"),
+      filename: `[name]-${OUTPUT_FILE}`,
+      chunkFilename: `[name]-chunk-${OUTPUT_FILE}`,
+      publicPath: config.assetPath,
+    },
+    plugins: [
+      new webpack.optimize.DedupePlugin(),
+      new webpack.optimize.OccurenceOrderPlugin(),
+      new webpack.NoErrorsPlugin(),
+      new webpack.DefinePlugin({
+        "process.env": getExposedEnvironmentVariables(configFilePath)
+      }),
+
+      // Make it so *.server.js files return empty function in client
+      new webpack.NormalModuleReplacementPlugin(/\.server(\.js)?$/, () => {}),
+
+      new webpack.optimize.CommonsChunkPlugin("vendor", "vendor.bundle.js"),
+      new webpack.optimize.CommonsChunkPlugin("commons", "commons.bundle.js"),
+      new webpack.optimize.AggressiveMergingPlugin()
+    ].concat(getEnvironmentPlugins(), webpackSharedConfig.plugins, plugins),
+    resolve: {
+      ...webpackSharedConfig.resolve
+    },
+    externals: {
+      ...additionalExternals
+    }
+  };
+
+}

--- a/src/config/getWebpackClientConfig.js
+++ b/src/config/getWebpackClientConfig.js
@@ -64,8 +64,8 @@ export function getEnvironmentPlugins(isProduction) {
   return environmentPlugins;
 }
 
-// @TODO: Fix config vs. configFilePath
-export default function (appRoot, config, configFilePath, isProduction) {
+export default function (appRoot, appConfigFilePath, isProduction) {
+  const config = require(appConfigFilePath).default;
   return {
     context: appRoot,
     devtool: isProduction ? null : "cheap-module-eval-source-map",
@@ -94,7 +94,7 @@ export default function (appRoot, config, configFilePath, isProduction) {
       new webpack.optimize.OccurenceOrderPlugin(),
       new webpack.NoErrorsPlugin(),
       new webpack.DefinePlugin({
-        "process.env": getExposedEnvironmentVariables(configFilePath)
+        "process.env": getExposedEnvironmentVariables(appConfigFilePath)
       }),
 
       // Make it so *.server.js files return empty function in client

--- a/test/lib/detectEnvironmentVariables.test.js
+++ b/test/lib/detectEnvironmentVariables.test.js
@@ -1,0 +1,37 @@
+import { expect } from "chai";
+import fs from "fs-extra";
+import path from "path";
+import temp from "temp";
+import detectEnvironmentVariables from "../../src/lib/detectEnvironmentVariables";
+
+describe("src/lib/detectEnvironmentVariables", () => {
+
+  let tmpDir, originalCwd, cwd;
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpDir = temp.mkdirSync("gluestick-new");
+    process.chdir(tmpDir);
+    cwd = process.cwd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.removeSync(tmpDir);
+  });
+
+  it("should detect all process.env variables in a file", () => {
+    const data = `export default {
+      option: {
+        pretty: true,
+        verbose: false
+      },
+      env: process.env.NODE_ENV,
+      foo: process.env.FOO,
+      bar: process.env.BAR,
+      baz: "test"
+    };`;
+    const filePath = path.join(cwd, "config.js");
+    fs.writeFileSync(filePath, data);
+    expect(detectEnvironmentVariables(filePath)).to.deep.equal(["NODE_ENV", "FOO", "BAR"]);
+  });
+});


### PR DESCRIPTION
Separate out webpack config from the `start-client` command. With this, we also don't need the `build` command to be part of `start-client`. Also added tests for `detectEnvironmentVariables`.
