### PR TITLE
Parallel builds

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -4,6 +4,7 @@
 # radium lib problems
 .*/node_modules/radium/.*
 .*/node_modules/.*/\(test\).*\.json$
+.*/node_modules/promise/.*
 
 [include]
 

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -113,6 +113,8 @@ Available options:
 * `--server` - Build only server bundle
 * `-Z, --static` - Prepare static HTML for each entry
 * `-S, --stats` - Output webpack stats
+* `-A, --app` - Build only specific app or a group of them
+* `-D, --vendor` - Build Vendor DLL bundle
 
 ### `gluestick bin`
 

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -115,6 +115,7 @@ Available options:
 * `-S, --stats` - Output webpack stats
 * `-A, --app` - Build only specific app or a group of them
 * `-D, --vendor` - Build Vendor DLL bundle
+* `-B, --skip-if-ok` - Skip vendor DLL recompilation if the bundle is valid
 
 ### `gluestick bin`
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -109,19 +109,37 @@ To see how the default GlueStick config looks like navigate [here](https://githu
 
 # Vendoring
 
-Some packages or modules like `React` don't change frequently, so they can me vendored.
-To do so, import desired module/file in `src/vendor.js`. This file will be used as a separate entry
-for webpack.
+Some packages or modules like `React` don't change frequently, so they can be vendored.
+In order to do so, import the desired module/file in `src/vendor.js`. This file will become a separate entry
+used by either:
+* `CommonsChunkPlugin`:
+  * build vendor as a normal bundle
+  * rebuild automatically when changed
+  * preferd for code that changes _kind of_ frequently at a cost of increased build time
+  * automatic common modules extraction to vendor bundle
+  * great for smaller and medium sized projects
 
-There are 2 types of using vendor bundle:
-* `CommonsChunkPlugin` - will build vendor as a normal bundle, rebuild it automatically when changed, preferd for code that changes frequently at a cost of build time
-* `DllPlugin` - will use vendor DLL bundle, won't be rebuilded, prefered for code that change rerely
+or
 
-`CommonsChunkPlugin` is a default mode, since it doesn't require any changes to be made or commands
+* `DllPlugin`:
+  * create Dynamicaly Linked Library with vendored modules
+  * no automatic rebuilds
+  * prefered for code that change rerely
+  * shared between parallel builds
+  * great for bigger projects
+
+`CommonsChunkPlugin` is the default used plugin, since it doesn't require any changes to be made or commands
 to be run.
 
-`DllPlugin`, requires `gluestick build --vendor` command to be run, before building any other app.
-This command will create files under `build/assets/dlls`. Now if you `build` or `start` some app, it will
-use vendor DLL bundle. It can be ueeful for parallelizing builds: first you need to build vendor DLL bundle, which should
-be shared across all parallel builds. To build a single app use `gluestick build --client -A /<appName>`.
+> Please note, that `CommonsChunkPlugin` and `DllPlugin` are __not interoperable__, so it's up to you to decide
+which one suits your project better.
+
+If you want to use `DllPlugin`, you firstly need to execute `gluestick build --vendor`, before building any other app.
+This command will create files (including your vendor DLL bundle) under `build/assets/dlls`. Now if you `build` or `start` an app or whole project, it will use vendor DLL bundle.
+
+`DllPlugin` is the essential part that allows for app builds parallelisation.
+In order to split app builds you, firstly need to have vendor DLL bundle compiled and available for each
+build thread/process, then to build a single app use `gluestick build --client -A /<appName>` command.
+
 Also remember to build server/renderer bundle as well - `gluestick build --server`.
+

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -134,7 +134,7 @@ to be run.
 > Please note, that `CommonsChunkPlugin` and `DllPlugin` are __not interoperable__, so it's up to you to decide
 which one suits your project better.
 
-If you want to use `DllPlugin`, you firstly need to execute `gluestick build --vendor`, before building any other app.
+If you want to use `DllPlugin`, you firstly need to execute `gluestick build --vendor` (for production add `NODE_ENV=production` when running the command), before building any other app.
 This command will create files (including your vendor DLL bundle) under `build/assets/dlls`. Now if you `build` or `start` an app or whole project, it will use vendor DLL bundle.
 
 `DllPlugin` is the essential part that allows for app builds parallelisation.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -2,6 +2,7 @@
 
 There are few files which allows to configure GleuStick:
 * [`src/entires.json`](./Apps.md) - define entries (apps)
+* [`src/vendor.js`](#vendoring) - Define vendored modules/packages
 * [`src/gluestick.hooks.js`](./CachingAndHooks.md#hooks) - define hooks which will run on specific lifecycle events
 * [`src/gluestick.plugins.js`](./Plugins.md) - specify which plugins to use
 * [`src/gluestick.config.js`](#gluestick-config) - overwrite gluestick config
@@ -105,3 +106,22 @@ export default config => ({
 })
 ```
 To see how the default GlueStick config looks like navigate [here](https://github.com/TrueCar/gluestick/blob/staging/packages/gluestick/src/config/defaults/glueStickConfig.js).
+
+# Vendoring
+
+Some packages or modules like `React` don't change frequently, so they can me vendored.
+To do so, import desired module/file in `src/vendor.js`. This file will be used as a separate entry
+for webpack.
+
+There are 2 types of using vendor bundle:
+* `CommonsChunkPlugin` - will build vendor as a normal bundle, rebuild it automatically when changed, preferd for code that changes frequently at a cost of build time
+* `DllPlugin` - will use vendor DLL bundle, won't be rebuilded, prefered for code that change rerely
+
+`CommonsChunkPlugin` is a default mode, since it doesn't require any changes to be made or commands
+to be run.
+
+`DllPlugin`, requires `gluestick build --vendor` command to be run, before building any other app.
+This command will create files under `build/assets/dlls`. Now if you `build` or `start` some app, it will
+use vendor DLL bundle. It can be ueeful for parallelizing builds: first you need to build vendor DLL bundle, which should
+be shared across all parallel builds. To build a single app use `gluestick build --client -A /<appName>`.
+Also remember to build server/renderer bundle as well - `gluestick build --server`.

--- a/packages/gluestick-config-legacy/src/__tests__/config.test.js
+++ b/packages/gluestick-config-legacy/src/__tests__/config.test.js
@@ -77,14 +77,20 @@ describe('plugin', () => {
     expect(webpackConfig.resolve.alias).toEqual({});
     expect(webpackConfig.module.rules).toEqual(['loader']);
     expect(webpackConfig.plugins).toEqual(['plugin']);
-    expect(webpackConfig.entry.vendor).toEqual(['vendor']);
+    expect(webpackConfig.entry.vendor).toBeUndefined();
+    expect(plugin.postOverwrites.clientWebpackConfig({
+      resolve: { alias: {} },
+      module: { rules: [] },
+      plugins: [new (class CommonsChunkPlugin {})()],
+      entry: {},
+    }).entry.vendor).toEqual(['vendor']);
   });
 
   it('should overwrite unshift new value to vendor in client webpack config', () => {
     const webpackConfig = {
       resolve: { alias: {} },
       module: { rules: [] },
-      plugins: [],
+      plugins: [new (class CommonsChunkPlugin {})()],
       entry: { vendor: ['file.js'] },
     };
     plugin.postOverwrites.clientWebpackConfig(webpackConfig);
@@ -103,5 +109,13 @@ describe('plugin', () => {
     expect(webpackConfig.module.rules).toEqual(['loader']);
     expect(webpackConfig.plugins).toEqual(['plugin']);
     expect(webpackConfig.entry.vendor).toBeUndefined();
+  });
+
+  it('should overwrite vendor dll webpack config', () => {
+    expect(plugin.postOverwrites.vendorDllWebpackConfig({
+      entry: { vendor: ['entry.js'] },
+    }).entry.vendor).toEqual([
+      'vendor', 'entry.js',
+    ]);
   });
 });

--- a/packages/gluestick/src/__tests__/mocks/context.js
+++ b/packages/gluestick/src/__tests__/mocks/context.js
@@ -33,6 +33,8 @@ const gsConfig: GSConfig = {
   buildStaticPath: '',
   buildAssetsPath: '',
   buildRendererPath: '',
+  buildDllPath: '',
+  vendorSourcePath: '',
   assetsPath: '',
   sourcePath: '',
   sharedPath: '',

--- a/packages/gluestick/src/__tests__/mocks/context.js
+++ b/packages/gluestick/src/__tests__/mocks/context.js
@@ -35,6 +35,7 @@ const gsConfig: GSConfig = {
   buildRendererPath: '',
   buildDllPath: '',
   vendorSourcePath: '',
+  webpackHooksPath: '',
   assetsPath: '',
   sourcePath: '',
   sharedPath: '',

--- a/packages/gluestick/src/cli/index.js
+++ b/packages/gluestick/src/cli/index.js
@@ -92,7 +92,7 @@ commander
   .option('--client', 'gluestick builds only client bundle')
   .option('--server', 'gluestick builds only server bundle')
   .option('-D, --vendor', 'build vendor DLL bundle')
-  .option('-B, --bail-if-ok', 'bail from building vendor DLL bundle if it\'s valid')
+  .option('-B, --skip-if-ok', 'skip vendor DLL recompilation if the bundle is valid')
   .option('-Z, --static', 'prepare html file for static hosting')
   .action(safelyExecCommand((...commandArguments) => {
     require('../commands/build')(commandApi, commandArguments);

--- a/packages/gluestick/src/cli/index.js
+++ b/packages/gluestick/src/cli/index.js
@@ -87,6 +87,7 @@ commander
 commander
   .command('build')
   .description('create production asset build')
+  .option('-A, --app', '@TODO')
   .option('-S, --stats', 'create webpack stats file')
   .option('--client', 'gluestick builds only client bundle')
   .option('--server', 'gluestick builds only server bundle')

--- a/packages/gluestick/src/cli/index.js
+++ b/packages/gluestick/src/cli/index.js
@@ -87,7 +87,7 @@ commander
 commander
   .command('build')
   .description('create production asset build')
-  .option('-A, --app', '@TODO')
+  .option('-A, --app <name>', '@TODO')
   .option('-S, --stats', 'create webpack stats file')
   .option('--client', 'gluestick builds only client bundle')
   .option('--server', 'gluestick builds only server bundle')

--- a/packages/gluestick/src/cli/index.js
+++ b/packages/gluestick/src/cli/index.js
@@ -87,12 +87,12 @@ commander
 commander
   .command('build')
   .description('create production asset build')
-  .option('-A, --app <name>', '@TODO')
+  .option('-A, --app <name>', 'app or a group of apps to build')
   .option('-S, --stats', 'create webpack stats file')
   .option('--client', 'gluestick builds only client bundle')
   .option('--server', 'gluestick builds only server bundle')
-  .option('-D, --vendor', '@TODO')
-  .option('-B, --bail-if-ok', '@TODO')
+  .option('-D, --vendor', 'build vendor DLL bundle')
+  .option('-B, --bail-if-ok', 'bail from building vendor DLL bundle if it\'s valid')
   .option('-Z, --static', 'prepare html file for static hosting')
   .action(safelyExecCommand((...commandArguments) => {
     require('../commands/build')(commandApi, commandArguments);

--- a/packages/gluestick/src/cli/index.js
+++ b/packages/gluestick/src/cli/index.js
@@ -91,7 +91,8 @@ commander
   .option('-S, --stats', 'create webpack stats file')
   .option('--client', 'gluestick builds only client bundle')
   .option('--server', 'gluestick builds only server bundle')
-  .option('--vendor', '@TODO')
+  .option('-D, --vendor', '@TODO')
+  .option('-B, --bail-if-ok', '@TODO')
   .option('-Z, --static', 'prepare html file for static hosting')
   .action(safelyExecCommand((...commandArguments) => {
     require('../commands/build')(commandApi, commandArguments);

--- a/packages/gluestick/src/cli/index.js
+++ b/packages/gluestick/src/cli/index.js
@@ -91,6 +91,7 @@ commander
   .option('-S, --stats', 'create webpack stats file')
   .option('--client', 'gluestick builds only client bundle')
   .option('--server', 'gluestick builds only server bundle')
+  .option('--vendor', '@TODO')
   .option('-Z, --static', 'prepare html file for static hosting')
   .action(safelyExecCommand((...commandArguments) => {
     require('../commands/build')(commandApi, commandArguments);

--- a/packages/gluestick/src/commands/__tests__/utils.test.js
+++ b/packages/gluestick/src/commands/__tests__/utils.test.js
@@ -21,7 +21,7 @@ describe('commands/utils#clearBuildDirecotry', () => {
       buildAssetsPath: 'clientBuildPath',
     }, 'client');
     expect(rimraf.sync).toHaveBeenCalled();
-    expect(rimraf.sync.mock.calls[0][0].includes('clientBuildPath/*')).toBeTruthy();
+    expect(rimraf.sync.mock.calls[0][0].includes('clientBuildPath/!(dlls)')).toBeTruthy();
   });
 
   it('should clear server build dir', () => {

--- a/packages/gluestick/src/commands/build/__tests__/build.test.js
+++ b/packages/gluestick/src/commands/build/__tests__/build.test.js
@@ -134,6 +134,7 @@ describe('commands/build/build', () => {
   });
 
   it('should build vendor bundle only and bail', () => {
+    // $FlowIgnore vendorDll is mocked
     vendorDll.isValid.mockImplementationOnce(() => true);
     build(commandApi, [{ client: false, server: false, vendor: true, bailIfOk: true }]);
     expect(utils.clearBuildDirectory).toHaveBeenCalledTimes(0);

--- a/packages/gluestick/src/commands/build/__tests__/build.test.js
+++ b/packages/gluestick/src/commands/build/__tests__/build.test.js
@@ -3,12 +3,14 @@
 jest.mock('../../../config/webpack/progressHandler');
 jest.mock('../../utils.js');
 jest.mock('../getEntiresSnapshots');
+jest.mock('../../../config/vendorDll');
 jest.mock('../compile.js', () => jest.fn(() => Promise.resolve()));
 
 const compile = require('../compile');
 const getEntiresSnapshots = require('../getEntiresSnapshots');
 const utils = require('../../utils');
 const build = require('../build');
+const vendorDll = require('../../../config/vendorDll');
 
 const mockedCommandApi = require('../../../__tests__/mocks/context').commandApi;
 
@@ -119,5 +121,22 @@ describe('commands/build/build', () => {
     build(commandApi, [{ client: true, server: false, static: true }]);
     expect(fatalLogger)
       .toHaveBeenCalledWith('--static options must be used with both client and server build');
+  });
+
+  it('should build vendor bundle only', () => {
+    build(commandApi, [{ client: true, server: true, static: true, vendor: true }]);
+    expect(utils.clearBuildDirectory).toHaveBeenCalledTimes(1);
+    // $FlowIgnore donesn't know about jest mock
+    expect(utils.clearBuildDirectory.mock.calls[0][1]).toEqual('dlls');
+    expect(compile).toHaveBeenCalledTimes(1);
+    // $FlowIgnore donesn't know about jest mock
+    expect(compile.mock.calls[0][2]).toEqual('vendor');
+  });
+
+  it('should build vendor bundle only and bail', () => {
+    vendorDll.isValid.mockImplementationOnce(() => true);
+    build(commandApi, [{ client: false, server: false, vendor: true, bailIfOk: true }]);
+    expect(utils.clearBuildDirectory).toHaveBeenCalledTimes(0);
+    expect(compile).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/gluestick/src/commands/build/__tests__/build.test.js
+++ b/packages/gluestick/src/commands/build/__tests__/build.test.js
@@ -136,7 +136,7 @@ describe('commands/build/build', () => {
   it('should build vendor bundle only and bail', () => {
     // $FlowIgnore vendorDll is mocked
     vendorDll.isValid.mockImplementationOnce(() => true);
-    build(commandApi, [{ client: false, server: false, vendor: true, bailIfOk: true }]);
+    build(commandApi, [{ client: false, server: false, vendor: true, skipIfOk: true }]);
     expect(utils.clearBuildDirectory).toHaveBeenCalledTimes(0);
     expect(compile).toHaveBeenCalledTimes(0);
   });

--- a/packages/gluestick/src/commands/build/__tests__/compile.test.js
+++ b/packages/gluestick/src/commands/build/__tests__/compile.test.js
@@ -24,7 +24,9 @@ describe('commands/build/compile', () => {
 
   it('should resolve promise on successfull compilation', () => {
     const promise = compile(context, {}, 'test');
-    webpack.run.mock.calls[0][0](null, { toJson: jest.fn(() => ({ time: 0 })) });
+    webpack.run.mock.calls[0][0](null, { toJson: jest.fn(() => ({
+      time: 0, errors: [], warnings: [],
+    })) });
     return promise.then(() => {
       expect(context.logger.success).toHaveBeenCalledWith('Test bundle has been prepared for test in 0.00s');
     });
@@ -32,7 +34,9 @@ describe('commands/build/compile', () => {
 
   it('should create webpack stats', () => {
     const promise = compile(context, { stats: true }, 'test');
-    webpack.run.mock.calls[0][0](null, { toJson: jest.fn(() => ({ time: 0 })) });
+    webpack.run.mock.calls[0][0](null, { toJson: jest.fn(() => ({
+      time: 0,  errors: [], warnings: [],
+    })) });
     return promise.then(() => {
       expect(context.logger.success).toHaveBeenCalledWith('Test bundle has been prepared for test in 0.00s');
       // $FlowIgnore createWebpackStats is mocked

--- a/packages/gluestick/src/commands/build/build.js
+++ b/packages/gluestick/src/commands/build/build.js
@@ -17,7 +17,7 @@ type CommandOptions = {
 }
 
 module.exports = (
-  { getOptions, getLogger, getContextConfig }: CommandAPI, commandArgs: any[],
+  { getOptions, getLogger, getContextConfig, getGluestickConfig, getPlugins }: CommandAPI, commandArgs: any[],
 ): void => {
   const options: CommandOptions = getOptions(commandArgs);
   const logger: Logger = getLogger();
@@ -64,7 +64,12 @@ module.exports = (
   }
 
 
-  const config = getContextConfig(logger, webpackOptions);
+  const config: Object = options.client || options.server
+    ? getContextConfig(logger, webpackOptions)
+    : {
+      GSConfig: getGluestickConfig(logger, getPlugins(logger)),
+      webpackConfig: {} // Don't need client and server configs, since we will add vendor config
+    }
 
   const compilationErrorHandler = (type: string) => error => {
     logger.clear();

--- a/packages/gluestick/src/commands/build/build.js
+++ b/packages/gluestick/src/commands/build/build.js
@@ -72,9 +72,16 @@ module.exports = (
   };
 
   if (options.vendor) {
-    clearBuildDirectory(config.GSConfig, 'dlls');
-    config.webpackConfig.vendor = vendorDll.getConfig({ logger, config });
-    compile({ logger, config }, options, 'vendor').catch(compilationErrorHandler('vendor'));
+    const vendorDllConfig = vendorDll.getConfig({ logger, config });
+    if (!options.bailIfOk || !vendorDll.isValid({ logger, config }, vendorDllConfig)) {
+      clearBuildDirectory(config.GSConfig, 'dlls');
+      config.webpackConfig.vendor = vendorDll.getConfig({ logger, config });
+      compile({ logger, config }, options, 'vendor')
+        .then(() => {
+          vendorDll.injectValidationMetadata({ config }, vendorDllConfig);
+        })
+        .catch(compilationErrorHandler('vendor'));
+    }
   }
 
   let clientCompilation = Promise.resolve();

--- a/packages/gluestick/src/commands/build/build.js
+++ b/packages/gluestick/src/commands/build/build.js
@@ -17,22 +17,24 @@ type CommandOptions = {
 }
 
 module.exports = (
-  { getOptions, getLogger, getContextConfig, getGluestickConfig, getPlugins }: CommandAPI, commandArgs: any[],
+  { getOptions, getLogger, getContextConfig, getGluestickConfig, getPlugins }: CommandAPI,
+  commandArgs: any[],
 ): void => {
   const options: CommandOptions = getOptions(commandArgs);
   const logger: Logger = getLogger();
   logger.clear();
   logger.printCommandInfo();
 
+  const compilationErrorHandler = (type: string) => error => {
+    logger.clear();
+    logger.fatal(`${type[0].toUpperCase()}${type.slice(1)} compilation failed`, error);
+  };
+
   // If neither server not client flag is passed
   // set them both to true to compile both client and server.
   if (!options.client && !options.server) {
     options.client = true;
-    // If app is passed by default disable server compilation.
-    if (options.app) {
-      logger.info('Disabling server compilation, you can enable it by passing `--server`');
-    }
-    options.server = !options.app;
+    options.server = true;
   }
 
   // If it's vendor compilation disable everything
@@ -63,46 +65,39 @@ module.exports = (
     webpackOptions.entryOrGroupToBuild = options.app;
   }
 
-  const plugins = getPlugins(logger);
-  const config: Object = options.client || options.server
-    ? getContextConfig(logger, webpackOptions)
-    : {
+  if (options.vendor) {
+    const plugins = getPlugins(logger);
+    const config: Object = {
       GSConfig: getGluestickConfig(logger, plugins),
       webpackConfig: {} // Don't need client and server configs, since we will add vendor config
-    }
-  const compilationErrorHandler = (type: string) => error => {
-    logger.clear();
-    logger.fatal(`${type[0].toUpperCase()}${type.slice(1)} compilation failed`, error);
-  };
-
-  if (options.vendor) {
+    };
     const vendorDllConfig = vendorDll.getConfig({ logger, config }, plugins);
+    config.webpackConfig.vendor = vendorDllConfig;
     if (!options.bailIfOk || !vendorDll.isValid({ logger, config }, vendorDllConfig)) {
       clearBuildDirectory(config.GSConfig, 'dlls');
-      config.webpackConfig.vendor = vendorDllConfig;
       compile({ logger, config }, options, 'vendor')
         .then(() => {
           vendorDll.injectValidationMetadata({ config }, vendorDllConfig);
         })
         .catch(compilationErrorHandler('vendor'));
     }
-  }
+  } else {
+    const config = getContextConfig(logger, webpackOptions);
+    let clientCompilation = Promise.resolve();
+    if (options.client) {
+      clearBuildDirectory(config.GSConfig, 'client');
+      clientCompilation = compile({ logger, config }, options, 'client')
+        .catch(compilationErrorHandler('client'));
+    }
 
-  let clientCompilation = Promise.resolve();
-  if (options.client) {
-    clearBuildDirectory(config.GSConfig, 'client');
-    clientCompilation
-      .then(() => compile({ logger, config }, options, 'client'))
-      .catch(compilationErrorHandler('client'));
-  }
-
-  if (options.server) {
-    clearBuildDirectory(config.GSConfig, 'server');
-    Promise.all([
-      compile({ logger, config }, options, 'server').catch(compilationErrorHandler('server')),
-      clientCompilation,
-    ]).then(() => {
-      return options.static ? getEntiresSnapshots({ config, logger }) : Promise.resolve();
-    });
+    if (options.server) {
+      clearBuildDirectory(config.GSConfig, 'server');
+      Promise.all([
+        compile({ logger, config }, options, 'server').catch(compilationErrorHandler('server')),
+        clientCompilation,
+      ]).then(() => {
+        return options.static ? getEntiresSnapshots({ config, logger }) : Promise.resolve();
+      });
+    }
   }
 };

--- a/packages/gluestick/src/commands/build/build.js
+++ b/packages/gluestick/src/commands/build/build.js
@@ -85,7 +85,9 @@ module.exports = (
     const config = getContextConfig(logger, webpackOptions);
     let clientCompilation = Promise.resolve();
     if (options.client) {
-      clearBuildDirectory(config.GSConfig, 'client');
+      if (!options.app) {
+        clearBuildDirectory(config.GSConfig, 'client');
+      }
       clientCompilation = compile({ logger, config }, options, 'client')
         .catch(compilationErrorHandler('client'));
     }

--- a/packages/gluestick/src/commands/build/build.js
+++ b/packages/gluestick/src/commands/build/build.js
@@ -12,7 +12,7 @@ type CommandOptions = {
   server: boolean;
   static: boolean;
   vendor: boolean;
-  bailIfOk: boolean;
+  skipIfOk: boolean;
   app?: string;
 }
 
@@ -73,7 +73,7 @@ module.exports = (
     };
     const vendorDllConfig = vendorDll.getConfig({ logger, config }, plugins);
     config.webpackConfig.vendor = vendorDllConfig;
-    if (!options.bailIfOk || !vendorDll.isValid({ logger, config })) {
+    if (!options.skipIfOk || !vendorDll.isValid({ logger, config })) {
       clearBuildDirectory(config.GSConfig, 'dlls');
       compile({ logger, config }, options, 'vendor')
         .then(() => {

--- a/packages/gluestick/src/commands/build/build.js
+++ b/packages/gluestick/src/commands/build/build.js
@@ -63,24 +63,23 @@ module.exports = (
     webpackOptions.entryOrGroupToBuild = options.app;
   }
 
-
+  const plugins = getPlugins(logger);
   const config: Object = options.client || options.server
     ? getContextConfig(logger, webpackOptions)
     : {
-      GSConfig: getGluestickConfig(logger, getPlugins(logger)),
+      GSConfig: getGluestickConfig(logger, plugins),
       webpackConfig: {} // Don't need client and server configs, since we will add vendor config
     }
-
   const compilationErrorHandler = (type: string) => error => {
     logger.clear();
     logger.fatal(`${type[0].toUpperCase()}${type.slice(1)} compilation failed`, error);
   };
 
   if (options.vendor) {
-    const vendorDllConfig = vendorDll.getConfig({ logger, config });
+    const vendorDllConfig = vendorDll.getConfig({ logger, config }, plugins);
     if (!options.bailIfOk || !vendorDll.isValid({ logger, config }, vendorDllConfig)) {
       clearBuildDirectory(config.GSConfig, 'dlls');
-      config.webpackConfig.vendor = vendorDll.getConfig({ logger, config });
+      config.webpackConfig.vendor = vendorDllConfig;
       compile({ logger, config }, options, 'vendor')
         .then(() => {
           vendorDll.injectValidationMetadata({ config }, vendorDllConfig);

--- a/packages/gluestick/src/commands/build/build.js
+++ b/packages/gluestick/src/commands/build/build.js
@@ -11,9 +11,9 @@ type CommandOptions = {
   client: boolean;
   server: boolean;
   static: boolean;
+  vendor: boolean;
+  bailIfOk: boolean;
   app?: string;
-  buildVendor: boolean;
-  excludeVendor: boolean;
 }
 
 module.exports = (
@@ -57,10 +57,10 @@ module.exports = (
   let clientCompilation = Promise.resolve();
   if (options.client) {
     clearBuildDirectory(config.GSConfig, 'client');
-    if (options.buildVendor || !vendorDll.isValid()) {
-      config.webpackConfig.vendor = vendorDll.getConfig({ logger, config });
-      clientCompilation = compile({ logger, config }, options, 'vendor')
-    }
+    // if (options.buildVendor || !vendorDll.isValid()) {
+    //   config.webpackConfig.vendor = vendorDll.getConfig({ logger, config });
+    //   clientCompilation = compile({ logger, config }, options, 'vendor')
+    // }
     clientCompilation
       .then(() => compile({ logger, config }, options, 'client'))
       .catch(compilationErrorHandler('client'));

--- a/packages/gluestick/src/commands/build/build.js
+++ b/packages/gluestick/src/commands/build/build.js
@@ -73,11 +73,11 @@ module.exports = (
     };
     const vendorDllConfig = vendorDll.getConfig({ logger, config }, plugins);
     config.webpackConfig.vendor = vendorDllConfig;
-    if (!options.bailIfOk || !vendorDll.isValid({ logger, config }, vendorDllConfig)) {
+    if (!options.bailIfOk || !vendorDll.isValid({ logger, config })) {
       clearBuildDirectory(config.GSConfig, 'dlls');
       compile({ logger, config }, options, 'vendor')
         .then(() => {
-          vendorDll.injectValidationMetadata({ config }, vendorDllConfig);
+          vendorDll.injectValidationMetadata({ logger, config });
         })
         .catch(compilationErrorHandler('vendor'));
     }

--- a/packages/gluestick/src/commands/build/compile.js
+++ b/packages/gluestick/src/commands/build/compile.js
@@ -19,7 +19,7 @@ module.exports = (
 
       const buildName: string = `${buildType[0].toUpperCase()}${buildType.slice(1)}`;
 
-      const buildTime = stats.toJson({ timing: true }).time;
+      const { time: buildTime, errors, warnings } = stats.toJson({ timing: true });
 
       logger.success(
         `${buildName}${buildName === 'vendor' ? ' DLL' : ''} bundle has been prepared `
@@ -28,6 +28,9 @@ module.exports = (
 
       if (buildType === 'client' || buildType === 'vendor') {
         printWebpackStats(logger, stats);
+      } else {
+        errors.forEach(error => logger.error(error));
+        warnings.forEach(warning => logger.warn(warning));
       }
 
       if (options.stats) {

--- a/packages/gluestick/src/commands/build/compile.js
+++ b/packages/gluestick/src/commands/build/compile.js
@@ -22,11 +22,11 @@ module.exports = (
       const buildTime = stats.toJson({ timing: true }).time;
 
       logger.success(
-        `${buildName} bundle has been prepared `
+        `${buildName}${buildName === 'vendor' ? ' DLL' : ''} bundle has been prepared `
         + `for ${process.env.NODE_ENV || 'development'} in ${(buildTime / 1000).toFixed(2)}s`,
       );
 
-      if (buildType === 'client') {
+      if (buildType === 'client' || buildType === 'vendor') {
         printWebpackStats(logger, stats);
       }
 

--- a/packages/gluestick/src/commands/utils.js
+++ b/packages/gluestick/src/commands/utils.js
@@ -18,12 +18,17 @@ module.exports = {
         break;
       case 'client':
         rimraf.sync(
-          path.join(process.cwd(), gluestickConfig.buildAssetsPath, '*'),
+          path.join(process.cwd(), gluestickConfig.buildAssetsPath, '!(dlls)'),
         );
         break;
       case 'static':
         rimraf.sync(
           path.join(process.cwd(), gluestickConfig.buildStaticPath, '*'),
+        );
+        break;
+      case 'dlls':
+        rimraf.sync(
+          path.join(process.cwd(), gluestickConfig.buildDllPath, '*'),
         );
         break;
       default:

--- a/packages/gluestick/src/config/__tests__/vendorDll.test.js
+++ b/packages/gluestick/src/config/__tests__/vendorDll.test.js
@@ -1,0 +1,226 @@
+/* @flow */
+
+jest.mock('webpack', () => ({
+  DefinePlugin: class {},
+  DllPlugin: class {},
+  optimize: {
+    UglifyJsPlugin: class {},
+  },
+}));
+jest.mock('../webpack/progressHandler.js');
+jest.mock('fs');
+jest.mock('../../utils.js');
+jest.mock('./vendor-manifest.json', () => ({ name: 'vendor_1234' }), { virtual: true });
+jest.mock('./mismatch/vendor-manifest.json', () => ({
+  name: 'vendor_1234',
+  validationMetadata: {
+    entryParts: ['src/vendor.js'],
+    sourceHash: '',
+  },
+}), { virtual: true });
+jest.mock('./mismatch-deps/vendor-manifest.json', () => ({
+  name: 'vendor_1234',
+  validationMetadata: {
+    entryParts: ['src/vendor.js'],
+    sourceHash: '1c2ff7d6dff16089846b72770c41783b87aa4a55', // hash of 'import "react";'
+  },
+}), { virtual: true });
+
+
+const path = require('path');
+const fs = require('fs');
+const sha1 = require('sha1');
+const vendorDll = require('../vendorDll');
+const utils = require('../../utils');
+const commandApi = require('../../__tests__/mocks/context').commandApi;
+
+const getMockedConext = (customLoggingFns = {}, customGsConfig = {}, customWebpackConfig = {}) => ({
+  config: {
+    GSConfig: {
+      ...commandApi.getContextConfig().GSConfig,
+      ...customGsConfig,
+    },
+    webpackConfig: {
+      ...commandApi.getContextConfig().webpackConfig,
+      ...customWebpackConfig,
+    },
+  },
+  logger: {
+    ...commandApi.getLogger(),
+    ...customLoggingFns,
+  },
+});
+
+describe('config/vendorDll', () => {
+  describe('getConfig', () => {
+    beforeEach(() => {
+      // $FlowIgnore `utils.requireModule` is mocked
+      utils.requireModule.mockImplementationOnce(() => ({}));
+    });
+
+    it('should throw an error if vendor entry file does not exist', () => {
+      const fatalLogFn = jest.fn();
+      vendorDll.getConfig(
+        getMockedConext({ fatal: fatalLogFn }, { vendorSourcePath: 'non-existent' }),
+        [],
+      );
+      expect(fatalLogFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return base config', () => {
+      const baseConfig = vendorDll.getConfig(getMockedConext(), []);
+      expect(baseConfig).toBeDefined();
+      expect(baseConfig).not.toBeNull();
+    });
+
+    it('should return modifie base config', () => {
+      // $FlowIgnore `utils.requireModule` is mocked
+      utils.requireModule.mockReset();
+      // $FlowIgnore `utils.requireModule` is mocked
+      utils.requireModule.mockImplementationOnce(() => ({
+        webpackVendorDllConfig: config => ({ ...config, bail: false }),
+      }));
+      // $FlowIgnore stripped version of plugins with the essentials only
+      const modifiedConfig = vendorDll.getConfig(getMockedConext(), [{
+        postOverwrites: {
+          vendorDllWebpackConfig: config => ({ ...config, addedProperty: true }),
+        },
+      }]);
+      expect(modifiedConfig).toBeDefined();
+      expect(modifiedConfig).not.toBeNull();
+      expect(modifiedConfig.addedProperty).toBeTruthy();
+      expect(modifiedConfig.bail).toBeFalsy();
+    });
+  });
+
+  describe('injectValidationMetadata', () => {
+    it('should add `validationMetadata` object to vendor dll manifest', () => {
+      const buildDllPath = 'build/assets/dlls';
+      const vendorSourcePath = 'src/vendor.js';
+      const manifestFilename = vendorDll.manifestFilename;
+      const manifestPath = path.join(process.cwd(), buildDllPath, manifestFilename);
+      const vendorSource = 'import "react";';
+      const reactVersion = require(path.join(process.cwd(), 'package.json')).devDependencies.react;
+      fs.writeFileSync(manifestPath, '{}');
+      fs.writeFileSync(path.join(process.cwd(), vendorSourcePath), vendorSource);
+
+      vendorDll.injectValidationMetadata(getMockedConext({}, {
+        buildDllPath: 'build/assets/dlls',
+        vendorSourcePath,
+      }, {
+        vendor: {
+          entry: {
+            vendor: [vendorSourcePath],
+          },
+        },
+      }));
+
+      const { validationMetadata } = JSON.parse(fs.readFileSync(manifestPath).toString());
+      expect(validationMetadata.entryParts).toEqual([vendorSourcePath]);
+      expect(validationMetadata.sourceHash).toEqual(sha1(vendorSource));
+      expect(validationMetadata.dependenciesHash).toEqual(sha1(`react@${reactVersion}`));
+    });
+  });
+
+  describe('isValid', () => {
+    beforeEach(() => {
+      fs.unlinkSync(path.join(__dirname, 'vendor-1234.dll.js'));
+      fs.unlinkSync(path.join(__dirname, 'mismatch/vendor-1234.dll.js'));
+    });
+
+    it('should return false if manifest does not exists', () => {
+      const infoLogger = jest.fn();
+      expect(vendorDll.isValid(getMockedConext(
+        { info: infoLogger },
+        { buildDllPath: 'non-exstent' },
+      ))).toBeFalsy();
+      expect(infoLogger).toHaveBeenCalledWith('Vendor DLL manifest does not exists, recompiling');
+    });
+
+    it('should return false if vendor dll bundle does not exists', () => {
+      const infoLogger = jest.fn();
+      expect(vendorDll.isValid(getMockedConext(
+        { info: infoLogger },
+        { buildDllPath: path.relative(process.cwd(), __dirname) },
+      ))).toBeFalsy();
+      expect(infoLogger).toHaveBeenCalledWith('Vendor DLL bundle does not exists, recompiling');
+    });
+
+    it('should return false if manifest does not have validation metadata', () => {
+      const infoLogger = jest.fn();
+      fs.writeFileSync(path.join(__dirname, 'vendor-1234.dll.js'), '//');
+      expect(vendorDll.isValid(getMockedConext(
+        { info: infoLogger },
+        { buildDllPath: path.relative(process.cwd(), __dirname) },
+      ))).toBeFalsy();
+      expect(infoLogger).toHaveBeenCalledWith('Validation metadata are not defined, recompiling');
+    });
+
+    it('should return false if vendor entry parts mismatch', () => {
+      const infoLogger = jest.fn();
+      fs.writeFileSync(path.join(__dirname, 'mismatch/vendor-1234.dll.js'), '//');
+      expect(vendorDll.isValid(getMockedConext(
+        { info: infoLogger },
+        {
+          buildDllPath: path.join(
+            path.relative(process.cwd(), __dirname), 'mismatch',
+          ),
+        },
+        {
+          vendor: {
+            entry: {
+              vendor: ['react', 'src/vendor.js'],
+            },
+          },
+        },
+      ))).toBeFalsy();
+      expect(infoLogger).toHaveBeenCalledWith('Vendor DLL entry parts mismatch, recompiling');
+    });
+
+    it('should return false if source hashes mismatch', () => {
+      const infoLogger = jest.fn();
+      const vendorSourcePath = 'src/vendor.js';
+      fs.writeFileSync(path.join(__dirname, 'mismatch/vendor-1234.dll.js'), '//');
+      expect(vendorDll.isValid(getMockedConext(
+        { info: infoLogger },
+        {
+          vendorSourcePath,
+          buildDllPath: path.join(
+            path.relative(process.cwd(), __dirname), 'mismatch',
+          ),
+        },
+        {
+          vendor: {
+            entry: {
+              vendor: ['src/vendor.js'],
+            },
+          },
+        },
+      ))).toBeFalsy();
+      expect(infoLogger).toHaveBeenCalledWith('Vendor source hash mismatch, recompiling');
+    });
+
+    it('should return false if dependencies hashes mismatch', () => {
+      const infoLogger = jest.fn();
+      const vendorSourcePath = 'src/vendor.js';
+      fs.writeFileSync(path.join(__dirname, 'mismatch-deps/vendor-1234.dll.js'), '//');
+      expect(vendorDll.isValid(getMockedConext(
+        { info: infoLogger },
+        {
+          vendorSourcePath,
+          buildDllPath: path.join(
+            path.relative(process.cwd(), __dirname), 'mismatch-deps',
+          ),
+        },
+        {
+          vendor: {
+            entry: {
+              vendor: ['src/vendor.js'],
+            },
+          },
+        },
+      ))).toBeFalsy();
+      expect(infoLogger).toHaveBeenCalledWith('Vendor dependencies hash mismatch, recompiling');
+    });
+  });
+});

--- a/packages/gluestick/src/config/__tests__/vendorDll.test.js
+++ b/packages/gluestick/src/config/__tests__/vendorDll.test.js
@@ -134,7 +134,7 @@ describe('config/vendorDll', () => {
         { info: infoLogger },
         { buildDllPath: 'non-exstent' },
       ))).toBeFalsy();
-      expect(infoLogger).toHaveBeenCalledWith('Vendor DLL manifest does not exists, recompiling');
+      expect(infoLogger).toHaveBeenCalledWith('Vendor DLL manifest does not exist, recompiling');
     });
 
     it('should return false if vendor dll bundle does not exists', () => {
@@ -143,7 +143,7 @@ describe('config/vendorDll', () => {
         { info: infoLogger },
         { buildDllPath: path.relative(process.cwd(), __dirname) },
       ))).toBeFalsy();
-      expect(infoLogger).toHaveBeenCalledWith('Vendor DLL bundle does not exists, recompiling');
+      expect(infoLogger).toHaveBeenCalledWith('Vendor DLL bundle does not exist, recompiling');
     });
 
     it('should return false if manifest does not have validation metadata', () => {
@@ -153,7 +153,7 @@ describe('config/vendorDll', () => {
         { info: infoLogger },
         { buildDllPath: path.relative(process.cwd(), __dirname) },
       ))).toBeFalsy();
-      expect(infoLogger).toHaveBeenCalledWith('Validation metadata are not defined, recompiling');
+      expect(infoLogger).toHaveBeenCalledWith('Validation metadata is not defined, recompiling');
     });
 
     it('should return false if vendor entry parts mismatch', () => {

--- a/packages/gluestick/src/config/compileWebpackConfig.js
+++ b/packages/gluestick/src/config/compileWebpackConfig.js
@@ -61,7 +61,7 @@ module.exports = (
       ? {}
       : prepareEntries(gluestickConfig, entryOrGroupToBuild);
   } catch (error) {
-    logger.fatal(error.message);
+    logger.fatal(error);
   }
 
   // Get runtime plugins that will be applied to project code and bundled together.

--- a/packages/gluestick/src/config/defaults/glueStickConfig.js
+++ b/packages/gluestick/src/config/defaults/glueStickConfig.js
@@ -58,6 +58,7 @@ const config: GSConfig = {
       'src/config/caching.server.js',
       // 1.x
       'src/gluestick.config.js',
+      'src/vendor.js',
     ],
     changed: [
       'src/config/.Dockerfile',   // -> last updated in 0.2.0

--- a/packages/gluestick/src/config/defaults/glueStickConfig.js
+++ b/packages/gluestick/src/config/defaults/glueStickConfig.js
@@ -14,6 +14,7 @@ const config: GSConfig = {
   buildStaticPath: 'build/static',
   buildAssetsPath: 'build/assets',
   buildRendererPath: 'build/server',
+  buildDllPath: 'build/assets/dlls',
   assetsPath: 'assets',
   sourcePath: 'src',
   appsPath: 'apps',
@@ -38,6 +39,7 @@ const config: GSConfig = {
   hooksPath: 'src/gluestick.hooks.js',
   webpackHooksPath: 'src/webpack.hooks.js',
   cachingConfigPath: 'src/config/caching.server',
+  vendorSourcePath: 'src/vendor.js',
   nodeModulesPath: 'node_modules',
   autoUpgrade: {
     added: [

--- a/packages/gluestick/src/config/vendorDll.js
+++ b/packages/gluestick/src/config/vendorDll.js
@@ -1,13 +1,111 @@
 const path = require('path');
 const fs = require('fs');
 const webpack = require('webpack');
+const sha1 = require('sha1');
 const progressHandler = require('./webpack/progressHandler');
 
 const manifestFilename: string = 'vendor-manifest.json';
 
-const isValid = ({ logger, config }) => {
-  // @TODO
-  return false;
+const getVendorSource = config => {
+  return fs.readFileSync(path.join(process.cwd(), config.GSConfig.vendorSourcePath));
+};
+
+const getDependenciesHash = (config, vendorEntryParts, vendorSource) => {
+  const projectPackage = require(path.join(process.cwd(), 'package.json'));
+  const projectDependencies = {
+    ...projectPackage.devDependencies,
+    ...projectPackage.dependencies,
+  };
+  return sha1(
+    Object.keys(projectDependencies)
+      .filter((name) => {
+        return (
+          vendorEntryParts.find((part) => part.includes(name)) ||
+          vendorSource.includes(name)
+        );
+      })
+      .map((name) => `${name}@${projectDependencies[name]}`)
+      .join('|'),
+  );
+};
+
+const isValid = ({ logger, config }, vendorWebpackConfig) => {
+  const { buildDllPath }: { buildDllPath: string } = config.GSConfig;
+
+  // Check if manifest exists
+  const vendorDllBundleManifestPath = path.join(process.cwd(), buildDllPath, manifestFilename);
+  let manifestContent;
+  try {
+    manifestContent = require(vendorDllBundleManifestPath);
+  } catch (e) {
+    logger.info('Vendor DLL manifest does not exists, recompiling');
+    return false;
+  }
+
+  // Check if DLL bundle itself exists
+  const vendorDllBundlePath = path.join(
+    process.cwd(),
+    config.GSConfig.buildDllPath,
+    `${manifestContent.name.replace('_', '-')}.dll.js`,
+  );
+  if (!fs.existsSync(vendorDllBundlePath)) {
+    logger.info('Vendor DLL bundle does not exists, recompiling');
+    return false;
+  }
+
+  // Check if manifest has validation metadata, if doesn't, it means bundle is not valid, since
+  // we cannot perform other checks
+  if (!manifestContent.validationMetadata) {
+    logger.info('Validation metadata are not defined, recompiling');
+    return false;
+  }
+
+  // Compare elements from vendor entry array stored in manifest against config
+  // which would be used to build DLL bundle
+  const vendorEntryParts: string[] = manifestContent.validationMetadata.entryParts;
+  const currentEntryParts: string[] = vendorWebpackConfig.entry.vendor;
+  if (
+    !Array.isArray(vendorEntryParts) ||
+    vendorEntryParts.length !== currentEntryParts.length ||
+    !vendorEntryParts.every((v, i) => v === currentEntryParts[i]) ||
+    !currentEntryParts.every((v, i) => v === vendorEntryParts[i])
+  ) {
+    logger.info('Vendor DLL entry parts mismatch, recompiling');
+    return false;
+  }
+
+  // Check if vendor source file's hash is the same as stored in manifest
+  const vendorSourceHash: string = manifestContent.validationMetadata.sourceHash;
+  const vendorSource: string = getVendorSource(config);
+  if (vendorSourceHash !== sha1(vendorSource)) {
+    logger.info('Vendor source hash mismatch, recompiling');
+    return false;
+  }
+
+  // Check if dependencies version from project `package.json` has changed
+  const dependenciesHash: string = manifestContent.validationMetadata.dependenciesHash;
+  if (getDependenciesHash(config, vendorEntryParts, vendorSource) !== dependenciesHash) {
+    logger.info('Vendor dependencies hash mismatch, recompiling');
+    return false;
+  }
+
+  logger.success('Vendor DLL bundle is valid, bailing from recompilation');
+  return true;
+};
+
+const injectValidationMetadata = ({ config }, vendorWebpackConfig) => {
+  const { buildDllPath }: { vendorSourcePath: string } = config.GSConfig;
+  const manifestPath = path.join(process.cwd(), buildDllPath, manifestFilename);
+  const manifestContent = JSON.parse(fs.readFileSync(manifestPath));
+  const entryParts = vendorWebpackConfig.entry.vendor;
+  const vendorSource = getVendorSource(config);
+  const dependenciesHash = getDependenciesHash(config, entryParts, vendorSource);
+  manifestContent.validationMetadata = {
+    entryParts,
+    sourceHash: sha1(vendorSource),
+    dependenciesHash,
+  };
+  fs.writeFileSync(manifestPath, JSON.stringify(manifestContent, null, '  '));
 };
 
 const getConfig = ({ logger, config }) => {
@@ -18,7 +116,7 @@ const getConfig = ({ logger, config }) => {
   return {
     context: appRoot,
     resolve: {
-      extensions: ['.js', '.css', '.json'],
+      extensions: ['.js', '.json'],
     },
     entry: {
       vendor: [path.join(process.cwd(), vendorSourcePath)],
@@ -63,5 +161,6 @@ module.exports = {
   isValid,
   getConfig,
   getBundleName,
+  injectValidationMetadata,
   manifestFilename,
 };

--- a/packages/gluestick/src/config/vendorDll.js
+++ b/packages/gluestick/src/config/vendorDll.js
@@ -160,7 +160,7 @@ const getConfig = ({ logger, config }: CLIContext, plugins: ConfigPlugin[]): Web
     },
     plugins: [
       new webpack.DefinePlugin({
-        'process.env.NODE_ENV': JSON.stringify('production'),
+        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
       }),
       new webpack.DllPlugin({
         // The manifest we will use to reference the libraries

--- a/packages/gluestick/src/config/vendorDll.js
+++ b/packages/gluestick/src/config/vendorDll.js
@@ -174,6 +174,7 @@ const getConfig = ({ logger, config }: CLIContext, plugins: ConfigPlugin[]): Web
   };
 
   if (process.env.NODE_ENV === 'production') {
+    // $FlowIgnore `plugins` is an Array
     baseConfig.plugins.push(
       new webpack.optimize.UglifyJsPlugin({
         compress: {

--- a/packages/gluestick/src/config/vendorDll.js
+++ b/packages/gluestick/src/config/vendorDll.js
@@ -1,0 +1,34 @@
+const path = require('path');
+const webpack = require('webpack');
+
+const isValid = ({ logger, config }) => {
+  // @TODO
+  return false;
+};
+
+const getConfig = ({ logger, config }) => {
+  // do we need loaders??
+  return {
+    extensions: ['.js', '.css', '.json'],
+    entry: {
+      vendor: [path.join(process.cwd(), 'src/vendor.js')],
+    },
+    output: {
+      path: path.join(process.cwd(), 'build/assets'),
+      filename: '[name].dll.js',
+      library: '[name]_[hash]',
+    },
+    plugins: [
+      new webpack.DllPlugin({
+        // The manifest we will use to reference the libraries
+        path: path.join('vendor', '[name]-manifest.json'),
+        name: '[name]-[hash]',
+      }),
+    ],
+  };
+};
+
+module.exports = {
+  isValid,
+  getConfig,
+};

--- a/packages/gluestick/src/config/vendorDll.js
+++ b/packages/gluestick/src/config/vendorDll.js
@@ -140,7 +140,7 @@ const getConfig = ({ logger, config }: CLIContext, plugins: ConfigPlugin[]): Web
   const vendorSourcePath: string = path.join(process.cwd(), config.GSConfig.vendorSourcePath);
   if (!fs.existsSync(vendorSourcePath)) {
     logger.fatal(
-      `${vendorSourcePath} does not exists, consider running 'gluestick auto-upgrade' `
+      `${vendorSourcePath} does not exist, consider running 'gluestick auto-upgrade' `
       + 'or create the file manually',
     );
   }

--- a/packages/gluestick/src/config/vendorDll.js
+++ b/packages/gluestick/src/config/vendorDll.js
@@ -55,7 +55,7 @@ const isValid = ({ logger, config }: CLIContext): boolean => {
   try {
     manifestContent = require(vendorDllBundleManifestPath);
   } catch (e) {
-    logger.info('Vendor DLL manifest does not exists, recompiling');
+    logger.info('Vendor DLL manifest does not exist, recompiling');
     return false;
   }
 
@@ -66,14 +66,14 @@ const isValid = ({ logger, config }: CLIContext): boolean => {
     `${manifestContent.name.replace('_', '-')}.dll.js`,
   );
   if (!fs.existsSync(vendorDllBundlePath)) {
-    logger.info('Vendor DLL bundle does not exists, recompiling');
+    logger.info('Vendor DLL bundle does not exist, recompiling');
     return false;
   }
 
   // Check if manifest has validation metadata, if doesn't, it means bundle is not valid, since
   // we cannot perform other checks
   if (!manifestContent.validationMetadata) {
-    logger.info('Validation metadata are not defined, recompiling');
+    logger.info('Validation metadata is not defined, recompiling');
     return false;
   }
 
@@ -107,7 +107,7 @@ const isValid = ({ logger, config }: CLIContext): boolean => {
     return false;
   }
 
-  logger.success('Vendor DLL bundle is valid, bailing from recompilation');
+  logger.success('Vendor DLL bundle is valid, skipping recompilation');
   return true;
 };
 

--- a/packages/gluestick/src/config/vendorDll.js
+++ b/packages/gluestick/src/config/vendorDll.js
@@ -138,7 +138,6 @@ const getConfig = ({ logger, config }: CLIContext, plugins: ConfigPlugin[]): Web
   const appRoot: string = process.cwd();
   const buildDllPath: string = path.join(process.cwd(), config.GSConfig.buildDllPath);
   const vendorSourcePath: string = path.join(process.cwd(), config.GSConfig.vendorSourcePath);
-
   if (!fs.existsSync(vendorSourcePath)) {
     logger.fatal(
       `${vendorSourcePath} does not exists, consider running 'gluestick auto-upgrade' `

--- a/packages/gluestick/src/config/vendorDll.js
+++ b/packages/gluestick/src/config/vendorDll.js
@@ -146,6 +146,7 @@ const getConfig = ({ logger, config }: CLIContext, plugins: ConfigPlugin[]): Web
   }
 
   const baseConfig: WebpackConfig = {
+    devtool: 'cheap-source-map',
     context: appRoot,
     resolve: {
       extensions: ['.js', '.json'],
@@ -167,15 +168,20 @@ const getConfig = ({ logger, config }: CLIContext, plugins: ConfigPlugin[]): Web
         path: path.join(buildDllPath, manifestFilename.replace('vendor', '[name]')),
         name: '[name]_[hash]',
       }),
+      progressHandler(logger, 'vendor'),
+    ],
+    bail: true,
+  };
+
+  if (process.env.NODE_ENV === 'production') {
+    baseConfig.plugins.push(
       new webpack.optimize.UglifyJsPlugin({
         compress: {
           warnings: false,
         },
       }),
-      progressHandler(logger, 'vendor'),
-    ],
-    bail: true,
-  };
+    );
+  }
 
   const intermediateConfig: WebpackConfig = plugins
     .filter((plugin: ConfigPlugin): boolean => !!plugin.postOverwrites.vendorDllWebpackConfig)

--- a/packages/gluestick/src/config/vendorDll.js
+++ b/packages/gluestick/src/config/vendorDll.js
@@ -2,6 +2,8 @@ const path = require('path');
 const fs = require('fs');
 const webpack = require('webpack');
 
+const manifestFilename: string = 'vendor-manifest.json';
+
 const isValid = ({ logger, config }) => {
   // @TODO
   return false;
@@ -31,7 +33,7 @@ const getConfig = ({ logger, config }) => {
       }),
       new webpack.DllPlugin({
         // The manifest we will use to reference the libraries
-        path: path.join(buildDllPath, '[name]-manifest.json'),
+        path: path.join(buildDllPath, manifestFilename.replace('vendor', '[name]')),
         name: '[name]_[hash]',
       }),
       new webpack.optimize.UglifyJsPlugin({
@@ -46,14 +48,18 @@ const getConfig = ({ logger, config }) => {
 
 const getBundleName = ({ config }): string => {
   const { buildDllPath } = config.GSConfig;
-  const manifestPath: string = path.join(process.cwd(), buildDllPath, 'vendor-manifest.json');
+  const manifestPath: string = path.join(process.cwd(), buildDllPath, manifestFilename);
   // Can't require it, because it will throw an error on server
   const { name } = JSON.parse(fs.readFileSync(manifestPath));
-  return `/assets/dlls/${name.replace('_', '-')}.dll.js`;
+  // It will be used by server thus compiled by webpack, so then we have access to
+  // webpack's public path
+  const publicPath: string = __webpack_public_path__ || '/assets/'; // eslint-disable-line
+  return `${publicPath}dlls/${name.replace('_', '-')}.dll.js`;
 };
 
 module.exports = {
   isValid,
   getConfig,
   getBundleName,
+  manifestFilename,
 };

--- a/packages/gluestick/src/config/vendorDll.js
+++ b/packages/gluestick/src/config/vendorDll.js
@@ -5,6 +5,8 @@ const sha1 = require('sha1');
 const progressHandler = require('./webpack/progressHandler');
 
 const manifestFilename: string = 'vendor-manifest.json';
+// Need to set env variable, so that server can access it
+process.env.GS_VENDOR_MANIFEST_FILENAME = manifestFilename;
 
 const getVendorSource = config => {
   return fs.readFileSync(path.join(process.cwd(), config.GSConfig.vendorSourcePath));
@@ -146,21 +148,9 @@ const getConfig = ({ logger, config }) => {
   };
 };
 
-const getBundleName = ({ config }): string => {
-  const { buildDllPath } = config.GSConfig;
-  const manifestPath: string = path.join(process.cwd(), buildDllPath, manifestFilename);
-  // Can't require it, because it will throw an error on server
-  const { name } = JSON.parse(fs.readFileSync(manifestPath));
-  // It will be used by server thus compiled by webpack, so then we have access to
-  // webpack's public path
-  const publicPath: string = __webpack_public_path__ || '/assets/'; // eslint-disable-line
-  return `${publicPath}dlls/${name.replace('_', '-')}.dll.js`;
-};
-
 module.exports = {
   isValid,
   getConfig,
-  getBundleName,
   injectValidationMetadata,
   manifestFilename,
 };

--- a/packages/gluestick/src/config/vendorDll.js
+++ b/packages/gluestick/src/config/vendorDll.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const webpack = require('webpack');
+const progressHandler = require('./webpack/progressHandler');
 
 const manifestFilename: string = 'vendor-manifest.json';
 
@@ -41,6 +42,7 @@ const getConfig = ({ logger, config }) => {
           warnings: false,
         },
       }),
+      progressHandler(logger, 'vendor'),
     ],
     bail: true,
   };

--- a/packages/gluestick/src/config/webpack/ChunksPlugin.js
+++ b/packages/gluestick/src/config/webpack/ChunksPlugin.js
@@ -1,0 +1,115 @@
+/* @flow */
+import type { WebpackConfig } from '../../types';
+
+const path = require('path');
+const fs = require('fs');
+
+type ChunksInfo = {
+  javascript: {
+    [key: ?string]: string;
+  },
+  styles: {
+    [key: ?string]: string;
+  }
+}
+
+const chunkInfoFilePath = (
+  webpackConfiguration: WebpackConfig,
+  chunkInfoFilename?: string = 'webpack-chunks.json',
+): string => {
+  // $FlowIgnore `output` is a Object
+  return path.join(webpackConfiguration.output.path, chunkInfoFilename);
+};
+
+const getChunksInfoBody = (json: Object, publicPath: string): ChunksInfo => {
+  const assetsByChunk: Object = json.assetsByChunkName;
+
+  const assetsChunks: ChunksInfo = {
+    javascript: {},
+    styles: {},
+  };
+
+  // gets asset paths by name and extension of their chunk
+  const getAssets = (chunkName: string, extension: string): string[] => {
+    let chunk: string | string[] = json.assetsByChunkName[chunkName];
+
+    // a chunk could be a string or an array, so make sure it is an array
+    if (!Array.isArray(chunk)) {
+      chunk = [chunk];
+    }
+
+    return chunk
+      .filter(name => path.extname(name) === `.${extension}`)
+      .map(name => `${publicPath}${name}`);
+  };
+
+  Object.keys(assetsByChunk).forEach((name: string) => {
+    // The second asset is usually a source map
+    const jsAsset: string = getAssets(name, 'js')[0];
+
+    if (jsAsset) {
+      assetsChunks.javascript[name] = jsAsset;
+    }
+
+    const styleAsset: string = getAssets(name, 'css')[0];
+
+    if (styleAsset) {
+      assetsChunks.styles[name] = styleAsset;
+    }
+  });
+
+  return assetsChunks;
+};
+
+module.exports = class ChunksPlugin {
+  configuration: WebpackConfig;
+  options: {
+    appendChunkInfo?: boolean;
+    chunkInfoFilename?: string;
+  }
+
+  constructor(configuration: WebpackConfig, options: Object = {}) {
+    // Webpack configuration from `compiler` has wrong `output.path`,
+    // so it has to be passed when constructing an instance
+    this.configuration = configuration;
+    this.options = options;
+  }
+
+  apply(compiler: Object): void {
+    const outputFilePath: string = chunkInfoFilePath(
+      this.configuration, this.options.chunkInfoFilename,
+    );
+
+    compiler.plugin('done', (stats: Object) => {
+      const json: Object = stats.toJson({
+        context: this.configuration.context || process.cwd(),
+        chunkModules: true,
+      });
+
+      // $FlowIgnore `devServer.publicPath` is a string
+      const publicPath: string = (
+        process.env.NODE_ENV !== 'production' &&
+        this.configuration.devServer &&
+        this.configuration.devServer.publicPath
+      ) ? this.configuration.devServer.publicPath : json.publicPath;
+
+      const chunksInfoFile: ChunksInfo = getChunksInfoBody(json, publicPath);
+
+      let outputChunkInfo: ChunksInfo = chunksInfoFile;
+      if (this.options.appendChunkInfo && fs.existsSync(outputFilePath)) {
+        const existingChunkInfoFile = require(outputFilePath);
+        outputChunkInfo = {
+          javascript: {
+            ...existingChunkInfoFile.javascript,
+            ...chunksInfoFile.javascript,
+          },
+          styles: {
+            ...existingChunkInfoFile.styles,
+            ...chunksInfoFile.styles,
+          },
+        };
+      }
+      fs.writeFileSync(outputFilePath, JSON.stringify(outputChunkInfo, null, '  '));
+    });
+  }
+};

--- a/packages/gluestick/src/config/webpack/__tests__/ChunksPlugin.test.js
+++ b/packages/gluestick/src/config/webpack/__tests__/ChunksPlugin.test.js
@@ -1,0 +1,72 @@
+jest.mock('fs');
+jest.mock('path/webpack-chunks', () => ({
+  javascript: {
+    main: 'publicPath/main.js',
+    profile: 'publicPath/profile.js',
+  },
+  styles: {
+    main: 'publicPath/main.css',
+  },
+}), { virtual: true });
+
+const fs = require('fs');
+const ChunksPlugin = require('../ChunksPlugin');
+
+describe('ChunksPlugin', () => {
+  it('should create chunks info file', () => {
+    const plugin = new ChunksPlugin({ output: { path: 'path' } }, {});
+    const doneTap = jest.fn();
+    plugin.apply({ plugin: doneTap });
+    expect(doneTap).toHaveBeenCalled();
+    doneTap.mock.calls[0][1]({
+      toJson: () => ({
+        publicPath: 'publicPath/',
+        assetsByChunkName: {
+          main: ['main.js', 'main.css'],
+          profile: ['profile.js'],
+        },
+      }),
+    });
+    expect(JSON.parse(fs.readFileSync('path/webpack-chunks.json'))).toEqual({
+      javascript: {
+        main: 'publicPath/main.js',
+        profile: 'publicPath/profile.js',
+      },
+      styles: {
+        main: 'publicPath/main.css',
+      },
+    });
+    fs.unlinkSync('path/webpack-chunks.json');
+  });
+
+  it('should append new chunks info data to file', () => {
+    fs.writeFileSync('path/webpack-chunks', '//');
+    const plugin = new ChunksPlugin(
+      { output: { path: 'path' } },
+      { appendChunkInfo: true, chunkInfoFilename: 'webpack-chunks' },
+    );
+    const doneTap = jest.fn();
+    plugin.apply({ plugin: doneTap });
+    expect(doneTap).toHaveBeenCalled();
+    doneTap.mock.calls[0][1]({
+      toJson: () => ({
+        publicPath: 'publicPath/',
+        assetsByChunkName: {
+          home: ['home.js', 'home.css'],
+        },
+      }),
+    });
+    expect(JSON.parse(fs.readFileSync('path/webpack-chunks'))).toEqual({
+      javascript: {
+        main: 'publicPath/main.js',
+        profile: 'publicPath/profile.js',
+        home: 'publicPath/home.js',
+      },
+      styles: {
+        main: 'publicPath/main.css',
+        home: 'publicPath/home.css',
+      },
+    });
+    fs.unlinkSync('path/webpack-chunks.json');
+  });
+});

--- a/packages/gluestick/src/config/webpack/progressHandler.js
+++ b/packages/gluestick/src/config/webpack/progressHandler.js
@@ -26,6 +26,12 @@ const compilations = {
     status: 'init',
     postprocessing: '',
   },
+  vendor: {
+    muted: false,
+    forceMute: false,
+    status: 'init',
+    postprocessing: '',
+  },
 };
 
 /**

--- a/packages/gluestick/src/config/webpack/webpack.config.client.js
+++ b/packages/gluestick/src/config/webpack/webpack.config.client.js
@@ -17,6 +17,7 @@ const buildEntries = require('./buildEntries');
 const progressHandler = require('./progressHandler');
 const chunksPlugin = require('universal-webpack/build/chunks plugin').default;
 const { updateBabelLoaderConfig } = require('./utils');
+const { manifestFilename } = require('../vendorDll');
 
 module.exports = (
   logger: Logger,
@@ -62,7 +63,7 @@ module.exports = (
   );
 
   // If vendor Dll bundle exists, use it otherwise fallback to CommonsChunkPlugin.
-  const vendorDllManifestPath = path.join(process.cwd(), gluestickConfig.buildDllPath, 'vendor-manifest.json');
+  const vendorDllManifestPath = path.join(process.cwd(), gluestickConfig.buildDllPath, manifestFilename);
   if (fs.existsSync(vendorDllManifestPath)) {
     config.plugins.unshift(
       new webpack.DllReferencePlugin({

--- a/packages/gluestick/src/config/webpack/webpack.config.client.js
+++ b/packages/gluestick/src/config/webpack/webpack.config.client.js
@@ -52,10 +52,6 @@ module.exports = (
     };
   });
   config.plugins.push(
-    new chunksPlugin(
-      deepClone(configuration),
-      { silent: settings.silent, chunk_info_filename: settings.chunk_info_filename },
-    ),
     // Make it so *.server.js files return null in client
     new webpack.NormalModuleReplacementPlugin(/\.server(\.js)?$/, path.join(__dirname, './mocks/serverFileMock.js')),
     progressHandler(logger, 'client'),

--- a/packages/gluestick/src/config/webpack/webpack.config.client.js
+++ b/packages/gluestick/src/config/webpack/webpack.config.client.js
@@ -15,7 +15,7 @@ const fs = require('fs');
 const DuplicatePackageChecker = require('duplicate-package-checker-webpack-plugin');
 const buildEntries = require('./buildEntries');
 const progressHandler = require('./progressHandler');
-const chunksPlugin = require('universal-webpack/build/chunks plugin').default;
+const ChunksPlugin = require('./ChunksPlugin');
 const { updateBabelLoaderConfig } = require('./utils');
 const { manifestFilename } = require('../vendorDll');
 
@@ -52,10 +52,6 @@ module.exports = (
     };
   });
   config.plugins.push(
-    new chunksPlugin(
-      deepClone(configuration),
-      { silent: settings.silent, chunk_info_filename: settings.chunk_info_filename },
-    ),
     // Make it so *.server.js files return null in client
     new webpack.NormalModuleReplacementPlugin(/\.server(\.js)?$/, path.join(__dirname, './mocks/serverFileMock.js')),
     progressHandler(logger, 'client'),
@@ -74,6 +70,7 @@ module.exports = (
         manifest: require(vendorDllManifestPath),
       }),
     );
+    config.plugins.push(new ChunksPlugin(deepClone(configuration), { appendChunkInfo: true }));
   } else {
     logger.info('Vendor DLL bundle not found, using CommonsChunkPlugin');
     config.plugins.push(
@@ -81,6 +78,7 @@ module.exports = (
         name: 'vendor',
         filename: `vendor${process.env.NODE_ENV === 'production' ? '-[hash]' : ''}.bundle.js`,
       }),
+      new ChunksPlugin(deepClone(configuration)),
     );
   }
 

--- a/packages/gluestick/src/config/webpack/webpack.config.client.js
+++ b/packages/gluestick/src/config/webpack/webpack.config.client.js
@@ -63,8 +63,11 @@ module.exports = (
   );
 
   // If vendor Dll bundle exists, use it otherwise fallback to CommonsChunkPlugin.
-  const vendorDllManifestPath = path.join(process.cwd(), gluestickConfig.buildDllPath, manifestFilename);
+  const vendorDllManifestPath: string = path.join(
+    process.cwd(), gluestickConfig.buildDllPath, manifestFilename,
+  );
   if (fs.existsSync(vendorDllManifestPath)) {
+    logger.info('Vendor DLL bundle found, using DllReferencePlugin');
     config.plugins.unshift(
       new webpack.DllReferencePlugin({
         context: configuration.context,
@@ -72,6 +75,7 @@ module.exports = (
       }),
     );
   } else {
+    logger.info('Vendor DLL bundle not found, using CommonsChunkPlugin');
     config.plugins.push(
       new webpack.optimize.CommonsChunkPlugin({
         name: 'vendor',

--- a/packages/gluestick/src/config/webpack/webpack.config.js
+++ b/packages/gluestick/src/config/webpack/webpack.config.js
@@ -48,7 +48,7 @@ module.exports = (gluestickConfig: GSConfig): WebpackConfig => {
       publicPath: '/assets/',
 
       // file name pattern for entry scripts
-      filename: '[name].[chunkhash].js',
+      filename: '[name].[hash].js',
 
       // file name pattern for chunk scripts
       chunkFilename: '[name].[hash].js',
@@ -129,10 +129,6 @@ module.exports = (gluestickConfig: GSConfig): WebpackConfig => {
           // Can also supply `query.context` parameter.
           context: appRoot,
         },
-      }),
-      new webpack.optimize.CommonsChunkPlugin({
-        name: 'vendor',
-        filename: `vendor${process.env.NODE_ENV === 'production' ? '-[hash]' : ''}.bundle.js`,
       }),
     ],
     node: {

--- a/packages/gluestick/src/config/webpack/webpack.config.server.js
+++ b/packages/gluestick/src/config/webpack/webpack.config.server.js
@@ -21,9 +21,13 @@ module.exports = (
     buildServerEntries(gluestickConfig, logger, entries, runtimeAndServerPlugins);
   }
   const config = deepClone(configuration);
-  // Disable warning for `getVersion` function from `cli/helpers.js`, which has dynamic require,
-  // but it's not used by server.
-  config.module.noParse = [/cli\/helpers/];
+  // Disable warning for `getVersion` function from `cli/helpers.js` and `getBundleName` from
+  // `config/vendorDll.js`, which both hve dynamic requires,
+  // but they're not used by server.
+  config.module.noParse = [
+    /cli\/helpers/,
+    /config\/vendorDll/,
+  ];
   config.module.rules[1].use = 'ignore-loader';
   config.module.rules[2].use = 'ignore-loader';
   config.resolve.alias['project-entries'] = path.join(

--- a/packages/gluestick/src/config/webpack/webpack.config.server.js
+++ b/packages/gluestick/src/config/webpack/webpack.config.server.js
@@ -21,6 +21,9 @@ module.exports = (
     buildServerEntries(gluestickConfig, logger, entries, runtimeAndServerPlugins);
   }
   const config = deepClone(configuration);
+  // Disable warning for `getVersion` function from `cli/helpers.js`, which has dynamic require,
+  // but it's not used by server.
+  config.module.noParse = [/cli\/helpers/];
   config.module.rules[1].use = 'ignore-loader';
   config.module.rules[2].use = 'ignore-loader';
   config.resolve.alias['project-entries'] = path.join(

--- a/packages/gluestick/src/config/webpack/webpack.config.server.js
+++ b/packages/gluestick/src/config/webpack/webpack.config.server.js
@@ -21,12 +21,10 @@ module.exports = (
     buildServerEntries(gluestickConfig, logger, entries, runtimeAndServerPlugins);
   }
   const config = deepClone(configuration);
-  // Disable warning for `getVersion` function from `cli/helpers.js` and `getBundleName` from
-  // `config/vendorDll.js`, which both hve dynamic requires,
-  // but they're not used by server.
+  // Disable warning for `getVersion` function from `cli/helpers.js`, which has dynamic require,
+  // but it's not used by server.
   config.module.noParse = [
     /cli\/helpers/,
-    /config\/vendorDll/,
   ];
   config.module.rules[1].use = 'ignore-loader';
   config.module.rules[2].use = 'ignore-loader';

--- a/packages/gluestick/src/generator/predefined/new.js
+++ b/packages/gluestick/src/generator/predefined/new.js
@@ -37,6 +37,7 @@ const templateGluestickHooks = require('../templates/gluestick.hooks')(createTem
 const templateGluestickConfig = require('../templates/gluestick.config')(createTemplate);
 const templateWebpackHooks = require('../templates/webpack.hooks')(createTemplate);
 const templateCachingServer = require('../templates/caching.server')(createTemplate);
+const templateVendor = require('../templates/vendor')(createTemplate);
 
 const { flowVersion, flowMapper } = require('../constants');
 
@@ -103,6 +104,11 @@ module.exports = (options: GeneratorOptions) => {
       path: 'src',
       filename: 'webpack.hooks.js',
       template: templateWebpackHooks,
+    },
+    {
+      path: 'src',
+      filename: 'vendor.js',
+      template: templateVendor,
     },
     {
       path: 'src/config',

--- a/packages/gluestick/src/generator/templates/vendor.js
+++ b/packages/gluestick/src/generator/templates/vendor.js
@@ -1,0 +1,8 @@
+/* @flow */
+import type { CreateTemplate } from '../../types';
+
+module.exports = (createTemplate: CreateTemplate) => createTemplate`
+// Import common modules or libraries here.
+// If you want to have them as a DLL bundle, run 'gluestick build --vendor',
+// otherwise it will be used as a normal bundle by CommonsChunkPlugin.
+`;

--- a/packages/gluestick/src/generator/templates/webpack.hooks.js
+++ b/packages/gluestick/src/generator/templates/webpack.hooks.js
@@ -5,5 +5,6 @@ module.exports = (createTemplate: CreateTemplate) => createTemplate`
 export default {
   webpackClientConfig: [],
   webpackServerConfig: [],
+  webpackVendorDllConfig: [],
 };
 `;

--- a/packages/gluestick/src/renderer/__tests__/render.test.js
+++ b/packages/gluestick/src/renderer/__tests__/render.test.js
@@ -12,6 +12,8 @@ import type {
   RenderMethod,
 } from '../../types';
 
+jest.mock('../helpers/linkAssets.js', () => () => ({ scriptTags: [], styleTags: [] }));
+
 const React = require('react');
 const clone = require('clone');
 const render = require('../render');

--- a/packages/gluestick/src/renderer/helpers/__tests__/linkAssets.test.js
+++ b/packages/gluestick/src/renderer/helpers/__tests__/linkAssets.test.js
@@ -1,4 +1,11 @@
+/* @flow */
+jest.mock('fs');
+jest.mock('path');
+
+const path = require('path');
+const fs = require('fs');
 const linkAssets = require('../linkAssets');
+const context = require('../../../__tests__/mocks/context').context;
 
 const assets = {
   javascript: {
@@ -16,7 +23,7 @@ describe('renderer/helpers/linkAssets', () => {
     const {
       styleTags,
       scriptTags,
-    } = linkAssets({}, 'main', assets, {});
+    } = linkAssets(context, 'main', assets, {});
     expect(styleTags.length).toBe(0);
     expect(scriptTags.length).toBe(1);
     expect(scriptTags[0].type).toEqual('script');
@@ -30,7 +37,7 @@ describe('renderer/helpers/linkAssets', () => {
     const {
       styleTags,
       scriptTags,
-    } = linkAssets({}, 'main', assets, {});
+    } = linkAssets(context, 'main', assets, {});
     expect(styleTags.length).toBe(2);
     expect(scriptTags.length).toBe(1);
     expect(scriptTags[0].type).toEqual('script');
@@ -46,7 +53,7 @@ describe('renderer/helpers/linkAssets', () => {
     const {
       styleTags,
       scriptTags,
-    } = linkAssets({}, '/', assets, {});
+    } = linkAssets(context, '/', assets, {});
     expect(styleTags.length).toBe(2);
     expect(scriptTags.length).toBe(1);
     expect(scriptTags[0].type).toEqual('script');
@@ -62,7 +69,7 @@ describe('renderer/helpers/linkAssets', () => {
     const {
       styleTags,
       scriptTags,
-    } = linkAssets({}, '/main', assets, {});
+    } = linkAssets(context, '/main', assets, {});
     expect(styleTags.length).toBe(2);
     expect(scriptTags.length).toBe(1);
     expect(scriptTags[0].type).toEqual('script');
@@ -75,11 +82,32 @@ describe('renderer/helpers/linkAssets', () => {
   it('should pass loadjs config', () => {
     const {
       scriptTags,
-    } = linkAssets({}, 'main', assets, {
+    } = linkAssets(context, 'main', assets, {
       before: () => { console.log('LoadJSBefore'); },
     });
     expect(scriptTags.length).toBe(1);
     expect(scriptTags[0].props.dangerouslySetInnerHTML.__html)
       .toContain('console.log(\'LoadJSBefore\')');
+  });
+
+  it('', () => {
+    global.__webpack_public_path__ = null;
+    path.join.mockImplementationOnce(() => 'vendor-manifest.json');
+    fs.writeFileSync('vendor-manifest.json', JSON.stringify({ name: 'vendor_hash' }));
+    const {
+      scriptTags,
+    } = linkAssets(context, '/main', {
+      ...assets,
+      javascript: {
+        main: assets.javascript.main,
+      },
+    }, {});
+    expect(scriptTags.length).toBe(1);
+    expect(
+      scriptTags[0].props.dangerouslySetInnerHTML.__html.includes('main-js'),
+    ).toBeTruthy();
+    expect(
+      scriptTags[0].props.dangerouslySetInnerHTML.__html.includes('/assets/dlls/vendor-hash.dll.js'),
+    ).toBeTruthy();
   });
 });

--- a/packages/gluestick/src/renderer/helpers/__tests__/linkAssets.test.js
+++ b/packages/gluestick/src/renderer/helpers/__tests__/linkAssets.test.js
@@ -23,7 +23,7 @@ describe('renderer/helpers/linkAssets', () => {
     const {
       styleTags,
       scriptTags,
-    } = linkAssets({}, 'main', assets, {});
+    } = linkAssets(context, 'main', assets, {});
     expect(styleTags.length).toBe(2);
     expect(scriptTags.length).toBe(1);
     expect(scriptTags[0].type).toEqual('script');

--- a/packages/gluestick/src/renderer/helpers/linkAssets.js
+++ b/packages/gluestick/src/renderer/helpers/linkAssets.js
@@ -3,8 +3,9 @@
 import type { Context } from '../../types';
 
 const React = require('react');
+const path = require('path');
+const fs = require('fs');
 const getAssetsLoader = require('./getAssetsLoader');
-const vendorDll = require('../../config/vendorDll');
 
 const getAssetPathForFile = (filename: string, section: string, webpackAssets: Object): string => {
   const assets: Object = webpackAssets[section] || {};
@@ -20,6 +21,20 @@ const filterEntryName = (name: string): string => {
   return match ? match[1] : name;
 };
 
+const getBundleName = ({ config }): string => {
+  const manifestFilename: string = process.env.GS_VENDOR_MANIFEST_FILENAME || '';
+  const { buildDllPath } = config.GSConfig;
+  const manifestPath: string = path.join(
+    process.cwd(),
+    buildDllPath,
+    manifestFilename,
+  );
+  // Can't require it, because it will throw an error on server
+  const { name } = JSON.parse(fs.readFileSync(manifestPath).toString());
+  // $FlowIgnore Server is compiled by webpack, so then we have access to webpack's public path
+  const publicPath: string = __webpack_public_path__ || '/assets/'; // eslint-disable-line
+  return `${publicPath}dlls/${name.replace('_', '-')}.dll.js`;
+};
 
 module.exports = (
   { config, logger }: Context, entryPoint: string, assets: Object, loadjsConfig: Object,
@@ -44,7 +59,7 @@ module.exports = (
   }
 
   const vendorBundleHref: string = (
-    getAssetPathForFile('vendor', 'javascript', assets) || vendorDll.getBundleName({ config })
+    getAssetPathForFile('vendor', 'javascript', assets) || getBundleName({ config })
   );
   const entryPointBundleHref: string = getAssetPathForFile(entryPointName, 'javascript', assets);
   const assetsLoader: string = getAssetsLoader(

--- a/packages/gluestick/src/renderer/helpers/linkAssets.js
+++ b/packages/gluestick/src/renderer/helpers/linkAssets.js
@@ -4,6 +4,7 @@ import type { Context } from '../../types';
 
 const React = require('react');
 const getAssetsLoader = require('./getAssetsLoader');
+const vendorDll = require('../../config/vendorDll');
 
 const getAssetPathForFile = (filename: string, section: string, webpackAssets: Object): string => {
   const assets: Object = webpackAssets[section] || {};
@@ -18,6 +19,7 @@ const filterEntryName = (name: string): string => {
   const match = /\/(.*)/.exec(name);
   return match ? match[1] : name;
 };
+
 
 module.exports = (
   { config, logger }: Context, entryPoint: string, assets: Object, loadjsConfig: Object,
@@ -41,7 +43,9 @@ module.exports = (
     }
   }
 
-  const vendorBundleHref: string = getAssetPathForFile('vendor', 'javascript', assets);
+  const vendorBundleHref: string = (
+    getAssetPathForFile('vendor', 'javascript', assets) || vendorDll.getBundleName({ config })
+  );
   const entryPointBundleHref: string = getAssetPathForFile(entryPointName, 'javascript', assets);
   const assetsLoader: string = getAssetsLoader(
     { before: () => {}, ...loadjsConfig },

--- a/packages/gluestick/src/types.js
+++ b/packages/gluestick/src/types.js
@@ -57,6 +57,7 @@ export type CompiledConfig = {
   universalSettings: UniversalSettings;
   client: WebpackConfig;
   server: WebpackConfig;
+  vendor?: WebpackConfig;
 }
 
 export type Config = {

--- a/packages/gluestick/src/types.js
+++ b/packages/gluestick/src/types.js
@@ -255,6 +255,7 @@ export type GSHooks = {
 export type WebpackHooks = {
   webpackClientConfig?: Hook;
   webpackServerConfig?: Hook;
+  webpackVendorDllConfig?: Hook;
 };
 
 export type Plugin = {
@@ -278,6 +279,7 @@ export type ConfigPlugin = {
     gluestickConfig?: (config: GSConfig) => void;
     clientWebpackConfig?: (config: WebpackConfig) => WebpackConfig;
     serverWebpackConfig?: (config: WebpackConfig) => WebpackConfig;
+    vendorDllWebpackConfig?: (config: WebpackConfig) => WebpackConfig;
   };
 };
 

--- a/packages/gluestick/src/types.js
+++ b/packages/gluestick/src/types.js
@@ -14,6 +14,7 @@ export type GSConfig = {
   buildStaticPath: string;
   buildAssetsPath: string;
   buildRendererPath: string;
+  buildDllPath: string;
   assetsPath: string;
   sourcePath: string;
   sharedPath: string;
@@ -30,6 +31,7 @@ export type GSConfig = {
   debugWatchDirectories: string[];
   defaultErrorTemplatePath: string;
   customErrorTemplatePath: string;
+  vendorSourcePath: string;
   autoUpgrade: {
     added: string[],
     changed: string[],

--- a/packages/gluestick/src/utils.js
+++ b/packages/gluestick/src/utils.js
@@ -126,6 +126,11 @@ const printWebpackStats = (logger: Logger, stats: Object) => {
   compilationStats.warnings.forEach(warning => {
     logger.warn(warning);
   });
+
+  compilationStats.errors.forEach(error => {
+    logger.error(error);
+  });
+
   logger.print(table.toString(), '\n');
 };
 


### PR DESCRIPTION
Ref: ##1033

How to run (npm@5 is not supported):
```
git clone https://github.com/TrueCar/gluestick
cd gluestick
npm run install:npm
cd ../
./gluestick/packages/gluestick-cli/bin/index.js new testApp --npm --dev ./gluestick
cd . testApp
./node_modules/.bin/gluestick build --vendor
./node_modules/.bin/gluestick build --client
```

If vendor DLL bundle is preset it will be used, otherwise it will create normal vendor bundle using `CommonsChunkPlugin`. Also `--skip-if-ok` option in `gluestick build --vendor` will make some checks (https://github.com/TrueCar/gluestick/blob/feature/vendor-dll/packages/gluestick/src/config/vendorDll.js#L47-L112), if every of them fail, it will conclude that vendor dll bundle is fine, and will bail from recompiling it. To build single app: `gluestick build --client -A /<appName>`. To parallely build project:
- build vendor dll `gluestick build --vendor`
- build every app using `gluestick build --client -A /<appName>`
- build server bundle `gluestick build --server`
Now you can `start -P` w/ `NODE_ENV=production` set.

`gluestick-config-legacy` has also been updated to support vendor DLL bundle, so if you're using it, you need to update it `npm i <pathToGluestickRepo>/packages/gluestick-config-legacy`

Documentation can be found [here](https://github.com/TrueCar/gluestick/blob/feature/vendor-dll/docs/Configuration.md#vendoring).

@todd should vendor DLL support also CSS files and loaders?