### PR TITLE
[Merge after #705] Prevent --dev option from failing start-client and start-server

### DIFF
--- a/packages/gluestick/src/commands/__tests__/utils.test.js
+++ b/packages/gluestick/src/commands/__tests__/utils.test.js
@@ -1,0 +1,6 @@
+/* @flow */
+const utils = require('../utils');
+
+test('commands/utils#filterArgs should exclude given arg from array', () => {
+  expect(utils.filterArg(['--arg1', '--arg2'], 'arg1')).toEqual(['--arg2']);
+});

--- a/packages/gluestick/src/commands/start.js
+++ b/packages/gluestick/src/commands/start.js
@@ -3,6 +3,7 @@ import type { Context } from '../types.js';
 
 const spawn = require('cross-spawn');
 const autoUpgrade = require('../autoUpgrade/autoUpgrade');
+const { filterArg } = require('./utils');
 
 type StartOptions = {
   runTests: boolean;
@@ -15,9 +16,11 @@ module.exports = async ({ config, logger }: Context, options: StartOptions) => {
   await autoUpgrade({ config, logger }, options.dev);
   const isProduction: boolean = process.env.NODE_ENV === 'production';
 
+  const rawArgs: string[] = filterArg(options.parent.rawArgs, 'dev');
+
   // Start tests only they asked us to or we are in production mode
   if (!isProduction && options.runTests) {
-    spawn('gluestick', ['test', ...options.parent.rawArgs.slice(4)], {
+    spawn('gluestick', ['test', ...rawArgs.slice(4)], {
       stdio: 'inherit',
       env: {
         ...process.env,
@@ -32,7 +35,7 @@ module.exports = async ({ config, logger }: Context, options: StartOptions) => {
       [
         './node_modules/.bin/gluestick',
         'start-client',
-        ...options.parent.rawArgs.slice(2),
+        ...rawArgs.slice(2),
       ],
       {
         stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
@@ -47,7 +50,7 @@ module.exports = async ({ config, logger }: Context, options: StartOptions) => {
         [
           './node_modules/.bin/gluestick',
           'start-server',
-          ...options.parent.rawArgs.slice(2),
+          ...rawArgs.slice(2),
         ],
         {
           stdio: 'inherit',

--- a/packages/gluestick/src/commands/utils.js
+++ b/packages/gluestick/src/commands/utils.js
@@ -1,0 +1,7 @@
+/* @flow */
+
+module.exports = {
+  filterArg: (args: string[], argToExclude: string): string[] => {
+    return args.filter(arg => arg !== `--${argToExclude}`);
+  },
+};


### PR DESCRIPTION
Must be merged after: #705 