### PR TITLE
Stop using aggressive merging plugin

### DIFF
--- a/src/config/getWebpackClientConfig.js
+++ b/src/config/getWebpackClientConfig.js
@@ -117,8 +117,7 @@ export default function (appRoot, appConfigFilePath, isProduction) {
       new webpack.NormalModuleReplacementPlugin(/\.server(\.js)?$/, () => {}),
 
       new webpack.optimize.CommonsChunkPlugin("vendor", `vendor${isProduction ? "-[hash]" : ""}.bundle.js`),
-      new webpack.optimize.CommonsChunkPlugin("commons", `commons${isProduction ? "-[hash]" : ""}.bundle.js`),
-      new webpack.optimize.AggressiveMergingPlugin()
+      new webpack.optimize.CommonsChunkPlugin("commons", `commons${isProduction ? "-[hash]" : ""}.bundle.js`)
     ].concat(getEnvironmentPlugins(isProduction), webpackSharedConfig.plugins, plugins),
     resolve: {
       ...webpackSharedConfig.resolve


### PR DESCRIPTION
When developers use code splitting to separate sections of an
application, the aggressive merging plugin will sometimes merge those
together. This can cause undesired behavior. If this is the desired
behavior then this plugin should be added on a per-app basis using the
webpack-additions.js file
