### PR TITLE
make dnsmasq more portable

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,6 @@ RUN apt-get update && \
 
 RUN apt-get update && apt-get install dnsmasq -y
 
-ADD docker/resolv.conf /etc/resolv.conf.new
 ADD docker/dnsmasq.conf /etc/dnsmasq.conf
 ADD docker/start /app/start
 RUN chmod +x /app/start

--- a/docker/dnsmasq.conf
+++ b/docker/dnsmasq.conf
@@ -1,5 +1,4 @@
-server=8.8.8.8
-server=8.8.4.4
 user=root
 listen-address=127.0.0.1
-
+# Allow more configuration options
+conf-dir=/etc/dnsmasq.d,*.conf

--- a/docker/resolv.conf
+++ b/docker/resolv.conf
@@ -1,2 +1,0 @@
-search local
-nameserver 127.0.0.1

--- a/docker/start
+++ b/docker/start
@@ -1,4 +1,8 @@
 #!/bin/sh
-cat /etc/resolv.conf.new > /etc/resolv.conf
+#
+# Remove any lines that have a nameserver localhost (because we'll add it)
+cat /etc/resolv.conf | sed -e '/^nameserver 127.0.0.1/d' | tee /etc/resolv.conf > /dev/null
+# Now add our own nameserver for localhost above the first nameserver
+cat /etc/resolv.conf | sed -e '0,/^nameserver .*/s/^nameserver /nameserver 127.0.0.1\n&/' | tee /etc/resolv.conf > /dev/null
 service dnsmasq start
 exec gluestick start -P


### PR DESCRIPTION
This PR takes and slightly modifies https://github.com/TrueCar/gluestick/pull/298 by @regiswilson

> We should not override the container's resolv configuration (which
> might have important configuration information in it). Instead, we add the
> nameserver for localhost to be inserted above the container's name servers, which
> dnsmasq will then use to resolve addresses.

> Also, allow other files to be placed in /etc/dnsmasq.d so that
> subsequent docker configuration layers can be added as needed.