### PR TITLE
include user extensions in file mock regex

### DIFF
--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -10,12 +10,13 @@ const TEST_MOCKS_PATH = `${path.join(__dirname, "..", "..", "test", "__mocks__")
 function getJestDefaultConfig() {
   const alias = configTools.alias;
   const images = configTools.assets.images.extensions;
+  const other = configTools.assets.other.extensions;
   const styles = configTools.assets.styles.extensions;
 
   const moduleNameMapper = {};
 
   // Handling Static Assets = mock them out
-  moduleNameMapper[`^[./a-zA-Z0-9@$_-]+\\.(${images.join("|")})$`] =`${TEST_MOCKS_PATH}/fileMock.js`;
+  moduleNameMapper[`^[./a-zA-Z0-9@$_-]+\\.(${images.join("|")}|${other.join("|")})$`] =`${TEST_MOCKS_PATH}/fileMock.js`;
   moduleNameMapper[`^[./a-zA-Z0-9@$_-]+\\.(${styles.join("|")})$`] =`${TEST_MOCKS_PATH}/styleMock.js`;
 
   // !Important: Aliases should be added at the end, see https://github.com/facebook/jest/issues/2818


### PR DESCRIPTION
GlueStick provides the ability to add app specific loaders from within an app. The extensions for these loaders exists on the `other` key inside of https://github.com/TrueCar/gluestick/blob/develop/src/config/webpack-isomorphic-tools-config.js#L59-L61

This PR will ensure file mocking continues to work on tests where one of these files was loaded.