### PR TITLE
Fixing custom scroll behavior to enable custom scroll behavior to be …

### DIFF
--- a/packages/gluestick/shared/containers/Root.js
+++ b/packages/gluestick/shared/containers/Root.js
@@ -82,9 +82,7 @@ export default class Root extends Component<DefaultProps, Props, State> {
         // If the user provides custom scroll behaviour, use it, otherwise fallback to the default
         // behaviour.
         const { useScroll: customScrollBehavior } = routes.find(route => (
-          route.useScroll &&
-          prevRouterProps &&
-          prevRouterProps.location.pathname !== location.pathname
+          route.useScroll
         )) || {};
 
         if (typeof customScrollBehavior === 'function') {


### PR DESCRIPTION
…called even if the current pathname isnt changing to allow for query string param changes and hash params as well. 