### PR TITLE
add extra debug to high-level catch, and prevent semver error

### DIFF
--- a/src/autoUpgrade/updatePackage.js
+++ b/src/autoUpgrade/updatePackage.js
@@ -213,6 +213,9 @@ export function isValidVersion (version, requiredVersion) {
 
   // Trim off carrot or other things on the version like `^3.0.1` or `>3.0.1`
   const trimmedVersion = version.replace(/^\D*/, "");
+  if (!semver.valid(trimmedVersion)){
+    return false;
+  }
 
   return semver.satisfies(trimmedVersion, requiredVersion) || semver.gte(trimmedVersion, requiredVersion);
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -233,6 +233,7 @@ async function startAll(options) {
   }
   catch (e) {
     logger.error(`During auto upgrade: ${e}`);
+    logger.debug(e.stack);
     process.exit();
   }
 


### PR DESCRIPTION
After trying to change a package version to a repo/commit-ish, ([i.e. option 'g' of npm install](https://docs.npmjs.com/cli/install#description)), gluestick's auto-update process started throwing this error:

```
vagrant@vagrant:~/react-boot-example$ gluestick start
[GlueStick] ERROR: During auto upgrade: TypeError: Invalid Version:
vagrant@vagrant:~/react-boot-example$
````
This PR also adds stack output to this error message, which shows this under the same circumstances:
```
[GlueStick] TypeError: Invalid Version:
    at new SemVer (/home/vagrant/gluestick/node_modules/semver/semver.js:293:11)
    at compare (/home/vagrant/gluestick/node_modules/semver/semver.js:566:10)
    at Function.gte (/home/vagrant/gluestick/node_modules/semver/semver.js:615:10)
    at isValidVersion (/home/vagrant/gluestick/src/autoUpgrade/updatePackage.js:220:70)
    at /home/vagrant/gluestick/src/autoUpgrade/updatePackage.js:59:12
    at fixVersionMismatch (/home/vagrant/gluestick/src/autoUpgrade/updatePackage.js:49:10)
    at _ref2$ (/home/vagrant/gluestick/src/autoUpgrade/index.js:35:9)
    at tryCatch (/home/vagrant/gluestick/node_modules/regenerator-runtime/runtime.js:62:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/home/vagrant/gluestick/node_modules/regenerator-runtime/runtime.js:336:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/home/vagrant/gluestick/node_modules/regenerator-runtime/runtime.js:95:21)
```

After this change, the package version falls into the updateable list:
```
vagrant@vagrant:~/react-boot-example$ gluestick start
? The `gluestick` CLI and your project have mismatching versions of the following modules:
{
 "gluestick-shared": {
  "required": "0.4.20",
  "project": "github:truecar/gluestick-shared#sbattin/add-body-script-tags",
  "type": "dependencies"
 }
}
Would you like to automatically update your project's dependencies to match the CLI? (Y/n)
```

...which allows choosing "no" to keep the installed version.

