### PR TITLE
[BUG] fix expressConfigurator

### DIFF
--- a/src/commands/start-client.js
+++ b/src/commands/start-client.js
@@ -61,10 +61,6 @@ module.exports = function (options) {
       }
     }));
 
-    if (typeof appServerConfig.expressConfigurator === "function") {
-      appServerConfig.expressConfigurator(app);
-    }
-
     app.listen(server.port, server.host, function (error) {
       if (error) {
         LOGGER.error(error);
@@ -78,3 +74,4 @@ module.exports = function (options) {
     build();
   }
 };
+

--- a/src/lib/server/index.js
+++ b/src/lib/server/index.js
@@ -6,6 +6,9 @@ import gluestickExpressMiddleware from "./express-middleware";
 import addProxies from "./addProxies";
 import path from "path";
 import serveAssets from "./serveAssets";
+import loadServerConfig from "./loadServerConfig";
+
+const appServerConfig = loadServerConfig();
 
 // Imported using `require` so that we can use `process.cwd()`
 const config = require(path.join(process.cwd(), "src", "config", "application")).default;
@@ -17,6 +20,10 @@ const port = process.env.PORT || (isProduction? 8888 : 8880);
 const app = express();
 app.use(getLoggerMiddleware());
 app.use(compression());
+
+if (typeof appServerConfig.expressConfigurator === "function") {
+  appServerConfig.expressConfigurator(app);
+}
 
 // Hook up all of the API proxies
 addProxies(app, config.proxies);


### PR DESCRIPTION
The original PR that adds the expressConfigurator added it to
start-client, but start-client only runs in development mode.

This PR simply moves it to where it belongs.

Original PR: https://github.com/TrueCar/gluestick/pull/436/files