### PR TITLE
Make asset path dynamic with environment variables

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -17,6 +17,7 @@ const run = lazyMethodRequire("./commands/run");
 
 const updateLastVersionUsed = require("./lib/updateVersion");
 const getVersion = require("./lib/getVersion");
+const updateWebpackAssetPath = require("./lib/updateWebpackAssetPath");
 
 const logger = require("./lib/cliLogger");
 const cliColorScheme = require("./lib/cliColorScheme");
@@ -231,6 +232,11 @@ async function startAll(options) {
   catch (e) {
     logger.error(`During auto upgrade: ${e}`);
     process.exit();
+  }
+
+  // Update the ASSET_PATH in webpack-assets.json in production environments
+  if (isProduction) {
+    updateWebpackAssetPath();
   }
 
   // Set parsed command line args so that spawned processes can refer to them

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -1,3 +1,4 @@
+import { rm, ls } from "shelljs";
 import fs from "fs-extra";
 import path from "path";
 import webpack from "webpack";
@@ -13,6 +14,16 @@ module.exports = function() {
   const isProduction = process.env.NODE_ENV === "production";
   const compiler = webpack(getWebpackConfig(appRoot, appConfigFilePath, isProduction));
   LOGGER.info("Bundling assets…");
+
+  // clean the slate, `shelljs.rm` throws a warning if you try to remove a
+  // folder or file that doesn't exist. To get around that warning we combine
+  // `ls` and `filter` to only remove the target files if the exist.
+  const removeableTargets = ["build", "_build", "webpack-assets.json", "_webpack-assets.json"];
+  const removable = ls(appRoot).filter((f) => removeableTargets.includes(f));
+  if (removable.length) {
+    rm("-R", removable);
+  }
+
   compiler.run((error, stats) => {
     const statsJson = stats.toJson();
     fs.writeFileSync("webpack-bundle-stats.json", JSON.stringify(statsJson));

--- a/src/lib/getAssetPathForFile.js
+++ b/src/lib/getAssetPathForFile.js
@@ -1,8 +1,5 @@
 import path from "path";
 import fs from "fs";
-import getAssetPath from "./getAssetPath";
-
-const IS_PROD = process.env.NODE_ENV === "production";
 
 let WEBPACK_ASSETS;
 try {
@@ -10,13 +7,6 @@ try {
   const WEBPACK_ASSETS_FILE_PATH = path.join(APP_ROOT, "webpack-assets.json");
   // This is only run once when the app spins up
   WEBPACK_ASSETS = JSON.parse(fs.readFileSync(WEBPACK_ASSETS_FILE_PATH));
-
-  // If we are in production, check out what the original assetPath was when
-  // `gluestick build` was ran.
-  if (IS_PROD) {
-    const ORIGINAL_ASSET_PATH_INFO_PATH = path.join(APP_ROOT, "build", "asset-path.json");
-    WEBPACK_ASSETS.path = JSON.parse(fs.readFileSync(ORIGINAL_ASSET_PATH_INFO_PATH)).assetPath;
-  }
 }
 catch (e) {
   WEBPACK_ASSETS = {
@@ -27,27 +17,9 @@ catch (e) {
   };
 }
 
-export default function (filename, section, webpackAssets=WEBPACK_ASSETS, isProduction=IS_PROD, config) {
-  const assetPath = getAssetPath(config);
+export default function (filename, section, webpackAssets=WEBPACK_ASSETS) {
   const assets = webpackAssets[section] || {};
   const webpackPath = assets[filename];
-
-  // in development mode, webpack-assets.json is always up to date because assets
-  // are constantly rebuilt.
-  if (!isProduction) {
-    return webpackPath;
-  }
-
-  // In production, it is possible that the assets were built with a different
-  // assetPath than what is currently reflected in src/config/application.js.
-  // This is because you can override the assetPath with an environment
-  // variable if you want to. To resolve this, we check if the assetPath used
-  // during the build step matches the current assetPath. If not, then we
-  // replace what was the assetPath with what is the assetPath.
-  const originalPath = webpackAssets.path;
-  if (webpackPath && originalPath !== assetPath) {
-    return `${assetPath}${webpackPath.substr(originalPath.length)}`;
-  }
 
   return webpackPath;
 }

--- a/src/lib/updateWebpackAssetPath.js
+++ b/src/lib/updateWebpackAssetPath.js
@@ -1,0 +1,47 @@
+import { cp, ls, sed, rm } from "shelljs";
+const fs = require("fs-extra");
+const path = require("path");
+
+const PLACEHOLDER = new RegExp("__GS_ASSET_URL__", "g");
+
+module.exports = function (assetUrl=process.env.ASSET_URL) {
+  let originalData;
+
+  assetUrl = assetUrl || "/assets";
+
+  const cwd = process.cwd();
+
+  const webpackAssetsPathOriginalCopy = path.join(cwd, "_webpack-assets.json");
+  const webpackAssetsPath = path.join(cwd, "webpack-assets.json");
+
+  const buildPathOriginalCopy = path.join(cwd, "_build");
+  const buildPath = path.join(cwd, "build");
+
+  try {
+    // If this is not our first time then the backup _webpack-assets will exist
+    fs.statSync(webpackAssetsPathOriginalCopy);
+    originalData = fs.readFileSync(webpackAssetsPathOriginalCopy, "utf8");
+  }
+  catch (e) {
+    // Must be our first time, back up webpack-assets and the build folder so
+    // we can use the backups for future replacements
+    originalData = fs.readFileSync(webpackAssetsPath, "utf8");
+    fs.writeFileSync(webpackAssetsPathOriginalCopy, originalData);
+    cp("-R", buildPath, buildPathOriginalCopy);
+  }
+
+  // swap webpack assets with original before our replace
+  rm(webpackAssetsPath);
+  cp(webpackAssetsPathOriginalCopy, webpackAssetsPath);
+  sed("-i", PLACEHOLDER, assetUrl, webpackAssetsPath);
+
+  // swap build folder with original before our replace
+  rm("-R", buildPath);
+  cp("-R", buildPathOriginalCopy, buildPath);
+
+  // grab ALL of the files in the build folder (filter exists because of
+  // awkward `ls` output
+  const buildFiles = ls("build/**").filter(f => f.substr(0, 6) === "build/");
+  sed("-i", PLACEHOLDER, assetUrl, buildFiles);
+};
+

--- a/templates/new/_gitignore
+++ b/templates/new/_gitignore
@@ -1,5 +1,6 @@
 # Output from webpack asset bunlding
 webpack-assets.json
+_webpack-assets.json
 webpack-bundle-stats.json
 
 # Files generated at runtime
@@ -29,6 +30,7 @@ coverage
 
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build
+_build
 
 # Dependency directory
 # https://docs.npmjs.com/misc/faq#should-i-check-my-node-modules-folder-into-git

--- a/templates/new/src/config/.Dockerfile
+++ b/templates/new/src/config/.Dockerfile
@@ -7,4 +7,4 @@ FROM truecar/gluestick:0.10.8
 ADD . /app
 
 RUN yarn
-RUN gluestick build
+RUN ASSET_URL=__GS_ASSET_URL__ gluestick build

--- a/test/lib/getAssetPathForFile.test.js
+++ b/test/lib/getAssetPathForFile.test.js
@@ -17,56 +17,20 @@ describe("lib/getAssetPathForFile", () => {
     path: "/assets/"
   };
 
-  context("when assetPath is the default `/assets` override is set", () => {
-    it("should return the asset path for a file listed in the javascript section", () => {
-      const result = getAssetPathForFile("main", "javascript", WEBPACK_ASSETS);
-      expect(result).to.equal(WEBPACK_ASSETS.javascript.main);
-
-      // production should be the same
-      const prodResult = getAssetPathForFile("main", "javascript", WEBPACK_ASSETS, true);
-      expect(prodResult).to.equal(result);
-    });
-
-    it("should return the asset path for a file listed in the styles section", () => {
-      const result = getAssetPathForFile("main", "styles", WEBPACK_ASSETS);
-      expect(result).to.equal(WEBPACK_ASSETS.styles.main);
-
-      // production should be the same
-      const prodResult = getAssetPathForFile("main", "styles", WEBPACK_ASSETS, true);
-      expect(prodResult).to.equal(result);
-    });
-
-    it("should return the asset path for a file listed in the assets section", () => {
-      const img = "./assets/img/logo.png";
-      const result = getAssetPathForFile(img, "assets", WEBPACK_ASSETS);
-      expect(result).to.equal(WEBPACK_ASSETS.assets[img]);
-
-      // production should be the same
-      const prodResult = getAssetPathForFile(img, "assets", WEBPACK_ASSETS, true);
-      expect(prodResult).to.equal(result);
-    });
+  it("should return the asset path for a file listed in the javascript section", () => {
+    const result = getAssetPathForFile("main", "javascript", WEBPACK_ASSETS);
+    expect(result).to.equal(WEBPACK_ASSETS.javascript.main);
   });
 
-  context("when config exports a different assetPath than `/assets`", () => {
-    const config = {
-      assetPath: "http://www.example.com/a$$ets"
-    };
+  it("should return the asset path for a file listed in the styles section", () => {
+    const result = getAssetPathForFile("main", "styles", WEBPACK_ASSETS);
+    expect(result).to.equal(WEBPACK_ASSETS.styles.main);
+  });
 
-    it("should return the asset path for a file listed in the javascript section", () => {
-      const result = getAssetPathForFile("main", "javascript", WEBPACK_ASSETS, true, config);
-      expect(result).to.equal("http://www.example.com/a$$ets/main-app-8ec5dba463cc8f7a38e2.bundle.js");
-    });
-
-    it("should return the asset path for a file listed in the styles section", () => {
-      const result = getAssetPathForFile("main", "styles", WEBPACK_ASSETS, true, config);
-      expect(result).to.equal("http://www.example.com/a$$ets/main-8ec5dba463cc8f7a38e2.css");
-    });
-
-    it("should return the asset path for a file listed in the assets section", () => {
-      const img = "./assets/img/logo.png";
-      const result = getAssetPathForFile(img, "assets", WEBPACK_ASSETS, true, config);
-      expect(result).to.equal("http://www.example.com/a$$ets/logo-0c9589cb57d3f36c1633353f3fd27185.png");
-    });
+  it("should return the asset path for a file listed in the assets section", () => {
+    const img = "./assets/img/logo.png";
+    const result = getAssetPathForFile(img, "assets", WEBPACK_ASSETS);
+    expect(result).to.equal(WEBPACK_ASSETS.assets[img]);
   });
 });
 

--- a/test/lib/updateWebpackAssetPath.test.js
+++ b/test/lib/updateWebpackAssetPath.test.js
@@ -1,0 +1,84 @@
+import temp from "temp";
+import rimraf from "rimraf";
+import fs from "fs";
+import path from "path";
+import { mkdir } from "shelljs";
+
+import updateWebpackAssetPath from "../../src/lib/updateWebpackAssetPath";
+import { expect } from "chai";
+
+const ASSETS_STRING = JSON.stringify({
+  "assets" : {
+    "__GS_ASSET_URL__/assets/css/normalize.css" : "body { background: #f0f; }"
+  },
+  "javascript" : {
+    "main" : "__GS_ASSET_URL__/main-app-c03464f0dd92831dad2e.bundle.js",
+    "vendor" : "__GS_ASSET_URL__/vendor-d716f60633c7f6c46235.bundle.js"
+  },
+  "styles" : {
+    "main" : "__GS_ASSET_URL__/main-c03464f0dd92831dad2e.css"
+  }
+});
+
+describe("lib/updateWebpackAssetPath", () => {
+  let originalCwd, tmpDir;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpDir = temp.mkdirSync("gluestick-new");
+    process.chdir(tmpDir);
+  });
+
+  afterEach(done => {
+    process.chdir(originalCwd);
+    rimraf(tmpDir, done);
+  });
+
+  it("should save the underscore backup version if one doesn't exist", () => {
+    fs.writeFileSync(path.join(process.cwd(), "webpack-assets.json"), ASSETS_STRING);
+
+    const originalFilePath = path.join(process.cwd(), "_webpack-assets.json");
+    expect(() => fs.statSync(originalFilePath)).to.throw("ENOENT");
+    updateWebpackAssetPath("http://www.assetsformybaskets.com/assets");
+    expect(() => fs.statSync(originalFilePath)).to.not.throw("ENOENT");
+  });
+
+  it("should read from and not update the underscored backup if it does exist", () => {
+    const filePath = path.join(process.cwd(), "webpack-assets.json");
+    const originalFilePath = path.join(process.cwd(), "_webpack-assets.json");
+
+    fs.writeFileSync(path.join(process.cwd(), "webpack-assets.json"), ASSETS_STRING);
+    fs.writeFileSync(originalFilePath, "{\"test\": \"__GS_ASSET_URL__/test.jpg\"}");
+
+    updateWebpackAssetPath("http://www.assetsformybaskets.com/assets");
+
+    expect(fs.readFileSync(originalFilePath, "utf8")).to.equal("{\"test\": \"__GS_ASSET_URL__/test.jpg\"}");
+    expect(fs.readFileSync(filePath, "utf8")).to.equal("{\"test\": \"http://www.assetsformybaskets.com/assets/test.jpg\"}");
+  });
+
+  it("should replace `__GS_ASSET_URL__` with new assetUrl", () => {
+    const filePath = path.join(process.cwd(), "webpack-assets.json");
+
+    fs.writeFileSync(filePath, ASSETS_STRING);
+
+    updateWebpackAssetPath("http://www.assetsformybaskets.com/assets");
+
+    const result = fs.readFileSync(filePath, "utf8");
+    expect(result).to.equal("{\"assets\":{\"http://www.assetsformybaskets.com/assets/assets/css/normalize.css\":\"body { background: #f0f; }\"},\"javascript\":{\"main\":\"http://www.assetsformybaskets.com/assets/main-app-c03464f0dd92831dad2e.bundle.js\",\"vendor\":\"http://www.assetsformybaskets.com/assets/vendor-d716f60633c7f6c46235.bundle.js\"},\"styles\":{\"main\":\"http://www.assetsformybaskets.com/assets/main-c03464f0dd92831dad2e.css\"}}");
+  });
+
+  it("should replace `__GS_ASSET_URL__` in the build folder", () => {
+    const buildFolder = path.join(process.cwd(), "build");
+    mkdir(buildFolder);
+    const filePath = path.join(buildFolder, "test.css");
+
+    fs.writeFileSync(path.join(process.cwd(), "webpack-assets.json"), ASSETS_STRING);
+    fs.writeFileSync(filePath, "body { background: url(__GS_ASSET_URL__/tacos.jpg); }");
+
+    updateWebpackAssetPath("http://www.assetsformybaskets.com/assets");
+
+    const result = fs.readFileSync(filePath, "utf8");
+    expect(result).to.equal("body { background: url(http://www.assetsformybaskets.com/assets/tacos.jpg); }");
+  });
+});
+


### PR DESCRIPTION
Currently when creating a `build` for GlueStick, the asset path is hard coded into the webpack-assets.json file (which is what webpack-isomorphic-tools uses to get asset urls) and sometimes directly into assets themselves (like css files referencing a font file like you see from bootstrap-sass). If you know the asset url ahead of time then this isn't a problem, just make sure to specify the correct URL during the build step.

When you don't know the asset url during build time, this doesn't work out so well. In those situations we wanted to add support for dynamically setting the asset url even after a build has been created. This will let you use the same docker container in a QA env vs a production environment with only changing environment variables.

To support this we now create docker builds using the `ASSET_URL` environment variable set to `__GS_ASSET_URL__`. Then at runtime we set that URL based on the environment settings.