### PR TITLE
mv … '/etc/resolv.conf': Device or resource busy

### DIFF
--- a/packages/gluestick/docker/start
+++ b/packages/gluestick/docker/start
@@ -4,6 +4,6 @@
 cat /etc/resolv.conf | sed -e '/^nameserver 127.0.0.1/d' > /tmp/resolv.conf.temp
 # Now add our own nameserver for localhost above the first nameserver
 cat /tmp/resolv.conf.temp | sed -e '0,/^nameserver .*/s/^nameserver /nameserver 127.0.0.1\n&/' > /tmp/resolv.conf.temp2
-mv /tmp/resolv.conf.temp2 /etc/resolv.conf
+cat /tmp/resolv.conf.temp2 > /etc/resolv.conf
 service dnsmasq start
 exec gluestick start -P


### PR DESCRIPTION
Work around /etc/resolve.conf being locked down by using `cat` instead