### PR TITLE
Add hash to js and css files

### DIFF
--- a/src/commands/start-client.js
+++ b/src/commands/start-client.js
@@ -5,17 +5,14 @@ const express = require("express");
 const proxy = require("http-proxy-middleware");
 
 import getWebpackConfig from "../config/getWebpackClientConfig";
+import getAssetPath from "../lib/getAssetPath";
 
 import { getLogger } from "../lib/server/logger";
 const LOGGER = getLogger();
 
 const APP_ROOT = process.cwd();
 const APP_CONFIG_PATH = path.join(APP_ROOT, "src", "config", "application.js");
-const APP_CONFIG = require(APP_CONFIG_PATH).default;
-let ASSET_PATH = APP_CONFIG.assetPath;
-if (ASSET_PATH.substr(-1) !== "/") {
-  ASSET_PATH = ASSET_PATH + "/";
-}
+const ASSET_PATH = getAssetPath();
 
 const IS_PRODUCTION = process.env.NODE_ENV === "production";
 const PORT = 8888;

--- a/src/config/getWebpackClientConfig.js
+++ b/src/config/getWebpackClientConfig.js
@@ -1,6 +1,7 @@
 const path = require("path");
 const webpack = require("webpack");
 const WebpackIsomorphicToolsPlugin = require("webpack-isomorphic-tools/plugin");
+const getAssetPath = require("../lib/getAssetPath").default;
 
 const buildWebpackEntries = require("../lib/buildWebpackEntries").default;
 const detectEnvironmentVariables = require("../lib/detectEnvironmentVariables");
