### PR TITLE
Less verbose test output

### DIFF
--- a/test/commands/destroy.test.js
+++ b/test/commands/destroy.test.js
@@ -41,7 +41,9 @@ describe("cli: gluestick destroy", function () {
     createDirectories(tmpDir, "components", "reducers", "containers");
 
     sandbox = sinon.sandbox.create();
-    sandbox.spy(logger, "error");
+    sandbox.stub(logger, "error");
+    sandbox.stub(logger, "info");
+    sandbox.stub(logger, "success");
   });
 
   afterEach(done => {

--- a/test/commands/generate.test.js
+++ b/test/commands/generate.test.js
@@ -6,6 +6,8 @@ import mkdirp from "mkdirp";
 import glob from "glob";
 import temp from "temp";
 import rimraf from "rimraf";
+import sinon from "sinon";
+import logger from "../../src/lib/cliLogger";
 import generate from "../../src/commands/generate";
 
 function stubProject(type) {
@@ -59,15 +61,21 @@ function assertImportPath(filePath, expectedPath) {
 
 describe("cli: gluestick generate", function () {
 
-  let originalCwd, tmpDir;
+  let originalCwd, tmpDir, sandbox;
 
   beforeEach(() => {
     originalCwd = process.cwd();
     tmpDir = temp.mkdirSync("gluestick-generate");
     process.chdir(tmpDir);
+
+    // Prevent verbose output in tests
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(logger, "info");
+    sandbox.stub(logger, "success");
   });
 
   afterEach((done) => {
+    sandbox.restore();
     process.chdir(originalCwd);
     rimraf(tmpDir, done);
   });

--- a/test/commands/new.test.js
+++ b/test/commands/new.test.js
@@ -25,8 +25,8 @@ describe("cli: gluestick new", function () {
     process.chdir(tmpDir);
     fakeNpm = sinon.stub(npmDependencies, "install");
     sandbox = sinon.sandbox.create();
-    sandbox.spy(logger, "info");
-    sandbox.spy(logger, "warn");
+    sandbox.stub(logger, "info");
+    sandbox.stub(logger, "warn");
   });
 
   afterEach(done => {

--- a/test/lib/getWebpackAdditions.test.js
+++ b/test/lib/getWebpackAdditions.test.js
@@ -29,8 +29,9 @@ describe("src/lib/getWebpackAdditions", () => {
     fs.unlinkSync(path.join(cwd, ".babelrc"));
 
     sandbox = sinon.sandbox.create();
-    sandbox.spy(logger, "info");
-    sandbox.spy(logger, "warn");
+    sandbox.stub(logger, "error");
+    sandbox.stub(logger, "info");
+    sandbox.stub(logger, "warn");
 
     defaultAdditions = {
       additionalAliases: {},

--- a/test/lib/updateVersion.test.js
+++ b/test/lib/updateVersion.test.js
@@ -25,7 +25,7 @@ describe("cli: gluestick touch", function () {
     dotFile = path.join(tmpDir, ".gluestick");
 
     sandbox = sinon.sandbox.create();
-    sandbox.spy(logger, "warn");
+    sandbox.stub(logger, "warn");
     sandbox.stub(process, "exit");
   });
 

--- a/test/lib/utils.test.js
+++ b/test/lib/utils.test.js
@@ -44,7 +44,7 @@ describe("utils", function () {
     beforeEach(() => {
       sandbox = sinon.sandbox.create();
       sandbox.stub(process, "exit");
-      sandbox.spy(logger, "error");
+      sandbox.stub(logger, "error");
     });
 
     afterEach(() => {


### PR DESCRIPTION
Make tests less verbose by stubbing out logging calls rather than spying on them.

Old:
![old output](https://cloud.githubusercontent.com/assets/59530/18496863/a97b4d70-79f7-11e6-834d-60bad7148ca3.png)

New:
![new output](https://cloud.githubusercontent.com/assets/59530/18496868/b4db535e-79f7-11e6-93ae-49501dfe475e.png)
