### PR TITLE
Add aliases to nameModuleMapper regardless whether it's in custom config

### DIFF
--- a/packages/gluestick/src/commands/test/__tests__/test.test.js
+++ b/packages/gluestick/src/commands/test/__tests__/test.test.js
@@ -16,6 +16,15 @@ jest.mock('cwd/custom/package.json', () => ({
     },
   },
 }), { virtual: true });
+jest.mock('cwd/custom2/package.json', () => ({
+  jest: {
+    roots: ['customRoot'],
+    verbose: true,
+    globals: {
+      __DEV__: true,
+    },
+  },
+}), { virtual: true });
 
 const commandApi = require('../../../__tests__/mocks/context').commandApi;
 const testCommand = require('../test');
@@ -172,6 +181,47 @@ describe('commands/test/test', () => {
       expect(moduleMapperKeys[3]).toEqual('^alias1(.*)$');
       expect(moduleMapperKeys[4]).toEqual('^alias2(.*)$');
       expect(moduleMapperKeys.length).toBe(5);
+
+      expect(jestConfig.roots).toEqual(['src', 'test', 'customRoot']);
+      expect(jestConfig.verbose).toBeTruthy();
+
+      expect(Object.keys(jestConfig.globals).length).toBe(1);
+      expect(jestConfig.globals.__DEV__).toBe(true);
+    });
+
+    it('should run jest directly with merged default and custom config (no custom moduleNameMapper)', () => {
+      path.join = () => 'cwd/custom2/package.json';
+      fs.existsSync = jest.fn(() => true);
+      testCommand(getMockedCommandApi({
+        alias1: 'path/to/alias1',
+        alias2: 'path/to/alias2',
+      }, [
+        { test: /\.js$/ },
+        { test: /\.scss$/ },
+        { test: /\.css$/ },
+        { test: /\.woff$/ },
+        { test: /\.png$/ },
+        { test: /\.ttf$/ },
+      ]), [{
+        debugTest: false,
+        parent: {
+          rawArgs: ['', '', ''],
+        },
+      }]);
+      path.join = originalPathJoin;
+      expect(jestMock.run.mock.calls.length).toBe(1);
+      const jestConfig = JSON.parse(jestMock.run.mock.calls[0][0][1]);
+      expect(jestMock.run.mock.calls[0][0].indexOf('--config')).toBeGreaterThan(-1);
+
+      // Precedence before aliases
+      const moduleMapperKeys = Object.keys(jestConfig.moduleNameMapper);
+      expect(moduleMapperKeys[0]).toEqual(
+        '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$',
+      );
+      expect(moduleMapperKeys[1]).toEqual('\\.(css|scss|sass|less)$');
+      expect(moduleMapperKeys[2]).toEqual('^alias1(.*)$');
+      expect(moduleMapperKeys[3]).toEqual('^alias2(.*)$');
+      expect(moduleMapperKeys.length).toBe(4);
 
       expect(jestConfig.roots).toEqual(['src', 'test', 'customRoot']);
       expect(jestConfig.verbose).toBeTruthy();

--- a/packages/gluestick/src/commands/test/__tests__/test.test.js
+++ b/packages/gluestick/src/commands/test/__tests__/test.test.js
@@ -17,14 +17,9 @@ jest.mock('cwd/custom/package.json', () => ({
   },
 }), { virtual: true });
 jest.mock('cwd/custom2/package.json', () => ({
-  jest: {
-    roots: ['customRoot'],
-    verbose: true,
-    globals: {
-      __DEV__: true,
-    },
-  },
+  jest: {},
 }), { virtual: true });
+
 
 const commandApi = require('../../../__tests__/mocks/context').commandApi;
 const testCommand = require('../test');
@@ -190,7 +185,7 @@ describe('commands/test/test', () => {
     });
 
     it('should run jest directly with merged default and custom config (no custom moduleNameMapper)', () => {
-      path.join = () => 'cwd/custom2/package.json';
+      path.join = () => 'cwd/empty/package.json';
       fs.existsSync = jest.fn(() => true);
       testCommand(getMockedCommandApi({
         alias1: 'path/to/alias1',
@@ -209,25 +204,13 @@ describe('commands/test/test', () => {
         },
       }]);
       path.join = originalPathJoin;
-      expect(jestMock.run.mock.calls.length).toBe(1);
       const jestConfig = JSON.parse(jestMock.run.mock.calls[0][0][1]);
-      expect(jestMock.run.mock.calls[0][0].indexOf('--config')).toBeGreaterThan(-1);
 
-      // Precedence before aliases
       const moduleMapperKeys = Object.keys(jestConfig.moduleNameMapper);
-      expect(moduleMapperKeys[0]).toEqual(
-        '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$',
-      );
-      expect(moduleMapperKeys[1]).toEqual('\\.(css|scss|sass|less)$');
+      console.log(moduleMapperKeys);
       expect(moduleMapperKeys[2]).toEqual('^alias1(.*)$');
       expect(moduleMapperKeys[3]).toEqual('^alias2(.*)$');
       expect(moduleMapperKeys.length).toBe(4);
-
-      expect(jestConfig.roots).toEqual(['src', 'test', 'customRoot']);
-      expect(jestConfig.verbose).toBeTruthy();
-
-      expect(Object.keys(jestConfig.globals).length).toBe(1);
-      expect(jestConfig.globals.__DEV__).toBe(true);
     });
   });
 });

