### PR TITLE
Add *.server.js functionality back in

### DIFF
--- a/packages/gluestick/src/config/webpack/mocks/serverFileMock.js
+++ b/packages/gluestick/src/config/webpack/mocks/serverFileMock.js
@@ -1,0 +1,2 @@
+module.exports = null;
+

--- a/packages/gluestick/src/config/webpack/webpack.config.client.js
+++ b/packages/gluestick/src/config/webpack/webpack.config.client.js
@@ -37,7 +37,7 @@ module.exports = (
       { silent: settings.silent, chunk_info_filename: settings.chunk_info_filename },
     ),
     // Make it so *.server.js files return null in client
-    new webpack.NormalModuleReplacementPlugin(/\.server(\.js)?$/, path.join(__dirname, "./mocks/serverFileMock.js")),
+    new webpack.NormalModuleReplacementPlugin(/\.server(\.js)?$/, path.join(__dirname, './mocks/serverFileMock.js')),
   );
   return () => config;
 };

--- a/packages/gluestick/src/config/webpack/webpack.config.client.js
+++ b/packages/gluestick/src/config/webpack/webpack.config.client.js
@@ -2,6 +2,8 @@
 
 import type { WebpackConfig, UniversalWebpackConfigurator, GSConfig, Logger } from '../../types';
 
+const webpack = require('webpack');
+const path = require('path');
 const deepClone = require('clone');
 const buildEntries = require('./buildEntries');
 const chunksPlugin = require('universal-webpack/build/chunks plugin').default;
@@ -34,6 +36,8 @@ module.exports = (
       deepClone(configuration),
       { silent: settings.silent, chunk_info_filename: settings.chunk_info_filename },
     ),
+    // Make it so *.server.js files return null in client
+    new webpack.NormalModuleReplacementPlugin(/\.server(\.js)?$/, path.join(__dirname, "./mocks/serverFileMock.js")),
   );
   return () => config;
 };


### PR DESCRIPTION
Prior to GlueStick v1 any files with the extension .server.js would be
mocked in the client bundle but used in the server bundle. This PR adds
that functionality back in.