### PR TITLE
Make app code loading more resilient

### DIFF
--- a/src/lib/buildWebpackEntries.js
+++ b/src/lib/buildWebpackEntries.js
@@ -100,7 +100,7 @@ export function getStore (httpClient) {
 }
 
 if (typeof window === "object") {
-  window.__startGSApp = function () { Entry.start(getRoutes, getStore); };
+  Entry.start(getRoutes, getStore);
 }
 `;
 

--- a/src/lib/server/getHead.js
+++ b/src/lib/server/getHead.js
@@ -37,23 +37,41 @@ function getScriptLoader ({vendor, entryPoint}:Object) {
   // eslint-disable-next-line quotes
   const scriptLoader = `
     loadjs=function(){function n(n,e){n=n.push?n:[n];var t,r,o,c,i=[],s=n.length,h=s;for(t=function(n,t){t.length&&i.push(n),h--,h||e(i)};s--;)r=n[s],o=u[r],o?t(r,o):(c=f[r]=f[r]||[],c.push(t))}function e(n,e){if(n){var t=f[n];if(u[n]=e,t)for(;t.length;)t[0](n,e),t.splice(0,1)}}function t(n,e,t){var r,o,c=document;/\.css$/.test(n)?(r=!0,o=c.createElement("link"),o.rel="stylesheet",o.href=n):(o=c.createElement("script"),o.src=n,o.async=void 0===t||t),o.onload=o.onerror=o.onbeforeload=function(t){var c=t.type[0];if(r&&"hideFocus"in o)try{o.sheet.cssText.length||(c="e")}catch(n){c="e"}e(n,c,t.defaultPrevented)},c.head.appendChild(o)}function r(n,e,r){n=n.push?n:[n];var o,c,i=n.length,u=i,f=[];for(o=function(n,t,r){if("e"==t&&f.push(n),"b"==t){if(!r)return;f.push(n)}i--,i||e(f)},c=0;c<u;c++)t(n[c],o,r)}function o(n,t,o){var u,f;if(t&&t.trim&&(u=t),f=(u?o:t)||{},u){if(u in i)throw new Error("LoadJS");i[u]=!0}r(n,function(n){n.length?(f.error||c)(n):(f.success||c)(),e(u,n)},f.async)}var c=function(){},i={},u={},f={};return o.ready=function(e,t){return n(e,function(n){n.length?(t.error||c)(n):(t.success||c)()}),o},o.done=function(n){e(n,[])},o}();
+    var maxRetries = 10;
+    var vendorRetries = 0;
+    var appRetries = 0;
+
     var loadEntryPoint = function() {
       loadjs("${entryPoint}", {
-        success: function() { window.__startGSApp(); },
-        error: function() { throw new Error("Failed to load ${entryPoint}"); }
+        error: function() {
+          appRetries++;
+          if (appRetries < maxRetries) {
+            setTimeout(function() { loadEntryPoint();}, 100);
+          }
+          else {
+            throw new Error("Failed to load ${entryPoint}");
+          }
+        }
       });
     };
-    document.addEventListener("DOMContentLoaded", function() {
+
+    var loadVendorThenEntry = function() {
       loadjs("${vendor}", {
         success: loadEntryPoint,
         error: function() {
-          // retry once for vendor bundle failures
-          loadjs("${vendor}", {
-            success: loadEntryPoint,
-            error: function() { throw new Error("Failed to load ${vendor}"); }
-          });
+          vendorRetries++;
+          if (vendorRetries < maxRetries) {
+            setTimeout(function() { loadVendorThenEntry();}, 100);
+          }
+          else {
+            throw new Error("Failed to load ${vendor}");
+          }
         }
       });
+    };
+
+    document.addEventListener("DOMContentLoaded", function() {
+      loadVendorThenEntry();
     });
   `;
   return <script key="script-loader" type="text/javascript" dangerouslySetInnerHTML={{__html: scriptLoader}} />;


### PR DESCRIPTION
There seems to be failures mostly occuring on mobile devices. We used
to try reloading `vendor` once. This will attempt each javascript asset
up to 10 times before giving up.

I have also added a 100ms delay before each retry in case it was caused
by some kind of internet connection issue.

Instead of calling `window.__startGSApp` it will now start
automatically as soon as it is loaded. `_startGSApp` was added when
support for loading the app before vendor was loaded. Since we have
backed off from paralell loading due to loading errors we are seeing,
it is no longer necessary. The hope is removing that will also account
for less errors.