### PR TITLE
support `v1` ,`v2` type branches in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ node_js:
 branches:
   only: #limit push building to develop branch and version tags to avoid double building on PRs and version tags
     - develop 
-    - /^v[\d]+\.[\d]+\.[\d]+$/
+    - /^v[\d]+(\.[\d]+\.[\d]+)?$/
 
 services:
 - docker


### PR DESCRIPTION
This will now support branches like:
```
v1
v1.1.1
v2
v0.10.4
```