### PR TITLE
Add deployment section to circle config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,3 +21,11 @@ test:
     - npm run lint
     - npm run flow
     - npm run test-coverage
+deployment:
+  release:
+    tag: /v\d+\.\d+\.\d+.*/
+    owner: TrueCar
+    commands:
+      - echo "registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+      - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+      - npm run publish -- $CIRCLE_TAG


### PR DESCRIPTION
Before we can test it, a read-write SSH key or user key must be added to settings on Circle CI. Otherwise, commits made by lerna on Circle CI won't be pushed to the repo.