### PR TITLE
Move babel-traverse to app to fix webpack builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "babel-preset-react": "6.5.0",
     "babel-preset-stage-0": "6.5.0",
     "babel-register": "6.14.0",
-    "babel-traverse": "6.21.0",
     "chai": "3.5.0",
     "chalk": "1.1.3",
     "chokidar": "1.5.2",

--- a/templates/new/package.json
+++ b/templates/new/package.json
@@ -18,6 +18,7 @@
     "babel-preset-stage-0": "6.5.0",
     "babel-register": "6.14.0",
     "babel-runtime": "6.9.2",
+    "babel-traverse": "6.14.0",
     "css-loader": "0.23.1",
     "electrode-react-ssr-caching": "0.1.3",
     "file-loader": "0.8.5",


### PR DESCRIPTION
`gluestick build` commands fail for some apps, possibly due to the way babel is resolving plugins. To fix this, we move `babel-traverse` to the app so that both `babel-core` and `babel-traverse` are using the same babel instance.