### PR TITLE
resolve assetPath when it changes after `build` step

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -4,6 +4,7 @@ import webpack from "webpack";
 import getWebpackConfig from "../config/getWebpackClientConfig";
 
 import { getLogger } from "../lib/server/logger";
+import getAssetPath from "../lib/getAssetPath";
 const LOGGER = getLogger();
 
 module.exports = function() {
@@ -15,6 +16,7 @@ module.exports = function() {
   compiler.run((error, stats) => {
     const statsJson = stats.toJson();
     fs.writeFileSync("webpack-bundle-stats.json", JSON.stringify(statsJson));
+    fs.writeFileSync("build/asset-path.json", JSON.stringify({assetPath: getAssetPath()}));
     const errors = statsJson.errors;
     if (errors.length) {
       errors.forEach((e) => {

--- a/src/commands/start-client.js
+++ b/src/commands/start-client.js
@@ -3,6 +3,7 @@ const webpack = require("webpack");
 const process = require("process");
 const express = require("express");
 const proxy = require("http-proxy-middleware");
+const fs = require("fs-extra");
 
 import build from "./build";
 import getWebpackConfig from "../config/getWebpackClientConfig";
@@ -24,7 +25,11 @@ const PUBLIC_PATH = ASSET_PATH;
 process.env.NODE_PATH = path.join(__dirname, "../..");
 
 module.exports = function () {
+  // clean the slate by removing `webpack-asset.json` before building a new one
+  fs.removeSync(path.join(process.cwd(), "webpack-assets.json"));
+
   const compiler = webpack(getWebpackConfig(APP_ROOT, APP_CONFIG_PATH, IS_PRODUCTION));
+
   if (!IS_PRODUCTION) {
     const app = express();
     app.use(require("webpack-dev-middleware")(compiler, {

--- a/src/lib/getAssetPath.js
+++ b/src/lib/getAssetPath.js
@@ -11,7 +11,7 @@ catch (e) {
 }
 
 export default function (config=APP_CONFIG) {
-  let assetPath = config.assetPath;
+  let assetPath = config.assetPath || "/assets";
   if (assetPath.substr(-1) !== "/") {
     assetPath = assetPath + "/";
   }

--- a/src/lib/getAssetPathForFile.js
+++ b/src/lib/getAssetPathForFile.js
@@ -1,5 +1,8 @@
 import path from "path";
 import fs from "fs";
+import getAssetPath from "./getAssetPath";
+
+const IS_PROD = process.env.NODE_ENV === "production";
 
 let WEBPACK_ASSETS;
 try {
@@ -7,17 +10,45 @@ try {
   const WEBPACK_ASSETS_FILE_PATH = path.join(APP_ROOT, "webpack-assets.json");
   // This is only run once when the app spins up
   WEBPACK_ASSETS = JSON.parse(fs.readFileSync(WEBPACK_ASSETS_FILE_PATH));
+
+  // If we are in production, check out what the original assetPath was when
+  // `gluestick build` was ran.
+  if (IS_PROD) {
+    const ORIGINAL_ASSET_PATH_INFO_PATH = path.join(APP_ROOT, "build", "asset-path.json");
+    WEBPACK_ASSETS.path = JSON.parse(fs.readFileSync(ORIGINAL_ASSET_PATH_INFO_PATH)).assetPath;
+  }
 }
 catch (e) {
   WEBPACK_ASSETS = {
     javascript: {},
     styles: {},
-    assets: {}
+    assets: {},
+    path: ""
   };
 }
 
-export default function (filename, section, webpackAssets=WEBPACK_ASSETS) {
+export default function (filename, section, webpackAssets=WEBPACK_ASSETS, isProduction=IS_PROD, config) {
+  const assetPath = getAssetPath(config);
   const assets = webpackAssets[section] || {};
-  return assets[filename];
+  const webpackPath = assets[filename];
+
+  // in development mode, webpack-assets.json is always up to date because assets
+  // are constantly rebuilt.
+  if (!isProduction) {
+    return webpackPath;
+  }
+
+  // In production, it is possible that the assets were built with a different
+  // assetPath than what is currently reflected in src/config/application.js.
+  // This is because you can override the assetPath with an environment
+  // variable if you want to. To resolve this, we check if the assetPath used
+  // during the build step matches the current assetPath. If not, then we
+  // replace what was the assetPath with what is the assetPath.
+  const originalPath = webpackAssets.path;
+  if (originalPath !== assetPath) {
+    return `${assetPath}${webpackPath.substr(originalPath.length)}`;
+  }
+
+  return webpackPath;
 }
 

--- a/test/lib/getAssetPathForFile.test.js
+++ b/test/lib/getAssetPathForFile.test.js
@@ -13,23 +13,60 @@ describe("lib/getAssetPathForFile", () => {
     },
     assets: {
       "./assets/img/logo.png": "/assets/logo-0c9589cb57d3f36c1633353f3fd27185.png"
-    }
+    },
+    path: "/assets/"
   };
 
-  it("should return the asset path for a file listed in the javascript section", () => {
-    const result = getAssetPathForFile("main", "javascript", WEBPACK_ASSETS);
-    expect(result).to.equal(WEBPACK_ASSETS.javascript.main);
+  context("when assetPath is the default `/assets` override is set", () => {
+    it("should return the asset path for a file listed in the javascript section", () => {
+      const result = getAssetPathForFile("main", "javascript", WEBPACK_ASSETS);
+      expect(result).to.equal(WEBPACK_ASSETS.javascript.main);
+
+      // production should be the same
+      const prodResult = getAssetPathForFile("main", "javascript", WEBPACK_ASSETS, true);
+      expect(prodResult).to.equal(result);
+    });
+
+    it("should return the asset path for a file listed in the styles section", () => {
+      const result = getAssetPathForFile("main", "styles", WEBPACK_ASSETS);
+      expect(result).to.equal(WEBPACK_ASSETS.styles.main);
+
+      // production should be the same
+      const prodResult = getAssetPathForFile("main", "styles", WEBPACK_ASSETS, true);
+      expect(prodResult).to.equal(result);
+    });
+
+    it("should return the asset path for a file listed in the assets section", () => {
+      const img = "./assets/img/logo.png";
+      const result = getAssetPathForFile(img, "assets", WEBPACK_ASSETS);
+      expect(result).to.equal(WEBPACK_ASSETS.assets[img]);
+
+      // production should be the same
+      const prodResult = getAssetPathForFile(img, "assets", WEBPACK_ASSETS, true);
+      expect(prodResult).to.equal(result);
+    });
   });
 
-  it("should return the asset path for a file listed in the styles section", () => {
-    const result = getAssetPathForFile("main", "styles", WEBPACK_ASSETS);
-    expect(result).to.equal(WEBPACK_ASSETS.styles.main);
-  });
+  context("when config exports a different assetPath than `/assets`", () => {
+    const config = {
+      assetPath: "http://www.example.com/a$$ets"
+    };
 
-  it("should return the asset path for a file listed in the assets section", () => {
-    const img = "./assets/img/logo.png";
-    const result = getAssetPathForFile(img, "assets", WEBPACK_ASSETS);
-    expect(result).to.equal(WEBPACK_ASSETS.assets[img]);
+    it("should return the asset path for a file listed in the javascript section", () => {
+      const result = getAssetPathForFile("main", "javascript", WEBPACK_ASSETS, true, config);
+      expect(result).to.equal("http://www.example.com/a$$ets/main-app-8ec5dba463cc8f7a38e2.bundle.js");
+    });
+
+    it("should return the asset path for a file listed in the styles section", () => {
+      const result = getAssetPathForFile("main", "styles", WEBPACK_ASSETS, true, config);
+      expect(result).to.equal("http://www.example.com/a$$ets/main-8ec5dba463cc8f7a38e2.css");
+    });
+
+    it("should return the asset path for a file listed in the assets section", () => {
+      const img = "./assets/img/logo.png";
+      const result = getAssetPathForFile(img, "assets", WEBPACK_ASSETS, true, config);
+      expect(result).to.equal("http://www.example.com/a$$ets/logo-0c9589cb57d3f36c1633353f3fd27185.png");
+    });
   });
 });
 


### PR DESCRIPTION
When using `gluestick dockerize` the webpack-assets.json file is
generated which statically makes the assetPath stuck to what it was
when the build was created. This is a problem when you want to pass a
different environment variable to change assetPath at runtime.

Without a complete refactor of how the asset paths work, the current
solution is to keep track of what the assetPath was when `gluestick
build` was run. If, at runtime, a different assetPath is found, it will
replace the old one with the new one when calling `getAssetPathForFile`.