### PR TITLE
Fix test coverage commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "lint": "./node_modules/.bin/eslint src test templates",
     "test": "NODE_ENV=test mocha --compilers js:babel-core/register --require babel-polyfill --recursive",
-    "test-coverage": "NODE_ENV=test ./node_modules/.bin/babel-node ./node_modules/babel-istanbul/lib/cli.js cover --include-all-sources --report html --dir coverage/html ./node_modules/.bin/_mocha -- --recursive",
+    "test-coverage": "NODE_ENV=test babel-node ./node_modules/.bin/babel-istanbul cover --include-all-sources --report html --dir coverage/html ./node_modules/.bin/_mocha -- --recursive",
     "prepublish": "./docker/generate-dockerfile.js",
     "postpublish": "./docker/create-base-image.js"
   },

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -13,8 +13,7 @@ const MOCHA_PATH = path.join(NODE_MODULES_PATH, ".bin", "mocha");
 const MOCHA_COVERAGE_PATH = path.join(NODE_MODULES_PATH, ".bin", "_mocha");
 const MOCHA_TEST_PATH = `${CWD}/test/**/*.test.js`;
 const MOCHA_HELPER_PATH = path.join(__dirname, "..", "lib", "testHelperMocha.js");
-const BABEL_NODE_PATH = path.join(NODE_MODULES_PATH, ".bin", "babel-node");
-const BABEL_ISTANBUL_PATH = path.join(NODE_MODULES_PATH, "babel-istanbul", "lib", "cli.js");
+const BABEL_ISTANBUL_PATH = path.join(NODE_MODULES_PATH, ".bin", "babel-istanbul");
 const INSPECTOR_PATH = path.join(NODE_MODULES_PATH, ".bin", "node-inspector");
 const MOCHA_ENV = { ...process.env, ...{ NODE_PATH: CWD, NODE_ENV: "test" }};
 
@@ -69,7 +68,7 @@ function useMocha(options) {
       }
     ],
     coverage: [
-      BABEL_NODE_PATH,
+      "node",
       [
         BABEL_ISTANBUL_PATH,
         "cover",
@@ -90,7 +89,7 @@ function useMocha(options) {
       }
     ],
     single: [
-      BABEL_NODE_PATH,
+      "node",
       [
         BABEL_ISTANBUL_PATH,
         "cover",


### PR DESCRIPTION
The test coverage commands used a hard-coded path to the `babel-istanbul` executable.  They were also using the `babel-node` command which turned out to be unnecessary.
