### PR TITLE
Fix server side stack trace

### DIFF
--- a/src/lib/server/RequestHandler.js
+++ b/src/lib/server/RequestHandler.js
@@ -168,7 +168,7 @@ export async function prepareOutput(req, {Index, store, getRoutes, fileName}, re
       bodyContent = renderOutput.body;
     }
     catch (e) {
-      throw new Error(e);
+      throw e;
     }
   }
   else {


### PR DESCRIPTION
Creating a new error object made it so we don't have the proper stack
trace when a server side rendering error occurs. This resolves that.