### PR TITLE
Add support for customizing asset settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "compression": "1.6.2",
     "cross-spawn": "4.0.0",
     "cssnano": "3.7.4",
+    "deepmerge": "1.2.0",
     "electrode-react-ssr-caching": "0.1.3",
     "express": "4.13.4",
     "express-pino-logger": "1.0.0",

--- a/src/lib/server/express-middleware.js
+++ b/src/lib/server/express-middleware.js
@@ -1,26 +1,18 @@
 import path from "path";
-import fs from "fs";
 import * as RequestHandler from "./RequestHandler";
 import errorHandler from "./errorHandler";
 import detectEnvironmentVariables from "../detectEnvironmentVariables";
 import getRenderRequirementsFromEntrypoints from "./getRenderRequirementsFromEntrypoints";
+import loadServerConfig from "./loadServerConfig";
 
 const GLOBAL_CONFIG_PATH = path.join(process.cwd(), "src", "config", "application");
-const SERVER_CONFIG_PATH = `${GLOBAL_CONFIG_PATH}.server`;
 
 let GLOBAL_CONFIG, SERVER_CONFIG, EXPOSED_ENV_VARIABLES;
 
 if (process.env.NODE_ENV !== "test") {
   GLOBAL_CONFIG = require(GLOBAL_CONFIG_PATH).default;
 
-  // Include application.server.js only if it exists
-  try {
-    fs.statSync(SERVER_CONFIG_PATH + ".js");
-    SERVER_CONFIG = require(SERVER_CONFIG_PATH).default;
-  }
-  catch (e) {
-    // NOOP
-  }
+  SERVER_CONFIG = loadServerConfig();
 
   EXPOSED_ENV_VARIABLES = detectEnvironmentVariables(GLOBAL_CONFIG_PATH + ".js");
 }

--- a/src/lib/server/index.js
+++ b/src/lib/server/index.js
@@ -5,6 +5,7 @@ const logger = getLogger();
 import gluestickExpressMiddleware from "./express-middleware";
 import addProxies from "./addProxies";
 import path from "path";
+import serveAssets from "./serveAssets";
 
 // Imported using `require` so that we can use `process.cwd()`
 const config = require(path.join(process.cwd(), "src", "config", "application")).default;
