### PR TITLE
Webpack config exposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "url-loader": "0.5.7",
     "webpack-dev-middleware": "1.8.1",
     "webpack-hot-middleware": "2.12.0",
-    "webpack-isomorphic-tools": "2.5.8"
+    "webpack-isomorphic-tools": "2.5.8",
+    "webpack-merge": "2.4.0"
   },
   "peerDependencies": {},
   "devDependencies": {

--- a/src/config/getWebpackClientConfig.js
+++ b/src/config/getWebpackClientConfig.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const webpack = require("webpack");
+const merge = require("webpack-merge");
 const WebpackIsomorphicToolsPlugin = require("webpack-isomorphic-tools/plugin");
 const getAssetPath = require("../lib/getAssetPath").default;
 
@@ -11,7 +12,7 @@ const {
   additionalLoaders,
   additionalPreLoaders,
   additionalExternals,
-  additionalWebpackNodeConfig,
+  additionalWebpackConfig,
   vendor,
   plugins
 } = getWebpackAdditions();
@@ -67,7 +68,7 @@ export function getEnvironmentPlugins(isProduction) {
 export default function (appRoot, appConfigFilePath, isProduction) {
   const OUTPUT_FILE = `app${isProduction ? "-[chunkhash]" : ""}.bundle.js`;
   const devtool = process.env.DEVTOOL || "inline-source-map";
-  return {
+  const baseWebpackConfig = {
     context: appRoot,
     devtool: isProduction ? null : devtool,
     entry: {
@@ -100,7 +101,6 @@ export default function (appRoot, appConfigFilePath, isProduction) {
     },
     node: {
       fs: "empty",
-      ...additionalWebpackNodeConfig
     },
     output: {
       path: path.join(appRoot, "build"),
@@ -129,4 +129,5 @@ export default function (appRoot, appConfigFilePath, isProduction) {
     }
   };
 
+  return merge(baseWebpackConfig, additionalWebpackConfig);
 }

--- a/src/config/webpack-shared-config.js
+++ b/src/config/webpack-shared-config.js
@@ -20,7 +20,7 @@ module.exports = {
     alias: {
       "assets": path.join(process.cwd(), "assets"),
       "actions": path.join(process.cwd(), "src", "actions"),
-      // "components": path.join(process.cwd(), "src", "components"),
+      "components": path.join(process.cwd(), "src", "components"),
       "containers": path.join(process.cwd(), "src", "containers"),
       "reducers": path.join(process.cwd(), "src", "reducers"),
       ...additionalAliases

--- a/src/config/webpack-shared-config.js
+++ b/src/config/webpack-shared-config.js
@@ -20,7 +20,7 @@ module.exports = {
     alias: {
       "assets": path.join(process.cwd(), "assets"),
       "actions": path.join(process.cwd(), "src", "actions"),
-      "components": path.join(process.cwd(), "src", "components"),
+      // "components": path.join(process.cwd(), "src", "components"),
       "containers": path.join(process.cwd(), "src", "containers"),
       "reducers": path.join(process.cwd(), "src", "reducers"),
       ...additionalAliases

--- a/src/lib/getWebpackAdditions.js
+++ b/src/lib/getWebpackAdditions.js
@@ -55,10 +55,10 @@ export default function (isomorphic=false) {
     additionalExternals: {},
     additionalLoaders: [],
     additionalPreLoaders: [],
-    additionalWebpackNodeConfig: {},
+    additionalWebpackConfig: {},
     vendor: [],
     entryPoints: {},
-    plugins: []
+    plugins: [],
   };
 
   // Babel will try to resolve require statements ahead of time which will cause an error
@@ -72,7 +72,7 @@ export default function (isomorphic=false) {
       additionalExternals,
       additionalLoaders,
       additionalPreLoaders,
-      additionalWebpackNodeConfig,
+      additionalWebpackConfig,
       vendor,
       plugins,
       entryPoints
@@ -82,7 +82,7 @@ export default function (isomorphic=false) {
       additionalExternals: additionalExternals || {},
       additionalLoaders: isomorphic ? additionalLoaders : prepareUserAdditionsForWebpack(additionalLoaders),
       additionalPreLoaders: isomorphic ? additionalPreLoaders : prepareUserAdditionsForWebpack(additionalPreLoaders),
-      additionalWebpackNodeConfig: additionalWebpackNodeConfig || {},
+      additionalWebpackConfig: additionalWebpackConfig || {},
       vendor: vendor || [],
       plugins: plugins || [],
       entryPoints: entryPoints || {}

--- a/test/lib/getWebpackAdditions.test.js
+++ b/test/lib/getWebpackAdditions.test.js
@@ -38,7 +38,7 @@ describe("src/lib/getWebpackAdditions", () => {
       additionalExternals: {},
       additionalLoaders: [],
       additionalPreLoaders: [],
-      additionalWebpackNodeConfig: {},
+      additionalWebpackConfig: {},
       entryPoints: {},
       plugins: [],
       vendor: []
@@ -133,10 +133,10 @@ describe("src/lib/getWebpackAdditions", () => {
     });
   });
 
-  it("should return additionalWebpackNodeConfig when they are specified in webpack-additions", () => {
+  it("should return additionalWebpackConfig when they are specified in webpack-additions", () => {
     const additions = {
       ...defaultAdditions,
-      additionalWebpackNodeConfig: {
+      additionalWebpackConfig: {
         mish: "kin"
       }
     };


### PR DESCRIPTION
I have mixed feeling about replacing whole `webpack-additions.js` with a regular webpack config file, that's why I've exposed another hook for `additionalWebpackConfig`. 

I like the way current hooks works and if we decide to drop it completely I will require a lot of additional changes in the way GlueStick currently works, and I'm afraid it might break developer experience a bit.

Let me know what do you think about this solution. Do you like it, or should we remove it completely?
