### PR TITLE
install node-gyp globally with npm install -g instead of yarn global

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -62,11 +62,10 @@ RUN apt-get update && \
     apt-get install -y yarn  && \
     apt-get install -y --no-install-recommends git && \
     apt-get install -y --no-install-recommends $BUILD_PACKAGES && \
-    npm install gluestick-cli@$GLUESTICK_VERSION -g && \
+    npm install gluestick-cli@$GLUESTICK_VERSION node-gyp -g && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
-RUN yarn global add node-gyp
 RUN apt-get update && apt-get install dnsmasq -y
 
 ADD ./scripts/docker/dnsmasq.conf /etc/dnsmasq.conf


### PR DESCRIPTION
`node-gyp` was still not found and not present in _/usr/local/bin/_ after installing with `yarn global add`. After changing this to use `npm install -g node-gyp` instead it appears in a local test so it should resolve the issue