### PR TITLE
Added options to pass to the generator

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -69,6 +69,7 @@ commander
   .description("generate a new entity from given template")
   .arguments("<name>")
   .option(...statelessFunctionalOption)
+  .option("-O, --gen-options <value>", "options to pass to the generator")
   .action(checkGluestickProject)
   .action(generate)
   .action(() => updateLastVersionUsed(currentGluestickVersion));

--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -2,15 +2,12 @@ const logger = require("../lib/cliLogger");
 const generator = require("../generator");
 
 module.exports = exports = (generatorName, entityName, options) => {
-  /**
-   * TODO: pass options from CLI to generator
-   */
   try {
-    const filteredOptions = { functional: options.functional };
+    const filteredOptions = { functional: options.functional, ...JSON.parse(options.genOptions) };
     generator({
       generatorName,
       entityName,
-      filteredOptions
+      options: filteredOptions
     }, logger);
   } catch (error) {
     logger.error(error.message);


### PR DESCRIPTION
Solves #469.

Example usage : 
`
gluestick generate <entity> <name> -O '{ "someOpt": "someValue" }'
`