### PR TITLE
Replace npm with yarn during docker image creation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,11 +55,16 @@ ENV BUILD_PACKAGES "autoconf \
                     xz-utils \
                     zlib1g-dev"
 
+
+RUN apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3 && \
+    echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git && \
     apt-get install -y --no-install-recommends $BUILD_PACKAGES && \
-    npm install -g gluestick@$GLUESTICK_VERSION && \
-    npm install && \
+    apt-get install -y yarn && \
+    yarn global add gluestick@$GLUESTICK_VERSION && \
+    yarn && \
     apt-get remove -y $BUILD_PACKAGES && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/generate-dockerfile.js
+++ b/docker/generate-dockerfile.js
@@ -14,7 +14,7 @@ var dockerfile = [
                      "",
                      "ADD . /app",
                      "",
-                     "RUN npm install",
+                     "RUN yarn",
                      "RUN gluestick build",
                      ""
                  ];


### PR DESCRIPTION
- Install yarn onto all GlueStick base images so apps can use yarn for faster installs
- Use yarn to install dependencies onto GlueStick base images
- Make yarn the default install tool for app docker images
