### PR TITLE
Add react-addons-test-utils as a dev dependency

### DIFF
--- a/templates/new/package.json
+++ b/templates/new/package.json
@@ -49,6 +49,7 @@
     "eslint": "3.3.1",
     "eslint-plugin-react": "6.1.1",
     "node-inspector": "0.12.8",
+    "react-addons-test-utils": "15.0.2",
     "react-hot-loader": "1.3.0",
     "react-transform-catch-errors": "1.0.2",
     "react-transform-hmr": "1.0.4",


### PR DESCRIPTION
The `gluestick test` command fails for new projects because the dependency is missing from them. This adds it for any projects and should cause an auto-upgrade for already-existing apps that are missing the dependency.