### PR TITLE
Update flow to 0.45.0

### DIFF
--- a/packages/gluestick-generators/templates/package.js
+++ b/packages/gluestick-generators/templates/package.js
@@ -51,7 +51,7 @@ const templatePackage = createTemplate`
     "enzyme": "2.7.1",
     "eslint": "3.14.1",
     "eslint-plugin-react": "6.9.0",
-    "flow-bin": "0.44.2",
+    "flow-bin": "0.45.0",
     "flow-typed": "^2.0.0",
     "react-addons-test-utils": "15.4.2",
     "react-hot-loader": "1.3.1",

--- a/packages/gluestick/generator/constants.js
+++ b/packages/gluestick/generator/constants.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 module.exports = {
-  flowVersion: '0.44.2',
+  flowVersion: '0.45.0',
   flowMapper: {
     root: '',
     src: '/src',


### PR DESCRIPTION
`0.44.2` was published because of broken `0.44.1` on linux, however it has backed in version `0.44.1` in binary, so `0.44.2` package requires `0.44.1` version in config. Due to this mismatch, gluestick should use `0.45.0` to keep versioning consistent.