### PR TITLE
Skip removal of build artifacts during deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ deploy:
   on:
     tags: true #only deploy tagged commits
     repo: TrueCar/gluestick #only deploy from official repo
+  skip_cleanup: true
 
 notifications:
   slack:


### PR DESCRIPTION
Travis is complaining about a missing npm module when it comes to deploy
time. It's possible that node_modules are simply being cleaned up during
the removal of build artifacts. This change skips that cleanup in hopes
that the node_modules packages are still around when needed during
deploy.

https://docs.travis-ci.com/user/deployment/#Uploading-Files

Travis build log with the issue (search for 'cross-spawn'): https://s3.amazonaws.com/archive.travis-ci.org/jobs/193923002/log.txt