### PR TITLE
Use LoadJS in place of script.js

### DIFF
--- a/src/lib/server/getHead.js
+++ b/src/lib/server/getHead.js
@@ -36,15 +36,22 @@ function getScriptLoader ({vendor, entryPoint}:Object) {
   const scriptLoader = `
     loadjs=function(){function n(n,e){n=n.push?n:[n];var t,r,o,c,i=[],s=n.length,h=s;for(t=function(n,t){t.length&&i.push(n),h--,h||e(i)};s--;)r=n[s],o=u[r],o?t(r,o):(c=f[r]=f[r]||[],c.push(t))}function e(n,e){if(n){var t=f[n];if(u[n]=e,t)for(;t.length;)t[0](n,e),t.splice(0,1)}}function t(n,e,t){var r,o,c=document;/\.css$/.test(n)?(r=!0,o=c.createElement("link"),o.rel="stylesheet",o.href=n):(o=c.createElement("script"),o.src=n,o.async=void 0===t||t),o.onload=o.onerror=o.onbeforeload=function(t){var c=t.type[0];if(r&&"hideFocus"in o)try{o.sheet.cssText.length||(c="e")}catch(n){c="e"}e(n,c,t.defaultPrevented)},c.head.appendChild(o)}function r(n,e,r){n=n.push?n:[n];var o,c,i=n.length,u=i,f=[];for(o=function(n,t,r){if("e"==t&&f.push(n),"b"==t){if(!r)return;f.push(n)}i--,i||e(f)},c=0;c<u;c++)t(n[c],o,r)}function o(n,t,o){var u,f;if(t&&t.trim&&(u=t),f=(u?o:t)||{},u){if(u in i)throw new Error("LoadJS");i[u]=!0}r(n,function(n){n.length?(f.error||c)(n):(f.success||c)(),e(u,n)},f.async)}var c=function(){},i={},u={},f={};return o.ready=function(e,t){return n(e,function(n){n.length?(t.error||c)(n):(t.success||c)()}),o},o.done=function(n){e(n,[])},o}();
     loadjs(["${vendor}"], "vendor");
+    var loadEntryPoint = function() {
+      loadjs(["${entryPoint}"], {
+        success: function() { window.__startGSApp(); },
+        error: function() { throw new Error("Failed to load ${entryPoint}"); }
+      });
+    };
     document.addEventListener("DOMContentLoaded", function() {
       loadjs.ready("vendor", {
-        success: function() {
-          loadjs(["${entryPoint}"], {
-            success: function() { window.__startGSApp(); },
-            error: function() { throw new Error("Failed to load ${entryPoint}"); }
+        success: loadEntryPoint,
+        error: function() {
+          // retry once for vendor bundle failures
+          loadjs(["${vendor}"], {
+            success: loadEntryPoint,
+            error: function() { throw new Error("Failed to load ${vendor}"); }
           });
-        },
-        error: function() { throw new Error("Failed to load ${vendor}"); }
+        }
       });
     });
   `;

--- a/src/lib/server/getHead.js
+++ b/src/lib/server/getHead.js
@@ -34,21 +34,19 @@ export default (config, entryPoint, assets) => {
 function getScriptLoader ({vendor, entryPoint}:Object) {
   // eslint-disable-next-line quotes
   const scriptLoader = `
-  /*!
-    * $script.js JS loader & dependency manager
-    * https://github.com/ded/script.js
-    * (c) Dustin Diaz 2014 | License MIT
-    */
-    (function(e,t){typeof module!="undefined"&&module.exports?module.exports=t():typeof define=="function"&&define.amd?define(t):this[e]=t()})("$script",function(){function p(e,t){for(var n=0,i=e.length;n<i;++n)if(!t(e[n]))return r;return 1}function d(e,t){p(e,function(e){return t(e),1})}function v(e,t,n){function g(e){return e.call?e():u[e]}function y(){if(!--h){u[o]=1,s&&s();for(var e in f)p(e.split("|"),g)&&!d(f[e],g)&&(f[e]=[])}}e=e[i]?e:[e];var r=t&&t.call,s=r?t:n,o=r?e.join(""):t,h=e.length;return setTimeout(function(){d(e,function t(e,n){if(e===null)return y();!n&&!/^https?:\\\/\\\//.test(e)&&c&&(e=e.indexOf(".js")===-1?c+e+".js":c+e);if(l[e])return o&&(a[o]=1),l[e]==2?y():setTimeout(function(){t(e,!0)},0);l[e]=1,o&&(a[o]=1),m(e,y)})},0),v}function m(n,r){var i=e.createElement("script"),u;i.onload=i.onerror=i[o]=function(){if(i[s]&&!/^c|loade/.test(i[s])||u)return;i.onload=i[o]=null,u=1,l[n]=2,r()},i.async=1,i.src=h?n+(n.indexOf("?")===-1?"?":"&")+h:n,t.insertBefore(i,t.lastChild)}var e=document,t=e.getElementsByTagName("head")[0],n="string",r=!1,i="push",s="readyState",o="onreadystatechange",u={},a={},f={},l={},c,h;return v.get=m,v.order=function(e,t,n){(function r(i){i=e.shift(),e.length?v(i,r):v(i,t,n)})()},v.path=function(e){c=e},v.urlArgs=function(e){h=e},v.ready=function(e,t,n){e=e[i]?e:[e];var r=[];return!d(e,function(e){u[e]||r[i](e)})&&p(e,function(e){return u[e]})?t():!function(e){f[e]=f[e]||[],f[e][i](t),n&&n(r)}(e.join("|")),v},v.done=function(e){v([null],e)},v})
-
-    document.addEventListener("DOMContentLoaded", function () {
-      $script("${vendor}", "vendor", function () {
-        $script("${entryPoint}", "entryPoint", function () {
-          window.__startGSApp();
-        });
+    loadjs=function(){function n(n,e){n=n.push?n:[n];var t,r,o,c,i=[],s=n.length,h=s;for(t=function(n,t){t.length&&i.push(n),h--,h||e(i)};s--;)r=n[s],o=u[r],o?t(r,o):(c=f[r]=f[r]||[],c.push(t))}function e(n,e){if(n){var t=f[n];if(u[n]=e,t)for(;t.length;)t[0](n,e),t.splice(0,1)}}function t(n,e,t){var r,o,c=document;/\.css$/.test(n)?(r=!0,o=c.createElement("link"),o.rel="stylesheet",o.href=n):(o=c.createElement("script"),o.src=n,o.async=void 0===t||t),o.onload=o.onerror=o.onbeforeload=function(t){var c=t.type[0];if(r&&"hideFocus"in o)try{o.sheet.cssText.length||(c="e")}catch(n){c="e"}e(n,c,t.defaultPrevented)},c.head.appendChild(o)}function r(n,e,r){n=n.push?n:[n];var o,c,i=n.length,u=i,f=[];for(o=function(n,t,r){if("e"==t&&f.push(n),"b"==t){if(!r)return;f.push(n)}i--,i||e(f)},c=0;c<u;c++)t(n[c],o,r)}function o(n,t,o){var u,f;if(t&&t.trim&&(u=t),f=(u?o:t)||{},u){if(u in i)throw new Error("LoadJS");i[u]=!0}r(n,function(n){n.length?(f.error||c)(n):(f.success||c)(),e(u,n)},f.async)}var c=function(){},i={},u={},f={};return o.ready=function(e,t){return n(e,function(n){n.length?(t.error||c)(n):(t.success||c)()}),o},o.done=function(n){e(n,[])},o}();
+    loadjs(["${vendor}"], "vendor");
+    document.addEventListener("DOMContentLoaded", function() {
+      loadjs.ready("vendor", {
+        success: function() {
+          loadjs(["${entryPoint}"], {
+            success: function() { window.__startGSApp(); },
+            error: function() { throw new Error("Failed to load ${entryPoint}"); }
+          });
+        },
+        error: function() { throw new Error("Failed to load ${vendor}"); }
       });
     });
   `;
-
   return <script key="script-loader" type="text/javascript" dangerouslySetInnerHTML={{__html: scriptLoader}} />;
 }


### PR DESCRIPTION
[LoadJS](https://github.com/muicss/loadjs) is very similar to script.js but it provides error handling via callbacks and is optimized for modern browsers. Also, it's very small at 654 bytes.

Unfortunately, loading the vendor and entrypoint bundles in parallel but as a series using the `async: false` flag still results in runtime error because the script will attempt to load the entrypoint bundle even if the vendor bundle fails to load.

To optimize, we can begin download of the vendor bundle before the `DOMContentLoaded` event fires. We can then wait for the vendor bundle to be ready before attempting to load the entrypoint bundle. We try to download the vendor bundle twice before throwing an error.