### PR TITLE
fix `config` alias

### DIFF
--- a/src/config/webpack-isomorphic-tools-config.js
+++ b/src/config/webpack-isomorphic-tools-config.js
@@ -66,6 +66,7 @@ module.exports = {
     "components": path.join(process.cwd(), "src", "components"),
     "containers": path.join(process.cwd(), "src", "containers"),
     "reducers": path.join(process.cwd(), "src", "reducers"),
+    "config": path.join(process.cwd(), "src", "config"),
     ...additionalAliases
   },
   patch_require: true

--- a/src/config/webpack-shared-config.js
+++ b/src/config/webpack-shared-config.js
@@ -8,23 +8,17 @@ const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 
 const isProduction = process.env.NODE_ENV === "production";
-const getWebpackAdditions = require("../lib/getWebpackAdditions").default;
-const { additionalAliases } = getWebpackAdditions();
+const webpackIsomorphicToolsConfig = require("../config/webpack-isomorphic-tools-config");
 
-const webpackIsomorphicToolsPlugin = new WebpackIsomorphicToolsPlugin(require("../config/webpack-isomorphic-tools-config"))
-.development(process.env.NODE_ENV !== "production");
+const webpackIsomorphicToolsPlugin = new WebpackIsomorphicToolsPlugin(webpackIsomorphicToolsConfig)
+  .development(process.env.NODE_ENV !== "production");
 
 module.exports = {
   resolve: {
     extensions: ["", ".js", ".css", ".json"],
     alias: {
-      "assets": path.join(process.cwd(), "assets"),
-      "actions": path.join(process.cwd(), "src", "actions"),
-      "components": path.join(process.cwd(), "src", "components"),
-      "containers": path.join(process.cwd(), "src", "containers"),
-      "reducers": path.join(process.cwd(), "src", "reducers"),
-      "config": path.join(process.cwd(), "src", "config"),
-      ...additionalAliases
+      // default alias are defined in src/config/webpack-isomorphic-tools-config.js
+      ...webpackIsomorphicToolsConfig.alias
     }
   },
   loaders: [


### PR DESCRIPTION
Alias were being defined in two locations. We couldn't consolodate them
into webpack-shared-config because it imported
webpack-isomorphic-tools-config, so I consoldated them there instead.

Now there is only 1 place to update alias