### PR TITLE
force posix-form for template's __$PATH__ property

### DIFF
--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -142,7 +142,7 @@ module.exports = function (command, name, options, cb) {
   }
 
   try {
-    const generatedComponentPath = destinationPath.replace(srcRoot, "").replace(".js", "").slice(1);
+    const generatedComponentPath = path.posix.join(availableCommands[command], dirname, generatedFileName);
     fs.writeFileSync(testPath, replaceName(testTemplate, generatedFileName, generatedComponentPath));
   }
   catch (e) {


### PR DESCRIPTION
Because the 3rd's argument to `replaceName` is used to create an import statement, it needs to be in posix form to avoid backslashes.  I experimented with forcing posix throughout the method, but it caused problems in various joins and string compares (on windows).