### PR TITLE
use helper for call hook

### DIFF
--- a/packages/gluestick/src/renderer/main.js
+++ b/packages/gluestick/src/renderer/main.js
@@ -56,7 +56,7 @@ module.exports = ({ config, logger }: Context) => {
   // Developers can add an optional hook that
   // includes script with initialization stuff.
   if (hooks.preInitServer) {
-      hooksHelper.call(hooks.preInitServer);
+    hooksHelper.call(hooks.preInitServer);
   }
 
   // Get runtime plugins that will be passed to EntryWrapper.

--- a/packages/gluestick/src/renderer/main.js
+++ b/packages/gluestick/src/renderer/main.js
@@ -55,8 +55,8 @@ module.exports = ({ config, logger }: Context) => {
 
   // Developers can add an optional hook that
   // includes script with initialization stuff.
-  if (hooks.preInitServer && typeof hooks.preInitServer === 'function') {
-    hooks.preInitServer();
+  if (hooks.preInitServer) {
+      hooksHelper.call(hooks.preInitServer);
   }
 
   // Get runtime plugins that will be passed to EntryWrapper.


### PR DESCRIPTION
It's a quick fix. 
Now after merging project hooks with plugins hooks the preInitServer is Array instead of Function.
So we can't check if it's a function before we call it