### PR TITLE
Handle case where logger config is undefined

### DIFF
--- a/src/lib/server/logger.js
+++ b/src/lib/server/logger.js
@@ -28,7 +28,7 @@ export function parseLogOptions(options) {
   return result;
 }
 
-export function getLogConfig(config) {
+export function getLogConfig(config={}) {
   let pretty = null;
   let cliOptions = {};
 

--- a/templates/new/src/config/application.js
+++ b/templates/new/src/config/application.js
@@ -21,7 +21,11 @@ const config = {
   production: {
     // This should be a CDN in development
     assetPath: process.env.ASSET_URL || "http://localhost:8888/assets",
-    head: headContent
+    head: headContent,
+    logger: {
+      pretty: false,
+      level: "warn"
+    }
   }
 };
 

--- a/test/lib/server/logger.test.js
+++ b/test/lib/server/logger.test.js
@@ -14,7 +14,17 @@ describe("lib/server/logger", () => {
   describe("getLogConfig()", () => {
 
     describe("when no custom configuration is provided", () => {
-      it("sets up logging with proper defaults", () => {
+      it("sets up logging with proper defaults even when no config is provided", () => {
+        const result = getLogConfig(undefined); // eslint-disable-line no-undefined
+        expect(result).to.deep.equal({
+          logConfig: {
+            ...defaultConfig
+          },
+          prettyConfig: null
+        });
+      });
+
+      it("sets up logging with proper defaults when an empty config is provided", () => {
         const result = getLogConfig({});
         expect(result).to.deep.equal({
           logConfig: {


### PR DESCRIPTION
Also add a default production logger configuration.
