### PR TITLE
Ignore any null CLI logger options

### DIFF
--- a/src/lib/server/logger.js
+++ b/src/lib/server/logger.js
@@ -20,7 +20,7 @@ export function parseLogOptions(options) {
 
   Object.entries(CLI_PARAM_MAP).forEach(e => {
     const [key, value] = e;
-    if (object.hasOwnProperty(key)) {
+    if (object.hasOwnProperty(key) && object[key] !== null) {
       result[value] = object[key];
     }
   });

--- a/test/lib/server/logger.test.js
+++ b/test/lib/server/logger.test.js
@@ -135,5 +135,21 @@ describe("lib/server/logger", () => {
       });
       expect(parseLogOptions(params)).to.deep.equal({level: "info", pretty: false});
     });
+
+    it("excludes null options", () => {
+      const params = JSON.stringify({
+        logLevel: null,
+        logPretty: false,
+      });
+      expect(parseLogOptions(params)).to.deep.equal({pretty: false});
+    });
+
+    it("excludes undefined options", () => {
+      const params = JSON.stringify({
+        logLevel: undefined, // eslint-disable-line no-undefined
+        logPretty: false,
+      });
+      expect(parseLogOptions(params)).to.deep.equal({pretty: false});
+    });
   });
 });


### PR DESCRIPTION
By default, the CLI sets the logger level to `null` if one wasn't specified: https://github.com/TrueCar/gluestick/blob/develop/src/cli.js#L89.

We should make sure that `null` options don't override valid options that were set via the app config or some other means.