### PR TITLE
Remove recommendation for installing as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ it under v4. Versions prior to 4 are not currently supported.
 
 ## Install
 ```
-sudo npm install gluestick -g
+npm install gluestick -g
 ```
 
 ## Getting Started


### PR DESCRIPTION
Reasons:
- npm, for a while, recommended never running as root, and instead suggested brew / brew + nvm / some other non-root method of installation.
- Nearly all other globally-installed npm packages don't include sudo as a recommendation.
- sudo doesn't exist on Windows.
- Installing Gluestick as root, while having a non-root Node installation, ends up mixing up permissions within the folder. Installing not as root will give a permissions error, and the user can add sudo to make it work. Overall, less damaging.
