### PR TITLE
Moving gs-shared

### DIFF
--- a/packages/gluestick/package.json
+++ b/packages/gluestick/package.json
@@ -56,7 +56,6 @@
     "express": "4.14.0",
     "extract-text-webpack-plugin": "2.0.0-beta.5",
     "fs-extra": "2.0.0",
-    "gluestick-shared": "0.4.22",
     "handlebars": "4.0.6",
     "http-proxy-middleware": "0.17.3",
     "inquirer": "3.0.1",
@@ -94,6 +93,7 @@
     "webpack-hot-middleware": "2.15.0"
   },
   "devDependencies": {
+    "gluestick-shared": "0.0.0",
     "temp": "0.8.3"
   },
   "jest": {

--- a/packages/gluestick/src/generator/templates/package.js
+++ b/packages/gluestick/src/generator/templates/package.js
@@ -34,6 +34,9 @@ module.exports = (createTemplate: CreateTemplate) => createTemplate`
     "gluestick": "${
       (args) => args.dev ? path.join('..', args.dev, 'packages/gluestick') : version
     }",
+    "gluestick-shared": "${
+      (args) => args.dev ? path.join('..', args.dev, 'packages/gluestick-shared') : version
+    }",
     "image-webpack-loader": "3.1.0",
     "normalize.css": "^5.0.0",
     "react": "15.4.2",


### PR DESCRIPTION
Moving gs-shared to devDependencies in gluestick and add gs-shared as a dependecy in project.

Solves #698