--- a/packages/gluestick/src/commands/test/test.js
+++ b/packages/gluestick/src/commands/test/test.js
@@ -17,7 +17,7 @@ const mergeCustomConfig = (defaultConfig: Object, aliases: Object): Object => {
     return defaultConfig;
   }
 
-  return Object.keys(customConfig).reduce((prev: Object, curr: string): Object => {
+  const config = Object.keys(customConfig).reduce((prev: Object, curr: string): Object => {
     let value: any = null;
     if (Array.isArray(customConfig[curr]) && Array.isArray(defaultConfig[curr])) {
       value = defaultConfig[curr].concat(customConfig[curr]);
@@ -25,19 +25,20 @@ const mergeCustomConfig = (defaultConfig: Object, aliases: Object): Object => {
       value = customConfig[curr];
     } else {
       value = { ...defaultConfig[curr], ...customConfig[curr] };
-      if (curr === 'moduleNameMapper') {
-        // Make sure aliases go always at the end of moduleNameMapper
-        // as Jest checks precedence inside this object
-        Object.keys(aliases).forEach((key) => {
-          value[`^${key}(.*)$`] = `${aliases[key]}$1`;
-        });
-      }
     }
     return {
       ...prev,
       [curr]: value,
     };
   }, defaultConfig);
+
+  // Make sure aliases go always at the end of moduleNameMapper
+  // as Jest checks precedence inside this object
+  Object.keys(aliases).forEach((key) => {
+    config.moduleNameMapper[`^${key}(.*)$`] = `${aliases[key]}$1`;
+  });
+
+  return config;
 };
 
 const getJestDefaultConfig = (aliases: Object): string[] => {

--- a/packages/gluestick/src/commands/test/test.js
+++ b/packages/gluestick/src/commands/test/test.js
@@ -13,11 +13,8 @@ const TEST_MOCKS_PATH = `${path.join(__dirname)}`;
 
 const mergeCustomConfig = (defaultConfig: Object, aliases: Object): Object => {
   const customConfig: Object = require(path.join(process.cwd(), 'package.json')).jest;
-  if (!customConfig) {
-    return defaultConfig;
-  }
 
-  const config = Object.keys(customConfig).reduce((prev: Object, curr: string): Object => {
+  const config = Object.keys(customConfig || {}).reduce((prev: Object, curr: string): Object => {
     let value: any = null;
     if (Array.isArray(customConfig[curr]) && Array.isArray(defaultConfig[curr])) {
       value = defaultConfig[curr].concat(customConfig[curr]);


### PR DESCRIPTION
A bug slipped into `1.9.5` which resulted in `aliases` wouldn't have been added, if `nameModuleMapper` was not defined in custom Jest config.