### PR TITLE
add support for webpack devtool override

### DIFF
--- a/src/config/getWebpackClientConfig.js
+++ b/src/config/getWebpackClientConfig.js
@@ -65,9 +65,10 @@ export function getEnvironmentPlugins(isProduction) {
 
 export default function (appRoot, appConfigFilePath, isProduction) {
   const OUTPUT_FILE = `app${isProduction ? "-[chunkhash]" : ""}.bundle.js`;
+  const devtool = process.env.DEVTOOL || "inline-source-map";
   return {
     context: appRoot,
-    devtool: isProduction ? null : "inline-source-map",
+    devtool: isProduction ? null : devtool,
     entry: {
       ...buildWebpackEntries(isProduction),
       vendor: vendor


### PR DESCRIPTION
`inline-source-map` is slow but it was picked because once your code gets over a certain size it seems that webkit can't handle `cheap-module-eval-source-map`.

Until a better solution comes along this wil ladd the ability to at least override the `devtool` with `DEVTOOL=X` environment variable.

On my local machine I will be updating ~/.bash_profile to include
```
export DEVTOOL=eval
```
so my rebuilds are faster.

When I need the original code sourcemaps I'll manually override it. I rebuild more than I need to see the original source.

### Example
```
DEVTOOL=eval gluestick start
```