### PR TITLE
CLI should use yarn when available

### DIFF
--- a/src/lib/npmDependencies.js
+++ b/src/lib/npmDependencies.js
@@ -1,12 +1,21 @@
+import path from "path";
+import rimraf from "rimraf";
 const spawn = require("cross-spawn").spawn;
 
 const IS_WINDOWS = process.platform === "win32";
 
 function install () {
   const postFix = IS_WINDOWS ? ".cmd" : "";
-  spawn("npm" + postFix, ["install"], {stdio: "inherit"});
+  return spawn("npm" + postFix, ["install"], {stdio: "inherit"});
+}
+
+function cleanSync () {
+  // wipe the existing node_modules folder so we can have a clean start
+  rimraf.sync(path.join(process.cwd(), "node_modules"));
+  spawn.sync("npm", ["cache", "clean"], {stdio: "inherit"});
 }
 
 module.exports = {
+  cleanSync: cleanSync,
   install: install
 };

--- a/src/lib/npmDependencies.js
+++ b/src/lib/npmDependencies.js
@@ -1,10 +1,15 @@
 import path from "path";
 import rimraf from "rimraf";
 const spawn = require("cross-spawn").spawn;
+import { which } from "shelljs";
 
 const IS_WINDOWS = process.platform === "win32";
 
 function install () {
+  if (which("yarn") !== null) {
+    return spawn("yarn");
+  }
+
   const postFix = IS_WINDOWS ? ".cmd" : "";
   return spawn("npm" + postFix, ["install"], {stdio: "inherit"});
 }


### PR DESCRIPTION
This change allows the CLI to prefer `yarn` over `npm` when installing dependencies for a new GlueStick application and during the auto-upgrade process.

