### PR TITLE
Perform build optimization on docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,4 +66,4 @@ RUN apt-get update && \
 
 EXPOSE 8888
 
-CMD ["gluestick", "start"]
+CMD ["gluestick", "start", "-P"]

--- a/docker/generate-dockerfile.js
+++ b/docker/generate-dockerfile.js
@@ -15,6 +15,7 @@ var dockerfile = [
                      "ADD . /app",
                      "",
                      "RUN npm install",
+                     "RUN gluestick build",
                      ""
                  ];
 

--- a/templates/new/src/config/.Dockerfile
+++ b/templates/new/src/config/.Dockerfile
@@ -7,3 +7,4 @@ FROM truecar/gluestick:0.9.6
 ADD . /app
 
 RUN npm install
+RUN gluestick build


### PR DESCRIPTION
Now that environment variables are interpreted at runtime (see #268), we no longer have the requirement to build upon server startup.  This is essentially an undo of #267 and https://github.com/TrueCar/gluestick/commit/9ee199d4d6e08e8a2c7b12fee4c0b1b62dc5bc37.
