### PR TITLE
[v1] Fix .on listener in newest node.

### DIFF
--- a/src/autoUpgrade/updatePackage.js
+++ b/src/autoUpgrade/updatePackage.js
@@ -192,11 +192,10 @@ function performModulesUpdate (mismatchedModules, done) {
   fs.writeFileSync(PROJECT_PACKAGE_LOCATION, JSON.stringify(projectPackageData, null, "  "), "utf8");
 
   cleanDeps();
-  const installProcess = installDeps();
-  installProcess.on("close", () => {
-    logger.info("node_modules have been updated.");
-    done();
-  });
+  installDeps();
+
+  logger.info("node_modules have been updated.");
+  done();
 }
 
 /**
@@ -220,4 +219,3 @@ export function isValidVersion (version, requiredVersion) {
 
   return semver.satisfies(trimmedVersion, requiredVersion) || semver.gte(trimmedVersion, requiredVersion);
 }
-

--- a/src/lib/npmDependencies.js
+++ b/src/lib/npmDependencies.js
@@ -7,11 +7,11 @@ const IS_WINDOWS = process.platform === "win32";
 
 function install () {
   if (which("yarn") !== null) {
-    return spawn.sync("yarn", {stdio: "inherit"});
+    spawn.sync("yarn", {stdio: "inherit"});
   }
 
   const postFix = IS_WINDOWS ? ".cmd" : "";
-  return spawn.sync("npm" + postFix, ["install"], {stdio: "inherit"});
+  spawn.sync("npm" + postFix, ["install"], {stdio: "inherit"});
 }
 
 function cleanSync () {


### PR DESCRIPTION
Fixes #532.

In newest `node` we cannot really attach `.on()` a listener to the synchronous method.

So in my solution, I've dropped `.on('close')` listener and let instructions from callback to be called after `installDeps()` function call.

Other solution would be to change `spawn.sync` to `spawn` call which is asynchronous, `await installDeps()` and then attach `.on('close')` listener. 

@toddw please let me know if you like the second solution more, or merge the stuff if ti's ok.

Both should behave the same.