### PR TITLE
Use req.url instead of req.path on the server

### DIFF
--- a/src/lib/server/requestHandler.js
+++ b/src/lib/server/requestHandler.js
@@ -59,7 +59,7 @@ module.exports = async function (req, res) {
 
     const routes = prepareRoutesWithTransitionHooks(getRoutes(store));
 
-    match({routes: routes, location: req.path}, async (error, redirectLocation, renderProps) => {
+    match({routes: routes, location: req.url}, async (error, redirectLocation, renderProps) => {
       try {
         if (error) {
           errorHandler(req, res, error, config);


### PR DESCRIPTION
According to react-router docs, we should be providing the full URL path from the original request, including the query string.

https://github.com/reactjs/react-router/blob/master/docs/guides/ServerRendering.md#server-rendering

This will fix an issue where `location` objects were dropping query params.
