### PR TITLE
add support for `config/init.server.js`

### DIFF
--- a/src/entrypoints/server.js
+++ b/src/entrypoints/server.js
@@ -1,4 +1,19 @@
+const path = require("path");
+const fs = require("fs");
 require("../lib/runThroughBabel");
+
+// Developers can add an optional file in src/config/init.server.js that
+// includes any script initialization stuff. This is a good place to add
+// something like `require("newrelic");`
+const optionalServerInitHookPath = path.join(process.cwd(), "src", "config", "init.server");
+try {
+  fs.statSync(optionalServerInitHookPath + ".js");
+  require(optionalServerInitHookPath);
+}
+catch (e) {
+  // NOOP
+}
+
 const WebpackIsomorphicTools = require("webpack-isomorphic-tools");
 
 (function () {


### PR DESCRIPTION
Developers can add an optional file in src/config/init.server.js that includes any script initialization stuff. This is a good place to add something like `require("newrelic");`
