### PR TITLE
Pin Node version to 6.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: node_js
 
 node_js:
-- '6'
+- '6.7'
 
 branches:
   only: #limit push building to develop branch and version tags to avoid double building on PRs and version tags

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-slim
+FROM node:6.7-slim
 
 ARG GLUESTICK_VERSION
 


### PR DESCRIPTION
Upgrading to 6.8.0 caused our builds to fail. Rather than wait for a
patch, lock down the version of Node to a version we know works for us.
