### PR TITLE
use babel-node for coverage

### DIFF
--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -13,6 +13,7 @@ const MOCHA_PATH = path.join(NODE_MODULES_PATH, ".bin", "mocha");
 const MOCHA_COVERAGE_PATH = path.join(NODE_MODULES_PATH, ".bin", "_mocha");
 const MOCHA_TEST_PATH = `${CWD}/test/**/*.test.js`;
 const MOCHA_HELPER_PATH = path.join(__dirname, "..", "lib", "testHelperMocha.js");
+const BABEL_NODE_PATH = path.join(NODE_MODULES_PATH, ".bin", "babel-node");
 const BABEL_ISTANBUL_PATH = path.join(NODE_MODULES_PATH, ".bin", "babel-istanbul");
 const INSPECTOR_PATH = path.join(NODE_MODULES_PATH, ".bin", "node-inspector");
 const MOCHA_ENV = { ...process.env, ...{ NODE_PATH: CWD, NODE_ENV: "test" }};
@@ -68,7 +69,7 @@ function useMocha(options) {
       }
     ],
     coverage: [
-      "node",
+      BABEL_NODE_PATH,
       [
         BABEL_ISTANBUL_PATH,
         "cover",
@@ -89,7 +90,7 @@ function useMocha(options) {
       }
     ],
     single: [
-      "node",
+      BABEL_NODE_PATH,
       [
         BABEL_ISTANBUL_PATH,
         "cover",


### PR DESCRIPTION
Fix https://github.com/TrueCar/gluestick/issues/345

This made the coverage report work for me. See if this works for others also.