### PR TITLE
Change sort of custom moduleNameMapper for Jest

### DIFF
--- a/packages/gluestick/src/commands/test/__tests__/test.test.js
+++ b/packages/gluestick/src/commands/test/__tests__/test.test.js
@@ -164,6 +164,10 @@ describe('commands/test/test', () => {
           ['woff', 'css', 'alias1', 'alias2', 'html'].find((alias) => mapper.includes(alias)),
         ).not.toBeUndefined();
       });
+      
+      // Expect "html" (our custom mapper) to be the first regex to be evaluated
+      expect(Object.keys(jestConfig.moduleNameMapper)[0]).toEqual('html');
+      
       expect(jestConfig.roots).toEqual(['src', 'test', 'customRoot']);
       expect(jestConfig.verbose).toBeTruthy();
     });

--- a/packages/gluestick/src/commands/test/__tests__/test.test.js
+++ b/packages/gluestick/src/commands/test/__tests__/test.test.js
@@ -11,6 +11,9 @@ jest.mock('cwd/custom/package.json', () => ({
     moduleNameMapper: {
       html: 'html-mapper',
     },
+    globals: {
+      __DEV__: true,
+    },
   },
 }), { virtual: true });
 
@@ -158,18 +161,23 @@ describe('commands/test/test', () => {
       expect(jestMock.run.mock.calls.length).toBe(1);
       const jestConfig = JSON.parse(jestMock.run.mock.calls[0][0][1]);
       expect(jestMock.run.mock.calls[0][0].indexOf('--config')).toBeGreaterThan(-1);
-      expect(Object.keys(jestConfig.moduleNameMapper).length).toBe(5);
-      Object.keys(jestConfig.moduleNameMapper).forEach((mapper) => {
-        expect(
-          ['woff', 'css', 'alias1', 'alias2', 'html'].find((alias) => mapper.includes(alias)),
-        ).not.toBeUndefined();
-      });
-      
-      // Expect "html" (our custom mapper) to be the first regex to be evaluated
-      expect(Object.keys(jestConfig.moduleNameMapper)[0]).toEqual('html');
-      
+
+      // Precedence before aliases
+      const moduleMapperKeys = Object.keys(jestConfig.moduleNameMapper);
+      expect(moduleMapperKeys[0]).toEqual(
+        '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$',
+      );
+      expect(moduleMapperKeys[1]).toEqual('\\.(css|scss|sass|less)$');
+      expect(moduleMapperKeys[2]).toEqual('html');
+      expect(moduleMapperKeys[3]).toEqual('^alias1(.*)$');
+      expect(moduleMapperKeys[4]).toEqual('^alias2(.*)$');
+      expect(moduleMapperKeys.length).toBe(5);
+
       expect(jestConfig.roots).toEqual(['src', 'test', 'customRoot']);
       expect(jestConfig.verbose).toBeTruthy();
+
+      expect(Object.keys(jestConfig.globals).length).toBe(1);
+      expect(jestConfig.globals.__DEV__).toBe(true);
     });
   });
 });

--- a/packages/gluestick/src/commands/test/test.js
+++ b/packages/gluestick/src/commands/test/test.js
@@ -11,7 +11,7 @@ const JEST_PATH = `${require.resolve('jest').split('jest')[0]}.bin/jest`;
 const JEST_DEBUG_CONFIG_PATH = path.join(__dirname, 'jestEnvironmentNodeDebug.js');
 const TEST_MOCKS_PATH = `${path.join(__dirname)}`;
 
-const mergeCustomConfig = (defaultConfig: Object): Object => {
+const mergeCustomConfig = (defaultConfig: Object, aliases: Object): Object => {
   const customConfig: Object = require(path.join(process.cwd(), 'package.json')).jest;
   if (!customConfig) {
     return defaultConfig;
@@ -24,9 +24,14 @@ const mergeCustomConfig = (defaultConfig: Object): Object => {
     } else if (Object.prototype.toString.call(customConfig[curr]) !== '[object Object]') {
       value = customConfig[curr];
     } else {
-      // Custom keys will take precedence (regex)
-      // Which will also mean we won't override exact same keys
-      value = { ...customConfig[curr], ...defaultConfig[curr] };
+      value = { ...defaultConfig[curr], ...customConfig[curr] };
+      if (curr === 'moduleNameMapper') {
+        // Make sure aliases go always at the end of moduleNameMapper
+        // as Jest checks precedence inside this object
+        Object.keys(aliases).forEach((key) => {
+          value[`^${key}(.*)$`] = `${aliases[key]}$1`;
+        });
+      }
     }
     return {
       ...prev,
@@ -43,12 +48,6 @@ const getJestDefaultConfig = (aliases: Object): string[] => {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$'
   ] = `${TEST_MOCKS_PATH}/fileMock.js`;
   moduleNameMapper['\\.(css|scss|sass|less)$'] = `${TEST_MOCKS_PATH}/styleMock.js`;
-
-  // We map webpack aliases from webpack-isomorphic-tools-config file
-  // so Jest can detect them in tests too
-  Object.keys(aliases).forEach((key) => {
-    moduleNameMapper[`^${key}(.*)$`] = `${aliases[key]}$1`;
-  });
 
   const roots: string[] = ['src'];
   if (fs.existsSync(path.join(process.cwd(), 'test'))) {
@@ -71,7 +70,7 @@ const getJestDefaultConfig = (aliases: Object): string[] => {
   };
 
   const argv: string[] = [];
-  argv.push('--config', JSON.stringify(mergeCustomConfig(config)));
+  argv.push('--config', JSON.stringify(mergeCustomConfig(config, aliases)));
   return argv;
 };
 

--- a/packages/gluestick/src/commands/test/test.js
+++ b/packages/gluestick/src/commands/test/test.js
@@ -24,7 +24,9 @@ const mergeCustomConfig = (defaultConfig: Object): Object => {
     } else if (Object.prototype.toString.call(customConfig[curr]) !== '[object Object]') {
       value = customConfig[curr];
     } else {
-      value = { ...defaultConfig[curr], ...customConfig[curr] };
+      // Custom keys will take precedence (regex)
+      // Which will also mean we won't override exact same keys
+      value = { ...customConfig[curr], ...defaultConfig[curr] };
     }
     return {
       ...prev,


### PR DESCRIPTION
Fixes #1003. 

For example, in a project I wanna mock `html`:

```
 "^.+\\.html$": "<rootDir>/node_modules/gluestick/build/commands/test/fileMock.js"
```

My `html` though, can be inside of `assets`, then, as aliases are before custom params, the regex will match the alias `assets` and it will fail to mock my custom `html` map.