### PR TITLE
Stop including .server.js files in build

### DIFF
--- a/src/config/getWebpackClientConfig.js
+++ b/src/config/getWebpackClientConfig.js
@@ -113,7 +113,7 @@ export default function (appRoot, appConfigFilePath, isProduction) {
         "process.env": getExposedEnvironmentVariables(appConfigFilePath)
       }),
 
-      // Make it so *.server.js files return empty function in client
+      // Make it so *.server.js files return null in client
       new webpack.NormalModuleReplacementPlugin(/\.server(\.js)?$/, path.join(__dirname, "./serverFileMock.js")),
 
       new webpack.optimize.CommonsChunkPlugin("vendor", `vendor${isProduction ? "-[hash]" : ""}.bundle.js`),

--- a/src/config/getWebpackClientConfig.js
+++ b/src/config/getWebpackClientConfig.js
@@ -114,7 +114,7 @@ export default function (appRoot, appConfigFilePath, isProduction) {
       }),
 
       // Make it so *.server.js files return empty function in client
-      new webpack.NormalModuleReplacementPlugin(/\.server(\.js)?$/, () => {}),
+      new webpack.NormalModuleReplacementPlugin(/\.server(\.js)?$/, path.join(__dirname, "./serverFileMock.js")),
 
       new webpack.optimize.CommonsChunkPlugin("vendor", `vendor${isProduction ? "-[hash]" : ""}.bundle.js`),
     ].concat(getEnvironmentPlugins(isProduction), webpackSharedConfig.plugins, plugins),

--- a/src/config/serverFileMock.js
+++ b/src/config/serverFileMock.js
@@ -1,0 +1,2 @@
+module.exports = null;
+


### PR DESCRIPTION
.server.js files are not supposed to be included in the build but they were. It looks like the way I was using NormalModuleReplacementPlugin was different than the examples I could find. In the examples an actual file path was returned instead of a function. This seems to resolve that problem.
