### PR TITLE
#410 onEnter hook added

### DIFF
--- a/src/lib/server/RequestHandler.js
+++ b/src/lib/server/RequestHandler.js
@@ -7,9 +7,10 @@ import Oy from "oy-vey";
 import { renderToString, renderToStaticMarkup } from "react-dom/server";
 import { match, RouterContext } from "react-router";
 import {
-    runBeforeRoutes as _runBeforeRoutes,
-    prepareRoutesWithTransitionHooks,
-    ROUTE_NAME_404_NOT_FOUND
+  runBeforeRoutes as _runBeforeRoutes,
+  prepareRoutesWithTransitionHooks,
+  ROUTE_NAME_404_NOT_FOUND,
+  getHttpClient
 } from "gluestick-shared";
 
 import _streamResponse from "./streamResponse";
@@ -54,9 +55,10 @@ export function renderCachedResponse (req, res, cache=_cache, streamResponse=_st
   return false;
 }
 
-export function  matchRoute (req, getRoutes, store) {
+export function matchRoute (req, res, getRoutes, store, config) {
   return new Promise((resolve, reject) => {
-    const routes = prepareRoutesWithTransitionHooks(getRoutes(store));
+    const httpClient = getHttpClient(config.httpClient, req, res);
+    const routes = prepareRoutesWithTransitionHooks(getRoutes(store, httpClient));
     match({routes: routes, location: req.url}, (error, redirectLocation, renderProps) => {
       if (error) {
         reject(error);

--- a/src/lib/server/express-middleware.js
+++ b/src/lib/server/express-middleware.js
@@ -59,7 +59,7 @@ export default async (req, res, overrides) => {
     const {
       redirectLocation,
       renderProps
-    } = await RequestHandler.matchRoute(req, getRoutes, store);
+    } = await RequestHandler.matchRoute(req, res, getRoutes, store, config);
 
     if (redirectLocation) {
       RequestHandler.redirect(res, redirectLocation);

--- a/templates/new/src/config/.entry.js
+++ b/templates/new/src/config/.entry.js
@@ -21,7 +21,7 @@ export default class Entry extends Component {
 
     return (
       <StyleRoot radiumConfig={radiumConfig}>
-        <Root routerContext={routerContext} routes={getRoutes(store)} store={store} />
+        <Root routerContext={routerContext} routes={getRoutes(store, httpClient)} store={store} />
       </StyleRoot>
     );
   }
@@ -33,7 +33,7 @@ Entry.start = function (getRoutes, getStore, match=originalMatch, history=browse
   require("./init.browser");
 
   const newStore = getStore(httpClient);
-  match({ history, routes: getRoutes(newStore)}, (error, redirectLocation, renderProps) => {
+  match({ history, routes: getRoutes(newStore, httpClient)}, (error, redirectLocation, renderProps) => {
     const entry = (
       <Entry
         radiumConfig={{userAgent: window.navigator.userAgent}}

--- a/templates/new/src/config/routes.js
+++ b/templates/new/src/config/routes.js
@@ -7,7 +7,7 @@ import MasterLayout from "components/MasterLayout";
 import HomeApp from "containers/HomeApp";
 import NoMatchApp from "containers/NoMatchApp";
 
-export default function routes (/*store:Object*/) {
+export default function routes (/*store: Object, httpClient: Object*/) {
   return (
     <Route name="app" component={MasterLayout} path="/">
       <IndexRoute name="home" component={HomeApp} />

--- a/test/lib/server/RequestHandler.test.js
+++ b/test/lib/server/RequestHandler.test.js
@@ -77,12 +77,17 @@ describe("lib/server/RequestHandler", () => {
   });
 
   describe("matchRoute", () => {
-    let req, getRoutes, store;
+    let req, res, getRoutes, store, config;
 
     beforeEach(() => {
       req = {
-        url: "/abc123"
+        url: "/abc123",
+        headers: {
+          host: "localhost"
+        }
       };
+      res = {};
+      config = {};
 
       getRoutes = jest.fn().mockImplementation(() =>
         <Route>
@@ -100,7 +105,7 @@ describe("lib/server/RequestHandler", () => {
 
     describe("when a matching route (not a redirect) exists", () => {
       it("should return the renderProps", (done) => {
-        RequestHandler.matchRoute(req, getRoutes, store).then(({redirectLocation, renderProps}) => {
+        RequestHandler.matchRoute(req, res, getRoutes, store, config).then(({redirectLocation, renderProps}) => {
           expect(redirectLocation).toBeNull();
           expect(renderProps).toBeDefined();
           done();
@@ -111,12 +116,15 @@ describe("lib/server/RequestHandler", () => {
     describe("when a matching redirect exists", () => {
       beforeEach(() => {
         req = {
-          url: "a"
+          url: "a",
+          headers: {
+            host: "localhost"
+          }
         };
       });
 
       it("should return the redirectLocation", (done) => {
-        RequestHandler.matchRoute(req, getRoutes, store).then(({redirectLocation, renderProps}) => {
+        RequestHandler.matchRoute(req, res, getRoutes, store, config).then(({redirectLocation, renderProps}) => {
           expect(redirectLocation).not.toBeNull();
           expect(redirectLocation.pathname).toEqual("/b");
           expect(renderProps).toBeUndefined();
@@ -128,12 +136,15 @@ describe("lib/server/RequestHandler", () => {
     describe("when no matching route exists", () => {
       beforeEach(() => {
         req = {
-          url: "zzzz"
+          url: "zzzz",
+          headers: {
+            host: "localhost"
+          }
         };
       });
 
       it("should forward to the promise `catch` with an error", (done) => {
-        RequestHandler.matchRoute(req, getRoutes, store).then(({redirectLocation, renderProps}) => {
+        RequestHandler.matchRoute(req, res, getRoutes, store, config).then(({redirectLocation, renderProps}) => {
           expect(redirectLocation).toBeUndefined();
           expect(renderProps).toBeUndefined();
           done();
@@ -184,7 +195,10 @@ describe("lib/server/RequestHandler", () => {
   describe("runPreRenderHooks", () => {
     it("forwards arguments to runBeforeRoutes", () => {
       const req = {
-        url: "/abc"
+        url: "/abc",
+        headers: {
+          host: "localhost"
+        }
       };
       const renderProps = {};
       const store = {};

--- a/test/templates/new/src/config/_entry.test.js
+++ b/test/templates/new/src/config/_entry.test.js
@@ -1,9 +1,11 @@
 import React from "react";
 import { Route } from "react-router";
 import { shallow } from "enzyme";
+import { getHttpClient } from "gluestick-shared";
 
 import Entry from "../../../../../templates/new/src/config/.entry";
 
+const httpClient = getHttpClient();
 const STORE = {};
 const HISTORY = {};
 const ROUTES = (
@@ -35,7 +37,7 @@ describe("templates/new/src/config/.entry", () => {
 
   it("should build a store and the proper routes when calling Entry.start", () => {
     Entry.start(getRoutes, getStore, match, history);
-    expect(getRoutes).toBeCalledWith(getStore());
+    expect(getRoutes).toBeCalledWith(getStore(), httpClient);
   });
 });
 


### PR DESCRIPTION
Example of usage :

```
/* @flow */
import React from "react";
import { Route, IndexRoute } from "react-router";
import { ROUTE_NAME_404_NOT_FOUND } from "gluestick-shared";

import MasterLayout from "components/MasterLayout";
import HomeApp from "containers/HomeApp";
import NoMatchApp from "containers/NoMatchApp";

const loadApp = (store, httpClient) => (nextState, replace, next) => {
  httpClient.get("http://localhost:7000/api/test").then((res) => {
    store.dispatch({
      type: "LOAD_DATA",
      payload: res.data,
    });
    next();
  });
};

export default function routes (store, httpClient) {
  return (
    <Route name="app" component={MasterLayout} onEnter={loadApp(store, httpClient)} path="/">
      <IndexRoute name="home" component={HomeApp} />
      <Route name={ROUTE_NAME_404_NOT_FOUND} path="*" component={NoMatchApp}/>
    </Route>
  );
}
```
