### PR TITLE
maxAge is milliseconds not seconds

### DIFF
--- a/src/lib/server/index.js
+++ b/src/lib/server/index.js
@@ -21,7 +21,7 @@ app.use(compression());
 addProxies(app, config.proxies);
 
 if (isProduction) {
-  app.use("/assets", express.static("build", { maxAge: 315360000 } ));
+  app.use("/assets", express.static("build", { maxAge: 315360000000 } ));
   logger.info("Server side rendering server running");
 }
 else {


### PR DESCRIPTION
Even though `maxAge` sets the `Cache-Control` header which is in seconds,
the value expected from `maxAge` is in milliseconds. So need 3 more
zeros to get to 1 year.
