### PR TITLE
remove ReactTestUtils global in test helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "optimize-css-assets-webpack-plugin": "1.3.0",
     "pino": "2.8.3",
     "pm2": "2.0.12",
-    "react-addons-test-utils": "15.1.0",
     "react-hot-loader": "1.3.0",
     "react-loader": "2.4.0",
     "react-transform-catch-errors": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "gluestick-shared": "0.4.20",
     "oy-vey": "0.7.0",
     "react": "15.1.0",
+    "react-addons-test-utils": "15.0.2",
     "react-dom": "15.1.0",
     "react-router": "2.4.1",
     "stream-to-string": "1.1.0",

--- a/src/lib/testHelperShared.js
+++ b/src/lib/testHelperShared.js
@@ -2,7 +2,6 @@ require("./projectRequireHack");
 require("babel-polyfill");
 const React = require("react");
 const ReactDOM = require("react-dom");
-const ReactTestUtils = require("react-addons-test-utils");
 global.React = React;
 global.ReactDOM = ReactDOM;
-global.TestUtils = ReactTestUtils;
+

--- a/templates/new/package.json
+++ b/templates/new/package.json
@@ -49,7 +49,6 @@
     "eslint": "3.3.1",
     "eslint-plugin-react": "6.1.1",
     "node-inspector": "0.12.8",
-    "react-addons-test-utils": "15.0.2",
     "react-hot-loader": "1.3.0",
     "react-transform-catch-errors": "1.0.2",
     "react-transform-hmr": "1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -973,20 +973,6 @@ babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.16.0, babel-te
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-traverse@6.21.0, babel-traverse@^6.18.0, babel-traverse@^6.20.0, babel-traverse@^6.21.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.21.0.tgz#69c6365804f1a4f69eb1213f85b00a818b8c21ad"
-  dependencies:
-    babel-code-frame "^6.20.0"
-    babel-messages "^6.8.0"
-    babel-runtime "^6.20.0"
-    babel-types "^6.21.0"
-    babylon "^6.11.0"
-    debug "^2.2.0"
-    globals "^9.0.0"
-    invariant "^2.2.0"
-    lodash "^4.2.0"
-
 babel-traverse@^6.0.20, babel-traverse@^6.14.0, babel-traverse@^6.16.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.18.0.tgz#5aeaa980baed2a07c8c47329cd90c3b90c80f05e"
@@ -995,6 +981,20 @@ babel-traverse@^6.0.20, babel-traverse@^6.14.0, babel-traverse@^6.16.0:
     babel-messages "^6.8.0"
     babel-runtime "^6.9.0"
     babel-types "^6.18.0"
+    babylon "^6.11.0"
+    debug "^2.2.0"
+    globals "^9.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+babel-traverse@^6.18.0, babel-traverse@^6.20.0, babel-traverse@^6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.21.0.tgz#69c6365804f1a4f69eb1213f85b00a818b8c21ad"
+  dependencies:
+    babel-code-frame "^6.20.0"
+    babel-messages "^6.8.0"
+    babel-runtime "^6.20.0"
+    babel-types "^6.21.0"
     babylon "^6.11.0"
     debug "^2.2.0"
     globals "^9.0.0"
@@ -4525,9 +4525,9 @@ rc@^1.0.1, rc@~1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~1.0.4"
 
-react-addons-test-utils@15.1.0:
-  version "15.1.0"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.1.0.tgz#ed9ab2a99ecf04acc99eeea10b308105eb3b183c"
+react-addons-test-utils@15.0.2:
+  version "15.0.2"
+  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.0.2.tgz#43457b8b42ecc28690cb18d61bedd99db248cf93"
 
 react-deep-force-update@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
No one probably uses it anymore because enzyme makes things way easier.
You can include it as a project level dependency if you want to use it.
It's no longer in it's own module but part of `react-dom` so if we
wanted to keep the global we would have to force people to update to a
newer version of React. That's okay but again, no one uses it so let's
just get rid of it