### PR TITLE
Gluestick will not generate main app with flag --skip-main

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -13,6 +13,7 @@ Available options:
 
 * `-d, --dev <path>` - Relative path from inside crated directory to development version of gluestick
 * `-n, --npm` - Use npm instead of yarn for install dependencies
+* `-s, --skip-main` - Gluestick will not generate main app
 
 ### `gluestick generate`
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
     "publish": "./scripts/deploy.js"
   },
   "dependencies": {
-    "gluestick": "file:packages/gluestick",
-    "gluestick-cli": "file:packages/gluestick-cli",
     "lerna": "2.0.0-beta.37"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "publish": "./scripts/deploy.js"
   },
   "dependencies": {
+    "gluestick": "file:packages/gluestick",
+    "gluestick-cli": "file:packages/gluestick-cli",
     "lerna": "2.0.0-beta.37"
   },
   "devDependencies": {

--- a/packages/gluestick-cli/cli.js
+++ b/packages/gluestick-cli/cli.js
@@ -22,6 +22,7 @@ commander
   .description('generate a new application')
   .arguments('<appName>')
   .option('-d, --dev <path>', 'relative path to development version of gluestick')
+  .option('-s, --skip-main', 'gluestick will not generate main app')
   .option('-n, --npm', 'use npm instead of yarn')
   .action((appName, options) => {
     newApp(appName, options, exitWithError);

--- a/packages/gluestick/generator/predefined/new.js
+++ b/packages/gluestick/generator/predefined/new.js
@@ -255,6 +255,6 @@ module.exports = (options: GeneratorOptions) => {
     },
   ];
   return {
-    entries: options.skipMain ? entries.filter(o => !o.path.includes('apps/main')) : entries
+    entries: options.skipMain ? entries.filter(o => !o.path.includes('apps/main')) : entries,
   };
 };

--- a/packages/gluestick/generator/predefined/new.js
+++ b/packages/gluestick/generator/predefined/new.js
@@ -37,8 +37,8 @@ const templateGluestickHooks = require('../templates/gluestick.hooks')(createTem
 
 const { flowVersion, flowMapper } = require('../constants');
 
-module.exports = (options: GeneratorOptions) => ({
-  entries: [
+module.exports = (options: GeneratorOptions) => {
+  const entries = [
     {
       path: '/',
       filename: '.gitignore',
@@ -253,5 +253,8 @@ module.exports = (options: GeneratorOptions) => ({
       filename: '.gitkeep',
       template: templateEmpty,
     },
-  ],
-});
+  ];
+  return {
+    entries: options.skipMain ? entries.filter(o => !o.path.includes('apps/main')) : entries
+  };
+};

--- a/packages/gluestick/src/cli/index.js
+++ b/packages/gluestick/src/cli/index.js
@@ -19,6 +19,7 @@ commander
   .description('generate a new application')
   .arguments('<appName>')
   .option('-d, --dev <path>', 'path to dev version of gluestick')
+  .option('-s, --skip-main', 'gluestick will not generate main app')
   .action((...commandArguments) => {
     execWithConfig(
       require('../commands/new'),

--- a/packages/gluestick/src/commands/new.js
+++ b/packages/gluestick/src/commands/new.js
@@ -43,7 +43,7 @@ module.exports = ({ logger }: Context, appName: string, options: Object = {}) =>
   if (currentlyInProjectFolder(process.cwd())) {
     logger.info(`${filename(appName)} is being generated...`);
 
-    generateTemplate('new', appName, logger, { dev: options.dev || null, appName });
+    generateTemplate('new', appName, logger, { dev: options.dev || null, appName, skipMain: options.skipMain });
 
     // Install necessary flow-typed definitions
     spawn.sync('./node_modules/.bin/flow-typed', ['install', `jest@${packageJSON.dependencies.jest}`], { stdio: 'inherit' });


### PR DESCRIPTION
Example usage:

`gluestick new ExampleProject --skip-main`

Solves : #864 