### PR TITLE
Update yarn install for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,16 @@ services:
 
 before_install:
 - for var in ${!TRAVIS_@}; do echo ${var}=${!var}; done #show travis env vars
-- 'curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.16.1'
+# Repo for Yarn
+- sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
+- echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+- sudo apt-get update -qq
+- sudo apt-get install -y -qq yarn=0.16.1-1
+- export PATH="/usr/share/yarn/bin:$PATH"
+
+cache:
+  directories:
+    - $HOME/.yarn-cache
 
 before_deploy:
 - sudo apt-get update -qq


### PR DESCRIPTION
The yarn docs now contain install instructions for installing specific versions of yarn for Travis CI. This removes the curl-based approach in favor of their recommended method:

https://yarnpkg.com/en/docs/install-ci#travis-tab

We are also updating the $PATH variable so that Travis CI will  use the version of yarn that is installed by us over the default installed version of yarn.