@@ -21,7 +22,7 @@ app.use(compression());
 addProxies(app, config.proxies);
 
 if (isProduction) {
-  app.use("/assets", express.static("build", { maxAge: 315360000000 } ));
+  serveAssets(app);
   logger.info("Server side rendering server running");
 }
 else {

--- a/src/lib/server/loadServerConfig.js
+++ b/src/lib/server/loadServerConfig.js
@@ -1,0 +1,18 @@
+import fs from "fs";
+import path from "path";
+
+export default function loadServerConfig () {
+  let serverConfig = {};
+
+  const serverConfigPath = path.join(process.cwd(), "src", "config", "application.server.js");
+  try {
+    fs.statSync(serverConfigPath);
+    serverConfig = require(serverConfigPath).default;
+  }
+  catch (e) {
+    // NOOP
+  }
+
+  return serverConfig;
+}
+

--- a/src/lib/server/serveAssets.js
+++ b/src/lib/server/serveAssets.js
@@ -1,0 +1,24 @@
+import express from "express";
+import deepMerge from "deepmerge";
+
+import _loadServerConfig from "./loadServerConfig";
+
+export const DEFAULT_ASSETS_CONFIG = {
+  headers: {
+    maxAge: 315360000000
+  },
+  path: "/assets",
+  buildFolder: "build"
+};
+
+export default function serveAssets (app, loadServerConfig=_loadServerConfig, staticMiddleware=express.static) {
+  const serverConfig = loadServerConfig();
+  let config = DEFAULT_ASSETS_CONFIG;
+
+  if (serverConfig.assets) {
+    config = deepMerge(config, serverConfig.assets);
+  }
+
+  app.use(config.path, staticMiddleware(config.buildFolder, config.headers));
+}
+

--- a/src/lib/server/serveAssets.js
+++ b/src/lib/server/serveAssets.js
@@ -4,7 +4,7 @@ import deepMerge from "deepmerge";
 import _loadServerConfig from "./loadServerConfig";
 
 export const DEFAULT_ASSETS_CONFIG = {
-  headers: {
+  options: {
     maxAge: 315360000000
   },
   path: "/assets",
@@ -19,6 +19,6 @@ export default function serveAssets (app, loadServerConfig=_loadServerConfig, st
     config = deepMerge(config, serverConfig.assets);
   }
 
-  app.use(config.path, staticMiddleware(config.buildFolder, config.headers));
+  app.use(config.path, staticMiddleware(config.buildFolder, config.options));
 }
 

--- a/test/lib/server/loadServerConfig.test.js
+++ b/test/lib/server/loadServerConfig.test.js
@@ -1,0 +1,60 @@
+import sinon from "sinon";
+import fs from "fs";
+import temp from "temp";
+import { join } from "path";
+import rimraf from "rimraf";
+import { expect } from "chai";
+
+import loadServerConfig from "../../../src/lib/server/loadServerConfig";
+
+describe("lib/server/loadServerConfig", () => {
+  let originalCwd, tmpDir, sandbox;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpDir = temp.mkdirSync("gluestick-new");
+    process.chdir(tmpDir);
+    fs.mkdirSync(join(tmpDir, "src"));
+    fs.mkdirSync(join(tmpDir, "src", "config"));
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(done => {
+    sandbox.restore();
+    process.chdir(originalCwd);
+    rimraf(tmpDir, done);
+  });
+
+  context("when no application.server file exists", () => {
+    it("should return an empty object", () => {
+      expect(loadServerConfig()).to.deep.equal({});
+    });
+  });
+
+  context("when application.server has an object", () => {
+    beforeEach(() => {
+      fs.writeFileSync("src/config/application.server.js", `
+        module.exports = {
+          default: {
+            assets: {
+              headers: {
+                maxAge: 1000
+              }
+            }
+          }
+        };
+      `);
+    });
+
+    it("should return the data in application.server", () => {
+      expect(loadServerConfig()).to.deep.equal({
+        assets: {
+          headers: {
+            maxAge: 1000
+          }
+        }
+      });
+    });
+  });
+});
+

--- a/test/lib/server/serveAssets.test.js
+++ b/test/lib/server/serveAssets.test.js
@@ -1,0 +1,62 @@
+import { expect } from "chai";
+import { spy, stub } from "sinon";
+
+import serveAssets, { DEFAULT_ASSETS_CONFIG } from "../../../src/lib/server/serveAssets";
+
+describe("lib/server/serveAssets", () => {
+  let mockStaticMiddleware, app, mockLoadServerConfig;
+
+  beforeEach(() => {
+    mockStaticMiddleware = spy();
+    mockLoadServerConfig = stub().returns({});
+    app = {
+      use: stub()
+    };
+  });
+
+  context("when no asset configuration has been set", () => {
+    it("should use the default configuration", () => {
+      serveAssets(app, mockLoadServerConfig, mockStaticMiddleware);
+      expect(mockStaticMiddleware.calledWith(DEFAULT_ASSETS_CONFIG.buildFolder, DEFAULT_ASSETS_CONFIG.headers)).to.equal(true);
+      expect(app.use.calledWith(DEFAULT_ASSETS_CONFIG.path));
+    });
+  });
+
+  context("when asset configuration has been set", () => {
+    it("should merge custom headers", () => {
+      mockLoadServerConfig.returns({
+        assets: {
+          headers: {
+            test: "best"
+          }
+        }
+      });
+      serveAssets(app, mockLoadServerConfig, mockStaticMiddleware);
+      expect(mockStaticMiddleware.lastCall.args[1]).to.deep.equal({
+        ...DEFAULT_ASSETS_CONFIG.headers,
+        test: "best",
+      });
+    });
+
+    it("should pass the custom asset path", () => {
+      mockLoadServerConfig.returns({
+        assets: {
+          path: "/files"
+        }
+      });
+      serveAssets(app, mockLoadServerConfig, mockStaticMiddleware);
+      expect(app.use.lastCall.args[0]).to.equal("/files");
+    });
+
+    it("should pass the custom build folder", () => {
+      mockLoadServerConfig.returns({
+        assets: {
+          buildFolder: "public-files"
+        }
+      });
+      serveAssets(app, mockLoadServerConfig, mockStaticMiddleware);
+      expect(mockStaticMiddleware.lastCall.args[0]).to.equal("public-files");
+    });
+  });
+});
+

--- a/test/lib/server/serveAssets.test.js
+++ b/test/lib/server/serveAssets.test.js
@@ -17,23 +17,23 @@ describe("lib/server/serveAssets", () => {
   context("when no asset configuration has been set", () => {
     it("should use the default configuration", () => {
       serveAssets(app, mockLoadServerConfig, mockStaticMiddleware);
-      expect(mockStaticMiddleware.calledWith(DEFAULT_ASSETS_CONFIG.buildFolder, DEFAULT_ASSETS_CONFIG.headers)).to.equal(true);
+      expect(mockStaticMiddleware.calledWith(DEFAULT_ASSETS_CONFIG.buildFolder, DEFAULT_ASSETS_CONFIG.options)).to.equal(true);
       expect(app.use.calledWith(DEFAULT_ASSETS_CONFIG.path));
     });
   });
 
   context("when asset configuration has been set", () => {
-    it("should merge custom headers", () => {
+    it("should merge custom options", () => {
       mockLoadServerConfig.returns({
         assets: {
-          headers: {
+          options: {
             test: "best"
           }
         }
       });
       serveAssets(app, mockLoadServerConfig, mockStaticMiddleware);
       expect(mockStaticMiddleware.lastCall.args[1]).to.deep.equal({
-        ...DEFAULT_ASSETS_CONFIG.headers,
+        ...DEFAULT_ASSETS_CONFIG.options,
         test: "best",
       });
     });


### PR DESCRIPTION
Express static file server accepts a few arguments. This PR gives developers the ability to pass addition options to the static file middleware, as well as setting the path and build folder.

Express static server options: https://github.com/expressjs/serve-static

Example setting custom headers:
![image](https://cloud.githubusercontent.com/assets/140000/19917339/b1d48f5a-a07f-11e6-803f-890fbd3dde1f.png)
