### PR TITLE
proxy `npm test` to gluestick rather than an unconfigured error message

### DIFF
--- a/templates/new/package.json
+++ b/templates/new/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "gluestick start",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "gluestick test -S"
   },
   "dependencies": {
     "axios": "0.12.0",


### PR DESCRIPTION
The default npm test message is unhelpful (and incorrect).  Hopefully this increases ease of use for green users.