### PR TITLE
Lock down Travis yarn version to 0.16.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ services:
 
 before_install:
 - for var in ${!TRAVIS_@}; do echo ${var}=${!var}; done #show travis env vars
+- 'curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.16.1'
 
 before_deploy:
 - sudo apt-get update -qq


### PR DESCRIPTION
Releases are (silently) failing on the docker image creation step due to an issue with `yarn`. We locked down the version of yarn that is used within the docker images, but Travis is still using it's own version which seems to be causing the issue with the `postpublish` step. See https://api.travis-ci.org/jobs/182474194/log.txt?deansi=true as an example.

