### PR TITLE
Correctly handle `class` attribute in `BodyAttibutes`

### DIFF
--- a/packages/gluestick/shared/components/BodyAttributes.js
+++ b/packages/gluestick/shared/components/BodyAttributes.js
@@ -33,7 +33,11 @@ function reducePropsToState(propsList: Object[]) {
 function handleStateChangeOnClient(attrs: Object) {
   for (const key in attrs) {
     if (document.body) {
-      document.body.setAttribute(key, attrs[key]);
+      if (key === 'className') {
+        document.body.setAttribute('class', attrs[key]);
+      } else {
+        document.body.setAttribute(key, attrs[key]);
+      }
     }
   }
 }


### PR DESCRIPTION
I have a use case where I want to set the `class` of body dynamically. If I use `className` it works on first load but not on updates and it also puts `className` on `<body>`. If I use `class` it works as expected but I get a warning:

```
Warning: Unknown DOM property class. Did you mean className?
    in body (created by Index)
    in html (created by Index)
    in Index
```