@@ -16,8 +17,8 @@ const {
 
 const webpackSharedConfig = require("./webpack-shared-config");
 
-
-const OUTPUT_FILE = "app.bundle.js";
+const ASSET_PATH = getAssetPath();
+const OUTPUT_FILE = "app-[chunkhash].bundle.js";
 
 
 export function getExposedEnvironmentVariables(config) {
@@ -65,7 +66,6 @@ export function getEnvironmentPlugins(isProduction) {
 }
 
 export default function (appRoot, appConfigFilePath, isProduction) {
-  const config = require(appConfigFilePath).default;
   return {
     context: appRoot,
     devtool: isProduction ? null : "cheap-module-eval-source-map",
@@ -87,7 +87,7 @@ export default function (appRoot, appConfigFilePath, isProduction) {
       path: path.join(appRoot, "build"),
       filename: `[name]-${OUTPUT_FILE}`,
       chunkFilename: `[name]-chunk-${OUTPUT_FILE}`,
-      publicPath: config.assetPath,
+      publicPath: ASSET_PATH,
     },
     plugins: [
       new webpack.optimize.DedupePlugin(),
@@ -100,8 +100,8 @@ export default function (appRoot, appConfigFilePath, isProduction) {
       // Make it so *.server.js files return empty function in client
       new webpack.NormalModuleReplacementPlugin(/\.server(\.js)?$/, () => {}),
 
-      new webpack.optimize.CommonsChunkPlugin("vendor", "vendor.bundle.js"),
-      new webpack.optimize.CommonsChunkPlugin("commons", "commons.bundle.js"),
+      new webpack.optimize.CommonsChunkPlugin("vendor", "vendor-[hash].bundle.js"),
+      new webpack.optimize.CommonsChunkPlugin("commons", "commons-[hash].bundle.js"),
       new webpack.optimize.AggressiveMergingPlugin()
     ].concat(getEnvironmentPlugins(), webpackSharedConfig.plugins, plugins),
     resolve: {

--- a/src/config/webpack-shared-config.js
+++ b/src/config/webpack-shared-config.js
@@ -62,7 +62,7 @@ module.exports = {
     }
   ],
   plugins: [
-    new ExtractTextPlugin("[name].css"),
+    new ExtractTextPlugin("[name]-[chunkhash].css"),
   ],
   preLoaders: []
 };

--- a/src/lib/buildWebpackEntries.js
+++ b/src/lib/buildWebpackEntries.js
@@ -33,7 +33,7 @@ export function getWebpackEntries () {
     output[key] = {
       ...entry,
       fileName: fileName,
-      filePath: `${path.join(basePath, fileName)}.js`,
+      filePath: `${path.join(basePath, fileName)}-[chunkhash].js`,
       routes: entry.routes || path.join(cwd, "src", "config", "routes", fileName),
       reducers: entry.reducers || path.join(cwd, "src", "reducers", fileName),
       index: entry.index || path.join(cwd, "Index")

--- a/src/lib/getAssetPath.js
+++ b/src/lib/getAssetPath.js
@@ -1,0 +1,21 @@
+import path from "path";
+
+let APP_CONFIG;
+try {
+  const APP_ROOT = process.cwd();
+  const APP_CONFIG_PATH = path.join(APP_ROOT, "src", "config", "application.js");
+  APP_CONFIG = require(APP_CONFIG_PATH).default;
+}
+catch (e) {
+  APP_CONFIG = {};
+}
+
+export default function (config=APP_CONFIG) {
+  let assetPath = config.assetPath;
+  if (assetPath.substr(-1) !== "/") {
+    assetPath = assetPath + "/";
+  }
+
+  return assetPath;
+}
+

--- a/src/lib/getAssetPathForFile.js
+++ b/src/lib/getAssetPathForFile.js
@@ -1,0 +1,23 @@
+import path from "path";
+import fs from "fs";
+
+let WEBPACK_ASSETS;
+try {
+  const APP_ROOT = process.cwd();
+  const WEBPACK_ASSETS_FILE_PATH = path.join(APP_ROOT, "webpack-assets.json");
+  // This is only run once when the app spins up
+  WEBPACK_ASSETS = JSON.parse(fs.readFileSync(WEBPACK_ASSETS_FILE_PATH));
+}
+catch (e) {
+  WEBPACK_ASSETS = {
+    javascript: {},
+    styles: {},
+    assets: {}
+  };
+}
+
+export default function (filename, section, webpackAssets=WEBPACK_ASSETS) {
+  const assets = webpackAssets[section] || {};
+  return assets[filename];
+}
+

--- a/src/lib/server/Body.js
+++ b/src/lib/server/Body.js
@@ -39,7 +39,7 @@ export default class Body extends Component {
         <script type="text/javascript" dangerouslySetInnerHTML={{__html: `window.__INITIAL_STATE__=${serialize(initialState, {isJSON: true})};`}}></script>
         <script type="text/javascript" src={getAssetPathForFile("commons", "javascript")}></script>
         <script type="text/javascript" src={getAssetPathForFile("vendor", "javascript")}></script>
-        <script type="text/javascript" src={getAssetPathForFile(entryPoint)}></script>
+        <script type="text/javascript" src={getAssetPathForFile(entryPoint, "javascript")}></script>
       </div>
     );
   }

--- a/src/lib/server/Body.js
+++ b/src/lib/server/Body.js
@@ -2,7 +2,7 @@
 import React, { Component, PropTypes} from "react";
 import serialize from "serialize-javascript";
 
-import getAssetPathForFile from "../lib/getAssetPathForFile";
+import getAssetPathForFile from "../getAssetPathForFile";
 
 export default class Body extends Component {
   static propTypes = {

--- a/src/lib/server/Body.js
+++ b/src/lib/server/Body.js
@@ -2,9 +2,10 @@
 import React, { Component, PropTypes} from "react";
 import serialize from "serialize-javascript";
 
+import getAssetPathForFile from "../lib/getAssetPathForFile";
+
 export default class Body extends Component {
   static propTypes = {
-    config: PropTypes.object.isRequired,
     html: PropTypes.string.isRequired,
     isEmail: PropTypes.bool.isRequired,
     entryPoint: PropTypes.string.isRequired,
@@ -29,17 +30,16 @@ export default class Body extends Component {
   _renderWithScriptTags () {
     const {
       initialState,
-      entryPoint,
-      config
+      entryPoint
     } = this.props;
 
     return (
       <div>
         { this._renderMainContent() }
         <script type="text/javascript" dangerouslySetInnerHTML={{__html: `window.__INITIAL_STATE__=${serialize(initialState, {isJSON: true})};`}}></script>
-        <script type="text/javascript" src={`${config.assetPath}/commons.bundle.js`}></script>
-        <script type="text/javascript" src={`${config.assetPath}/vendor.bundle.js`}></script>
-        <script type="text/javascript" src={`${config.assetPath}/${entryPoint}-app.bundle.js`}></script>
+        <script type="text/javascript" src={getAssetPathForFile("commons", "javascript")}></script>
+        <script type="text/javascript" src={getAssetPathForFile("vendor", "javascript")}></script>
+        <script type="text/javascript" src={getAssetPathForFile(entryPoint)}></script>
       </div>
     );
   }

--- a/src/lib/server/getHead.js
+++ b/src/lib/server/getHead.js
@@ -2,8 +2,8 @@
 import React from "react";
 import serialize from "serialize-javascript";
 import process from "process";
-import getAssetPath from "../lib/getAssetPath";
-import getAssetPathForFile from "../lib/getAssetPathForFile";
+import getAssetPath from "../getAssetPath";
+import getAssetPathForFile from "../getAssetPathForFile";
 
 const isProduction = process.env.NODE_ENV === "production";
 

--- a/src/lib/server/getHead.js
+++ b/src/lib/server/getHead.js
@@ -1,14 +1,9 @@
 /*eslint-disable react/no-danger*/
 import React from "react";
 import serialize from "serialize-javascript";
-import path from "path";
 import process from "process";
-
-// Make sure path ends in forward slash
-let assetPath = require(path.resolve(path.join(process.cwd(), "src", "config", "application"))).default.assetPath;
-if (assetPath.substr(-1) !== "/") {
-  assetPath = assetPath + "/";
-}
+import getAssetPath from "../lib/getAssetPath";
+import getAssetPathForFile from "../lib/getAssetPathForFile";
 
 const isProduction = process.env.NODE_ENV === "production";
 
@@ -16,9 +11,10 @@ const isProduction = process.env.NODE_ENV === "production";
 export default (config, entryPoint, assets) => {
   const tags = [];
   let key = 0;
+  const assetPath = getAssetPath(config);
 
   if (isProduction) {
-    tags.push(<link key={key++} rel="stylesheet" type="text/css" href={`${config.assetPath}/${entryPoint}.css`} />);
+    tags.push(<link key={key++} rel="stylesheet" type="text/css" href={getAssetPathForFile(`${entryPoint}`, "styles")} />);
   }
 
   tags.push(

--- a/src/lib/server/requestHandler.js
+++ b/src/lib/server/requestHandler.js
@@ -91,7 +91,7 @@ module.exports = async function (req, res) {
           // grab the react generated body stuff. This includes the
           // script tag that hooks up the client side react code.
           const currentState = store.getState();
-          const body = createElement(Body, {html: reactRenderFunc(main), entryPoint: fileName, config: config, initialState: currentState, isEmail: isEmail});
+          const body = createElement(Body, {html: reactRenderFunc(main), entryPoint: fileName, initialState: currentState, isEmail});
           const head = isEmail ? null : getHead(config, fileName, webpackIsomorphicTools.assets()); // eslint-disable-line webpackIsomorphicTools
 
 

--- a/test/lib/buildWebpackEntries.test.js
+++ b/test/lib/buildWebpackEntries.test.js
@@ -43,7 +43,7 @@ describe("src/lib/buildWebpackEntries", () => {
             routes: `${cwd}/src/config/routes`,
             reducers: `${cwd}/src/reducers`,
             fileName: "main",
-            filePath: `${cwd}/src/config/.entries/main.js`,
+            filePath: `${cwd}/src/config/.entries/main-[chunkhash].js`,
             index: `${cwd}/Index`
         }
       };
@@ -58,7 +58,7 @@ describe("src/lib/buildWebpackEntries", () => {
       const expectedResult = {
         "/": {
           fileName: "main",
-          filePath: `${cwd}/src/config/.entries/main.js`,
+          filePath: `${cwd}/src/config/.entries/main-[chunkhash].js`,
           index: `${cwd}/Index`,
           name: "main",
           reducers: `${cwd}/src/reducers`,
@@ -66,7 +66,7 @@ describe("src/lib/buildWebpackEntries", () => {
         },
         "/used-cars-for-sale": {
           fileName: "used",
-          filePath: `${cwd}/src/config/.entries/used.js`,
+          filePath: `${cwd}/src/config/.entries/used-[chunkhash].js`,
           index: `${cwd}/Index`,
           name: "used",
           reducers: `${cwd}/src/reducers/used`,
@@ -87,7 +87,7 @@ describe("src/lib/buildWebpackEntries", () => {
 
       const expectedResult = {
         fileName: "used",
-        filePath: `${cwd}/src/config/.entries/used.js`,
+        filePath: `${cwd}/src/config/.entries/used-[chunkhash].js`,
         index: indexPath,
         name: "used",
         reducers: reducersPath,
@@ -102,8 +102,8 @@ describe("src/lib/buildWebpackEntries", () => {
     it("should create necessary entry files", () => {
       const entriesFolder = path.join(cwd, "src", "config", ".entries");
       const webpackAdditionsContent = "module.exports = { additionalLoaders: [], additionalPreLoaders: [], entryPoints: {'/used-cars-for-sale': { name: 'used'}}};";
-      const mainEntryPath = path.join(entriesFolder, "main.js");
-      const usedEntryPath = path.join(entriesFolder, "used.js");
+      const mainEntryPath = path.join(entriesFolder, "main-[chunkhash].js");
+      const usedEntryPath = path.join(entriesFolder, "used-[chunkhash].js");
       fs.outputFileSync(webpackAdditionsPath, webpackAdditionsContent);
       expect(() => fs.statSync(mainEntryPath)).to.throw("ENOENT");
       expect(() => fs.statSync(usedEntryPath)).to.throw("ENOENT");
@@ -121,12 +121,12 @@ describe("src/lib/buildWebpackEntries", () => {
         "main": [
           "webpack-hot-middleware/client",
           clientPath,
-          path.join(cwd, "/src/config/.entries/main.js")
+          path.join(cwd, "/src/config/.entries/main-[chunkhash].js")
         ],
         "used": [
           "webpack-hot-middleware/client",
           clientPath,
-          path.join(cwd, "/src/config/.entries/used.js")
+          path.join(cwd, "/src/config/.entries/used-[chunkhash].js")
         ]
       };
       expect(output).to.deep.equal(expectedResult);
@@ -140,11 +140,11 @@ describe("src/lib/buildWebpackEntries", () => {
       const expectedResult = {
         "main": [
           clientPath,
-          path.join(cwd, "/src/config/.entries/main.js")
+          path.join(cwd, "/src/config/.entries/main-[chunkhash].js")
         ],
         "used": [
           clientPath,
-          path.join(cwd, "/src/config/.entries/used.js")
+          path.join(cwd, "/src/config/.entries/used-[chunkhash].js")
         ]
       };
       expect(output).to.deep.equal(expectedResult);

--- a/test/lib/getAssetPath.test.js
+++ b/test/lib/getAssetPath.test.js
@@ -1,0 +1,23 @@
+import { expect } from "chai";
+
+import getAssetPath from "../../src/lib/getAssetPath";
+
+describe("lib/getAssetPath", () => {
+  const MOCK_CONFIG_NO_TRAILING_SLASH = {
+    assetPath: "assets"
+  };
+
+  const MOCK_CONFIG_WITH_TRAILING_SLASH = {
+    assetPath: "assets/"
+  };
+
+  it("should return the assetPath from a config object", () => {
+    const assetPath = getAssetPath(MOCK_CONFIG_WITH_TRAILING_SLASH);
+    expect(assetPath).to.equal("assets/");
+  });
+
+  it("should add a slash if assetPath doesn't have one", () => {
+    const assetPath = getAssetPath(MOCK_CONFIG_NO_TRAILING_SLASH);
+    expect(assetPath).to.equal("assets/");
+  });
+});

--- a/test/lib/getAssetPathForFile.test.js
+++ b/test/lib/getAssetPathForFile.test.js
@@ -1,0 +1,35 @@
+import { expect } from "chai";
+import getAssetPathForFile from "../../src/lib/getAssetPathForFile.js";
+
+describe("lib/getAssetPathForFile", () => {
+  const WEBPACK_ASSETS = {
+    javascript: {
+      "default": "/assets/default-chunk-app-63a1352e709f56fa9274.bundle.js",
+      "main": "/assets/main-app-8ec5dba463cc8f7a38e2.bundle.js"
+    },
+    styles: {
+      "vendor": "/assets/vendor-caae0456842614ac670e.css",
+      "main": "/assets/main-8ec5dba463cc8f7a38e2.css"
+    },
+    assets: {
+      "./assets/img/logo.png": "/assets/logo-0c9589cb57d3f36c1633353f3fd27185.png"
+    }
+  };
+
+  it("should return the asset path for a file listed in the javascript section", () => {
+    const result = getAssetPathForFile("main", "javascript", WEBPACK_ASSETS);
+    expect(result).to.equal(WEBPACK_ASSETS.javascript.main);
+  });
+
+  it("should return the asset path for a file listed in the styles section", () => {
+    const result = getAssetPathForFile("main", "styles", WEBPACK_ASSETS);
+    expect(result).to.equal(WEBPACK_ASSETS.styles.main);
+  });
+
+  it("should return the asset path for a file listed in the assets section", () => {
+    const img = "./assets/img/logo.png";
+    const result = getAssetPathForFile(img, "assets", WEBPACK_ASSETS);
+    expect(result).to.equal(WEBPACK_ASSETS.assets[img]);
+  });
+});
+

--- a/test/lib/server/getRenderRequirementsFromEntrypoints.test.js
+++ b/test/lib/server/getRenderRequirementsFromEntrypoints.test.js
@@ -55,7 +55,7 @@ describe("src/lib/server/getRenderRequirementsFromEntrypoints", () => {
       Index: `Contents of ${cwd}/Index.js`,
       fileName: "main",
       getRoutes: `Contents of ${cwd}/src/config/routes`,
-      store: `getStore: ${cwd}/src/config/.entries/main.js`
+      store: `getStore: ${cwd}/src/config/.entries/main-[chunkhash].js`
     };
     expect(result).to.deep.equal(expectedResult);
   });
@@ -73,7 +73,7 @@ describe("src/lib/server/getRenderRequirementsFromEntrypoints", () => {
       Index: `Contents of ${cwd}/Index.js`,
       fileName: "used",
       getRoutes: `Contents of ${cwd}/src/config/routes/used`,
-      store: `getStore: ${cwd}/src/config/.entries/used.js`
+      store: `getStore: ${cwd}/src/config/.entries/used-[chunkhash].js`
     };
     expect(result).to.deep.equal(expectedResult);
   });


### PR DESCRIPTION
For better CDN caching, we are now going to include hashes in the .js
and .css filenames the same way we do for other assets
