### PR TITLE
use `image-webpack-loader` to optimize images

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "gluestick-shared": "0.4.15",
     "history": "3.0.0",
     "http-proxy-middleware": "0.17.1",
+    "image-webpack-loader": "2.0.0",
     "inquirer": "1.0.3",
     "jsdom": "9.3.0",
     "json-loader": "0.5.4",

--- a/src/config/webpack-shared-config.js
+++ b/src/config/webpack-shared-config.js
@@ -47,7 +47,10 @@ module.exports = {
     },
     {
       test: webpackIsomorphicToolsPlugin.regular_expression("images"),
-      loader: "file-loader?name=[name]-[hash].[ext]"
+      loaders: [
+        "file-loader?name=[name]-[hash].[ext]",
+        "image-webpack"
+      ]
     },
     {
       test: webpackIsomorphicToolsPlugin.regular_expression("fonts"),

--- a/templates/new/package.json
+++ b/templates/new/package.json
@@ -21,6 +21,7 @@
     "file-loader": "0.8.5",
     "gluestick-shared": "0.4.15",
     "history": "3.0.0",
+    "image-webpack-loader": "2.0.0",
     "json-loader": "0.5.4",
     "node-sass": "3.7.0",
     "oy-vey": "0.7.0",


### PR DESCRIPTION
> Image loader module for webpack
> 
> > Minify PNG, JPEG, GIF and SVG images with imagemin
> 
> Issues with the output should be reported on the imagemin issue tracker.

https://github.com/tcoopman/image-webpack-loader
