### PR TITLE
force pull of node:6.10-slim

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,5 +30,6 @@ deployment:
     tag: /v\d+\.\d+\.\d+.*/
     owner: TrueCar
     commands:
+      - docker pull node:6.10-slim
       - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD -e $DOCKER_EMAIL
       - BRANCH=$CIRCLE_BRANCH npm run publish -- $CIRCLE_TAG

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -55,11 +55,7 @@ ENV BUILD_PACKAGES "autoconf \
                     zlib1g-dev"
 
 
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-
 RUN apt-get update && \
-    apt-get install -y yarn  && \
     apt-get install -y --no-install-recommends git && \
     apt-get install -y --no-install-recommends $BUILD_PACKAGES && \
     npm install gluestick-cli@$GLUESTICK_VERSION node-gyp -g && \


### PR DESCRIPTION
Our builds were using a cached version of node:6.10-slim which had an
outdated version of yarn in it. Even though we were trying to install
yarn the one installed via node:6.10-slim was favored so our version was
ignorred. If we pull the latest version it will maintain the yarn
updates for us and therefore we don't need to install yarn manually
anymore.