### PR TITLE
filter html type from tests

### DIFF
--- a/src/lib/testHelperMocha.js
+++ b/src/lib/testHelperMocha.js
@@ -44,7 +44,7 @@ function noop() {
 //
 // "Since the Module system is locked, this feature will probably never go away. However, it may have subtle bugs
 // and complexities that are best left untouched."
-[".css", ".jpg", ".png", ".scss", ".svg", ".gif", ".ico", ".sass"].forEach((extension) => {
+[".css", ".jpg", ".png", ".scss", ".svg", ".gif", ".ico", ".sass", ".html"].forEach((extension) => {
   require.extensions[extension] = noop;
 });
 


### PR DESCRIPTION
a number of static file types have been excluded from mocha tests because they're not js modules, .html files should be filtered as well, eg: iframe content that is not react app.
