### PR TITLE
add `gluestick run` command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -13,6 +13,7 @@ const startTest = lazyMethodRequire("./commands/test");
 const generate = lazyMethodRequire("./commands/generate");
 const destroy = lazyMethodRequire("./commands/destroy");
 const dockerize = lazyMethodRequire("./commands/dockerize");
+const run = lazyMethodRequire("./commands/run");
 
 const updateLastVersionUsed = require("./lib/updateVersion");
 const getVersion = require("./lib/getVersion");
@@ -152,6 +153,14 @@ commander
     const proc = spawnProcess("test", commander.rawArgs.slice(3));
     proc.on("close", code => { process.exit(code); });
   });
+
+commander
+  .command("run")
+  .arguments("<script_path>")
+  .action(() => updateLastVersionUsed(currentGluestickVersion))
+  .action((scriptPath) => run(scriptPath, (err) => {
+    if (err) { logger.error(err); }
+  }));
 
 // This is a catch all command. DO NOT PLACE ANY COMMANDS BELOW THIS
 commander

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -10,6 +10,7 @@ module.exports = function (scriptPath, cb) {
       .server(process.cwd(), () => {
         try {
           require(path.join(process.cwd(), scriptPath));
+          cb();
         }
         catch (e) {
           cb(e);

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -1,0 +1,23 @@
+import "babel-register";
+import path from "path";
+import WebpackIsomorphicTools from "webpack-isomorphic-tools";
+import webpackIsomorphicToolsConfig from "../config/webpack-isomorphic-tools-config";
+
+module.exports = function (scriptPath, cb) {
+  try {
+    new WebpackIsomorphicTools(webpackIsomorphicToolsConfig)
+      .development(process.env.NODE_ENV !== "production")
+      .server(process.cwd(), () => {
+        try {
+          require(path.join(process.cwd(), scriptPath));
+        }
+        catch (e) {
+          cb(e);
+        }
+      });
+  }
+  catch (e) {
+    cb(e);
+  }
+};
+

--- a/test/commands/run.test.js
+++ b/test/commands/run.test.js
@@ -1,0 +1,61 @@
+/*global afterEach beforeEach describe it*/
+import sinon from "sinon";
+import { expect } from "chai";
+import fs from "fs";
+import path from "path";
+import temp from "temp";
+import rimraf from "rimraf";
+import mkdirp from "mkdirp";
+import run from "../../src/commands/run";
+
+function getDoStuffScript () {
+  return `
+    var fs = require("fs");
+    var path = require("path");
+    console.log('      -> Hello gluestick runner script');
+    fs.writeFileSync(path.join(__dirname, "..", "test.txt"), "written from runner");
+  `;
+}
+
+describe("cli: gluestick run", function () {
+
+  let originalCwd, tmpDir;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpDir = temp.mkdirSync("gluestick-run");
+    process.chdir(tmpDir);
+
+    fs.closeSync(fs.openSync(".gluestick", "w"));
+  });
+
+  afterEach(done => {
+    process.chdir(originalCwd);
+    rimraf(tmpDir, done);
+  });
+
+  it("runs the provided script", (done) => {
+    const errorCallback = sinon.spy();
+    mkdirp.sync(path.join(tmpDir, "scripts"));
+    const filePath = path.join(tmpDir, "scripts", "doStuff.js");
+    fs.closeSync(fs.openSync(path.join(tmpDir, "webpack-assets.json"), "w"));
+    fs.writeFileSync(filePath, getDoStuffScript());
+    run("scripts/doStuff", errorCallback);
+
+    // wait till next tick so file write operation can finish
+    setTimeout(() => {
+      const output = fs.readFileSync(path.join(tmpDir, "test.txt"), "utf8");
+      expect(output).to.equal("written from runner");
+      expect(errorCallback.called).to.equal(false);
+      done();
+    }, 0);
+  });
+
+  it("throws error if the provided script does not exist", () => {
+    const errorCallback = sinon.spy();
+    mkdirp.sync(path.join(tmpDir, "scripts"));
+    fs.closeSync(fs.openSync(path.join(tmpDir, "webpack-assets.json"), "w"));
+    run("scripts/hi", errorCallback);
+    expect(errorCallback.called).to.equal(true);
+  });
+});

--- a/test/commands/run.test.js
+++ b/test/commands/run.test.js
@@ -1,5 +1,4 @@
 /*global afterEach beforeEach describe it*/
-import sinon from "sinon";
 import { expect } from "chai";
 import fs from "fs";
 import path from "path";
@@ -35,27 +34,24 @@ describe("cli: gluestick run", function () {
   });
 
   it("runs the provided script", (done) => {
-    const errorCallback = sinon.spy();
     mkdirp.sync(path.join(tmpDir, "scripts"));
     const filePath = path.join(tmpDir, "scripts", "doStuff.js");
     fs.closeSync(fs.openSync(path.join(tmpDir, "webpack-assets.json"), "w"));
     fs.writeFileSync(filePath, getDoStuffScript());
-    run("scripts/doStuff", errorCallback);
-
-    // wait till next tick so file write operation can finish
-    setTimeout(() => {
+    run("scripts/doStuff", (error) => {
       const output = fs.readFileSync(path.join(tmpDir, "test.txt"), "utf8");
       expect(output).to.equal("written from runner");
-      expect(errorCallback.called).to.equal(false);
+      expect(error).to.be.undefined;
       done();
-    }, 0);
+    });
   });
 
-  it("throws error if the provided script does not exist", () => {
-    const errorCallback = sinon.spy();
+  it("throws error if the provided script does not exist", (done) => {
     mkdirp.sync(path.join(tmpDir, "scripts"));
     fs.closeSync(fs.openSync(path.join(tmpDir, "webpack-assets.json"), "w"));
-    run("scripts/hi", errorCallback);
-    expect(errorCallback.called).to.equal(true);
+    run("scripts/hi", (error) => {
+      expect(error).to.not.be.undefined;
+      done();
+    });
   });
 });


### PR DESCRIPTION
Just like Ruby on Rails has a `rails run` command that lets you run scripts within the context of your Rails application we needed the ability to do this for GlueStick applications. For now this just sets up webpack isomorphic tools and babel but this can be modified to include more things in the future
