### PR TITLE
Remove support for non-`v1` branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ node_js:
 branches:
   only: #limit push building to develop branch and version tags to avoid double building on PRs and version tags
     - develop 
-    - /^v[\d]+(\.[\d]+\.[\d]+)?$/
+    - v1
+    - /^v[\d]+\.[\d]+\.[\d]+$/
 
 services:
 - docker


### PR DESCRIPTION
Keep building `v1` branches and `vX.X.X` tags but remove support for other `vX` type branches.