### PR TITLE
Expose node_modules/.bin/ directory trough `gluestick bin` command.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -5,6 +5,7 @@ const fs = require("fs-extra");
 const path = require("path");
 const lazyMethodRequire = require("./lib/LazyMethodRequire").default(__dirname);
 
+const bin = lazyMethodRequire("./commands/bin");
 const build = lazyMethodRequire("./commands/build");
 const newApp = lazyMethodRequire("./commands/new");
 const startClient = lazyMethodRequire("./commands/start-client");
@@ -106,6 +107,13 @@ commander
   .action(checkGluestickProject)
   .action(() => build())
   .action(() => updateLastVersionUsed(currentGluestickVersion));
+
+commander
+  .command("bin")
+  .description("access dependencies bin directory")
+  .arguments("<dependency_name> [dependency_commands...]")
+  .option("-O, --options <opts>", "specify dependency options")
+  .action(bin);
 
 commander
   .command("dockerize")

--- a/src/cli.js
+++ b/src/cli.js
@@ -110,9 +110,8 @@ commander
 
 commander
   .command("bin")
+  .allowUnknownOption(true)
   .description("access dependencies bin directory")
-  .arguments("<dependency_name> [dependency_commands...]")
-  .option("-O, --options <opts>", "specify dependency options")
   .action(bin);
 
 commander

--- a/src/commands/bin.js
+++ b/src/commands/bin.js
@@ -1,29 +1,17 @@
-import { exec } from "shelljs";
+import { spawn } from "cross-spawn";
 import path from "path";
 
-const invokeDependency = (name) =>
+// Creates patch to dependency's bin directory
+const getDependencyPath = (name) =>
   path.join(__dirname, "..", "..", "node_modules", ".bin", name);
 
-const prepareExecCommand = (path, args, options) => {
-  const flattenArgs = args.reduce((prev, next) => `${prev} ${next}`, "");
-  const flattenOptions = options.reduce((prev, next) => `${prev} ${next}`, "");
-
-  return `${path} ${flattenArgs} ${flattenOptions}`;
-};
-
-const parseOptions = (options) => {
-  const isShorthand = (option) => option.length === 1;
-
-  return options.map((option) => isShorthand(option) ? `-${option}` : `--${option}`);
-};
-
-module.exports = function(dependencyName, dependencyCommands, { options }) {
-  const optionsArray = typeof options === "string" ? options.split(",") : [];
-  const execCommand = prepareExecCommand(
-    invokeDependency(dependencyName),
-    dependencyCommands,
-    parseOptions(optionsArray)
+// `opts` is array of options with Command object attached as last element
+module.exports = function(dependencyName, ...opts) {
+  spawn(
+    getDependencyPath(dependencyName),
+    opts.splice(0, opts.length - 1),
+    {
+      stdio: "inherit",
+    }
   );
-
-  exec(execCommand);
 };

--- a/src/commands/bin.js
+++ b/src/commands/bin.js
@@ -1,0 +1,29 @@
+import { exec } from "shelljs";
+import path from "path";
+
+const invokeDependency = (name) =>
+  path.join(__dirname, "..", "..", "node_modules", ".bin", name);
+
+const prepareExecCommand = (path, args, options) => {
+  const flattenArgs = args.reduce((prev, next) => `${prev} ${next}`, "");
+  const flattenOptions = options.reduce((prev, next) => `${prev} ${next}`, "");
+
+  return `${path} ${flattenArgs} ${flattenOptions}`;
+};
+
+const parseOptions = (options) => {
+  const isShorthand = (option) => option.length === 1;
+
+  return options.map((option) => isShorthand(option) ? `-${option}` : `--${option}`);
+};
+
+module.exports = function(dependencyName, dependencyCommands, { options }) {
+  const optionsArray = typeof options === "string" ? options.split(",") : [];
+  const execCommand = prepareExecCommand(
+    invokeDependency(dependencyName),
+    dependencyCommands,
+    parseOptions(optionsArray)
+  );
+
+  exec(execCommand);
+};

--- a/test/commands/bin.test.js
+++ b/test/commands/bin.test.js
@@ -30,7 +30,7 @@ describe("cli: gluestick bin", function () {
     const dependencyOptions = ["test", "-T", "--test"];
     const commanderObject = {};
 
-    bin(dependencyName, ...[...dependencyOptions, commanderObject]);
+    bin(dependencyName, ...dependencyOptions, commanderObject);
     expect(crossSpawn.spawn).toBeCalledWith(
       getDependencyPath(dependencyName), dependencyOptions, spawnOptions
     );

--- a/test/commands/bin.test.js
+++ b/test/commands/bin.test.js
@@ -1,0 +1,38 @@
+import crossSpawn from "cross-spawn";
+import path from "path";
+
+import bin from "../../src/commands/bin";
+
+const spawnOptions = { stdio: "inherit" };
+
+const getDependencyPath = (name) =>
+  path.join(__dirname, "..", "..", "node_modules", ".bin", name);
+
+
+describe("cli: gluestick bin", function () {
+  beforeAll(() => {
+    crossSpawn.spawn = jest.fn();
+  });
+
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  it("runs the dependency without any options", () => {
+    const dependencyName = "fakeDep";
+
+    bin(dependencyName);
+    expect(crossSpawn.spawn).toBeCalledWith(getDependencyPath(dependencyName), [], spawnOptions);
+  });
+
+  it("runs the dependency with specified options options", () => {
+    const dependencyName = "fakeDep";
+    const dependencyOptions = ["test", "-T", "--test"];
+    const commanderObject = {};
+
+    bin(dependencyName, ...[...dependencyOptions, commanderObject]);
+    expect(crossSpawn.spawn).toBeCalledWith(
+      getDependencyPath(dependencyName), dependencyOptions, spawnOptions
+    );
+  });
+});


### PR DESCRIPTION
Now it is possible to run `gluestick bin <dependency_name> -- <options>` from the CLI to access dependency directory.