### PR TITLE
load the application code in an async tag

### DIFF
--- a/src/lib/server/Body.js
+++ b/src/lib/server/Body.js
@@ -39,7 +39,7 @@ export default class Body extends Component {
         <script type="text/javascript" dangerouslySetInnerHTML={{__html: `window.__INITIAL_STATE__=${serialize(initialState, {isJSON: true})};`}}></script>
         <script type="text/javascript" src={getAssetPathForFile("commons", "javascript")}></script>
         <script type="text/javascript" src={getAssetPathForFile("vendor", "javascript")}></script>
-        <script type="text/javascript" src={getAssetPathForFile(entryPoint, "javascript")}></script>
+        <script type="text/javascript" src={getAssetPathForFile(entryPoint, "javascript")} async></script>
       </div>
     );
   }


### PR DESCRIPTION
Even though the script tags are at the end of our document, we can defer
the loading of the application code since the server did all of the
rendering for us.
