### PR TITLE
Performance tuning

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,6 +6,7 @@
   ],
   "plugins": [
     "transform-decorators-legacy",
+    "closure-elimination"
   ],
   "env": {
     "production": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-core": "6.9.1",
     "babel-istanbul": "0.8.0",
     "babel-loader": "6.2.4",
+    "babel-plugin-closure-elimination": "1.0.6",
     "babel-plugin-react-transform": "2.0.2",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-plugin-transform-react-constant-elements": "6.9.1",

--- a/src/lib/buildWebpackEntries.js
+++ b/src/lib/buildWebpackEntries.js
@@ -95,8 +95,9 @@ import Entry from "${mainEntry}";
 import { createStore } from "gluestick-shared";
 import middleware from "${reduxMiddlewarePath}";
 
+let store;
 export function getStore (httpClient) {
-  const store = createStore(httpClient, () => require("${reducers}"), middleware, (cb) => module.hot && module.hot.accept("${reducers}", cb), !!module.hot);
+  store = store || createStore(httpClient, () => require("${reducers}"), middleware, (cb) => module.hot && module.hot.accept("${reducers}", cb), !!module.hot);
   return store;
 }
 

--- a/src/lib/isChildPath.js
+++ b/src/lib/isChildPath.js
@@ -1,10 +1,19 @@
 import { relative } from "path";
 
+const cache = {};
+
 export default function isChildPath (parent, child) {
-  if (parent === "/") {
-    return true;
+  const key = `${parent}-${child}`;
+  const cacheResult = cache[key];
+
+  if (cacheResult) {
+    return cacheResult;
   }
 
-  return relative(parent, child).substr(0, 1) !== ".";
+  if (parent === "/") {
+    return cache[key] = true;
+  }
+
+  return cache[key] = relative(parent, child).substr(0, 1) !== ".";
 }
 

--- a/src/lib/server/Body.js
+++ b/src/lib/server/Body.js
@@ -6,7 +6,7 @@ import getAssetPathForFile from "../getAssetPathForFile";
 
 export default class Body extends Component {
   static propTypes = {
-    html: PropTypes.string.isRequired,
+    main: PropTypes.string.object,
     isEmail: PropTypes.bool.isRequired,
     entryPoint: PropTypes.string.isRequired,
     initialState: PropTypes.any.isRequired
@@ -22,7 +22,7 @@ export default class Body extends Component {
   _renderWithoutScriptTags () {
     return (
       <div>
-        { this._renderMainContent() }
+        { this.props.main }
       </div>
     );
   }
@@ -35,17 +35,13 @@ export default class Body extends Component {
 
     return (
       <div>
-        { this._renderMainContent() }
+        { this.props.main }
         <script type="text/javascript" dangerouslySetInnerHTML={{__html: `window.__INITIAL_STATE__=${serialize(initialState, {isJSON: true})};`}}></script>
         <script type="text/javascript" src={getAssetPathForFile("commons", "javascript")}></script>
         <script type="text/javascript" src={getAssetPathForFile("vendor", "javascript")}></script>
         <script type="text/javascript" src={getAssetPathForFile(entryPoint, "javascript")} async></script>
       </div>
     );
-  }
-
-  _renderMainContent () {
-    return <div id="main" dangerouslySetInnerHTML={{__html: this.props.html}} />;
   }
 }
 

--- a/src/lib/server/getRenderRequirementsFromEntrypoints.js
+++ b/src/lib/server/getRenderRequirementsFromEntrypoints.js
@@ -5,22 +5,27 @@ import { getLogger } from "./logger";
 const logger = getLogger();
 import { getHttpClient } from "gluestick-shared";
 
-const entryPoints = getWebpackEntries();
+const cachedEntryPoints = getWebpackEntries();
 
 /**
  * Sort through all of the entry points based on the number of `/` characters
  * found in the url. It will test the most deeply nested entry points first
  * while finally falling back to the default index parameter.
  */
-const sortedEntries = Object.keys(entryPoints).sort((a, b) => {
-  const bSplitLength = b.split("/").length;
-  const aSplitLength = a.split("/").length;
-  if (bSplitLength === aSplitLength) {
-    return b.length - a.length;
-  }
+const getSortedEntries = function () {
+  return Object.keys(getWebpackEntries()).sort((a, b) => {
+    const bSplitLength = b.split("/").length;
+    const aSplitLength = a.split("/").length;
+    if (bSplitLength === aSplitLength) {
+      return b.length - a.length;
+    }
 
-  return bSplitLength - aSplitLength;
-});
+    return bSplitLength - aSplitLength;
+  });
+};
+
+// Cache this result so it only runs once in production
+const cachedSortedEntries = getSortedEntries();
 
 /**
  * This method takes the server request object, determines which entry point
@@ -31,6 +36,15 @@ const sortedEntries = Object.keys(entryPoints).sort((a, b) => {
 export default function getRenderRequirementsFromEntrypoints (req, res, config={}, customRequire=require) {
   const httpClient = getHttpClient(config.httpClient, req, res);
   const { path: urlPath } = parseURL(req.url);
+  let sortedEntries, entryPoints;
+  if (process.env.NODE_ENV === "production") {
+    sortedEntries = cachedSortedEntries;
+    entryPoints = cachedEntryPoints;
+  }
+  else {
+    sortedEntries = getSortedEntries();
+    entryPoints = getWebpackEntries();
+  }
 
   logger.debug("Getting webpack entries");
 

--- a/src/lib/server/requestHandler.js
+++ b/src/lib/server/requestHandler.js
@@ -91,7 +91,7 @@ module.exports = async function (req, res) {
           // grab the react generated body stuff. This includes the
           // script tag that hooks up the client side react code.
           const currentState = store.getState();
-          const body = createElement(Body, {html: reactRenderFunc(main), entryPoint: fileName, initialState: currentState, isEmail});
+          const body = createElement(Body, {main, entryPoint: fileName, initialState: currentState, isEmail});
           const head = isEmail ? null : getHead(config, fileName, webpackIsomorphicTools.assets()); // eslint-disable-line webpackIsomorphicTools
 
 


### PR DESCRIPTION
After running several load tests and analyzing the CPU profile we found
a few places that were showing up close to the top of the profiler.
Most of the time is spent in ReactDOM.renderToString but we are updating
the parts of the code that are part of GlueStick.

Move methods that were showing up in the JavaScript CPU profiler out of
the request handler that don't need to be run on each request. Add
memoizing to methods that can benefit from it.

Add another babel plugin that could improve performance.
