### PR TITLE
Update flow to v0.50.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -18,4 +18,4 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowIgnore
 module.ignore_non_literal_requires=true
 
 [version]
-^0.45.0
+^0.50.0

--- a/flow-typed/npm/jest_v20.x.x.js
+++ b/flow-typed/npm/jest_v20.x.x.js
@@ -1,5 +1,5 @@
-// flow-typed signature: adc2f239806ddd8eb09272d1b4e23cb9
-// flow-typed version: 7dc2a8971e/jest_v19.x.x/flow_>=v0.33.x
+// flow-typed signature: a0369c11661f437ec4ccdd805579ddcf
+// flow-typed version: c4b9fea7c9/jest_v20.x.x/flow_>=v0.33.x
 
 type JestMockFn = {
   (...args: Array<any>): any,
@@ -17,7 +17,7 @@ type JestMockFn = {
      * An array that contains all the object instances that have been
      * instantiated from this mock function.
      */
-    instances: mixed,
+    instances: mixed
   },
   /**
    * Resets all information stored in the mockFn.mock.calls and
@@ -30,6 +30,14 @@ type JestMockFn = {
    * completely restore a mock back to its initial state.
    */
   mockReset(): Function,
+  /**
+   * Removes the mock and restores the initial implementation. This is useful
+   * when you want to mock functions in certain test cases and restore the
+   * original implementation in others. Beware that mockFn.mockRestore only
+   * works when mock was created with jest.spyOn. Thus you have to take care of
+   * restoration yourself when manually assigning jest.fn().
+   */
+  mockRestore(): Function,
   /**
    * Accepts a function that should be used as the implementation of the mock.
    * The mock itself will still record all calls that go into and instances
@@ -54,15 +62,15 @@ type JestMockFn = {
   /**
    * Sugar for only returning a value once inside your mock
    */
-  mockReturnValueOnce(value: any): JestMockFn,
-}
+  mockReturnValueOnce(value: any): JestMockFn
+};
 
 type JestAsymmetricEqualityType = {
   /**
    * A custom Jasmine equality tester
    */
-  asymmetricMatch(value: mixed): boolean,
-}
+  asymmetricMatch(value: mixed): boolean
+};
 
 type JestCallsType = {
   allArgs(): mixed,
@@ -71,25 +79,61 @@ type JestCallsType = {
   count(): number,
   first(): mixed,
   mostRecent(): mixed,
-  reset(): void,
-}
+  reset(): void
+};
 
 type JestClockType = {
   install(): void,
   mockDate(date: Date): void,
-  tick(): void,
-  uninstall(): void,
-}
+  tick(milliseconds?: number): void,
+  uninstall(): void
+};
 
 type JestMatcherResult = {
-  message?: string | ()=>string,
-  pass: boolean,
-}
+  message?: string | (() => string),
+  pass: boolean
+};
 
 type JestMatcher = (actual: any, expected: any) => JestMatcherResult;
 
+type JestPromiseType = {
+  /**
+   * Use rejects to unwrap the reason of a rejected promise so any other
+   * matcher can be chained. If the promise is fulfilled the assertion fails.
+   */
+  rejects: JestExpectType,
+  /**
+   * Use resolves to unwrap the value of a fulfilled promise so any other
+   * matcher can be chained. If the promise is rejected the assertion fails.
+   */
+  resolves: JestExpectType
+};
+
+/**
+ *  Plugin: jest-enzyme
+ */
+type EnzymeMatchersType = {
+  toBeChecked(): void,
+  toBeDisabled(): void,
+  toBeEmpty(): void,
+  toBePresent(): void,
+  toContainReact(element: React$Element<any>): void,
+  toHaveClassName(className: string): void,
+  toHaveHTML(html: string): void,
+  toHaveProp(propKey: string, propValue?: any): void,
+  toHaveRef(refName: string): void,
+  toHaveState(stateKey: string, stateValue?: any): void,
+  toHaveStyle(styleKey: string, styleValue?: any): void,
+  toHaveTagName(tagName: string): void,
+  toHaveText(text: string): void,
+  toIncludeText(text: string): void,
+  toHaveValue(value: any): void,
+  toMatchElement(element: React$Element<any>): void,
+  toMatchSelector(selector: string): void,
+};
+
 type JestExpectType = {
-  not: JestExpectType,
+  not: JestExpectType & EnzymeMatchersType,
   /**
    * If you have a mock function, you can use .lastCalledWith to test what
    * arguments it was last called with.
@@ -190,6 +234,11 @@ type JestExpectType = {
    */
   toHaveBeenCalledWith(...args: Array<any>): void,
   /**
+   * Use .toHaveBeenLastCalledWith to ensure that a mock function was last called
+   * with specific arguments.
+   */
+  toHaveBeenLastCalledWith(...args: Array<any>): void,
+  /**
    * Check that an object has a .length property and it is set to a certain
    * numeric value.
    */
@@ -199,9 +248,9 @@ type JestExpectType = {
    */
   toHaveProperty(propPath: string, value?: any): void,
   /**
-   * Use .toMatch to check that a string matches a regular expression.
+   * Use .toMatch to check that a string matches a regular expression or string.
    */
-  toMatch(regexp: RegExp): void,
+  toMatch(regexpOrString: RegExp | string): void,
   /**
    * Use .toMatchObject to check that a javascript object matches a subset of the properties of an object.
    */
@@ -212,20 +261,20 @@ type JestExpectType = {
   toMatchSnapshot(name?: string): void,
   /**
    * Use .toThrow to test that a function throws when it is called.
+   * If you want to test that a specific error gets thrown, you can provide an
+   * argument to toThrow. The argument can be a string for the error message,
+   * a class for the error, or a regex that should match the error.
+   *
+   * Alias: .toThrowError
    */
-  toThrow(message?: string | Error): void,
-  /**
-   * Use .toThrowError to test that a function throws a specific error when it
-   * is called. The argument can be a string for the error message, a class for
-   * the error, or a regex that should match the error.
-   */
+  toThrow(message?: string | Error | RegExp): void,
   toThrowError(message?: string | Error | RegExp): void,
   /**
    * Use .toThrowErrorMatchingSnapshot to test that a function throws a error
    * matching the most recent snapshot when it is called.
    */
-  toThrowErrorMatchingSnapshot(): void,
-}
+  toThrowErrorMatchingSnapshot(): void
+};
 
 type JestObjectType = {
   /**
@@ -247,6 +296,11 @@ type JestObjectType = {
    * An un-hoisted version of enableAutomock
    */
   autoMockOn(): JestObjectType,
+  /**
+   * Clears the mock.calls and mock.instances properties of all mocks.
+   * Equivalent to calling .mockClear() on every mocked function.
+   */
+  clearAllMocks(): JestObjectType,
   /**
    * Resets the state of all mocks. Equivalent to calling .mockReset() on every
    * mocked function.
@@ -289,7 +343,11 @@ type JestObjectType = {
    * The third argument can be used to create virtual mocks -- mocks of modules
    * that don't exist anywhere in the system.
    */
-  mock(moduleName: string, moduleFactory?: any): JestObjectType,
+  mock(
+    moduleName: string,
+    moduleFactory?: any,
+    options?: Object
+  ): JestObjectType,
   /**
    * Resets the module registry - the cache of all required modules. This is
    * useful to isolate modules where local state might conflict between tests.
@@ -346,12 +404,12 @@ type JestObjectType = {
    * Creates a mock function similar to jest.fn but also tracks calls to
    * object[methodName].
    */
-  spyOn(object: Object, methodName: string): JestMockFn,
-}
+  spyOn(object: Object, methodName: string): JestMockFn
+};
 
 type JestSpyType = {
-  calls: JestCallsType,
-}
+  calls: JestCallsType
+};
 
 /** Runs this function after every test inside this context */
 declare function afterEach(fn: Function): void;
@@ -361,8 +419,25 @@ declare function beforeEach(fn: Function): void;
 declare function afterAll(fn: Function): void;
 /** Runs this function before any tests have started inside this context */
 declare function beforeAll(fn: Function): void;
+
 /** A context for grouping tests together */
-declare function describe(name: string, fn: Function): void;
+declare var describe: {
+  /**
+   * Creates a block that groups together several related tests in one "test suite"
+   */
+  (name: string, fn: Function): void,
+
+  /**
+   * Only run this describe block
+   */
+  only(name: string, fn: Function): void,
+
+  /**
+   * Skip running this describe block
+   */
+  skip(name: string, fn: Function): void,
+};
+
 
 /** An individual test unit */
 declare var it: {
@@ -393,7 +468,7 @@ declare var it: {
    * @param {string} Name of Test
    * @param {Function} Test
    */
-  concurrent(name: string, fn?: Function): ?Promise<void>,
+  concurrent(name: string, fn?: Function): ?Promise<void>
 };
 declare function fit(name: string, fn: Function): ?Promise<void>;
 /** An individual test unit */
@@ -410,19 +485,20 @@ declare var xtest: typeof it;
 /** The expect function is used every time you want to test a value */
 declare var expect: {
   /** The object that you want to make assertions against */
-  (value: any): JestExpectType,
+  (value: any): JestExpectType & JestPromiseType & EnzymeMatchersType,
   /** Add additional Jasmine matchers to Jest's roster */
-  extend(matchers: {[name:string]: JestMatcher}): void,
+  extend(matchers: { [name: string]: JestMatcher }): void,
   /** Add a module that formats application-specific data structures. */
   addSnapshotSerializer(serializer: (input: Object) => string): void,
   assertions(expectedAssertions: number): void,
+  hasAssertions(): void,
   any(value: mixed): JestAsymmetricEqualityType,
   anything(): void,
   arrayContaining(value: Array<mixed>): void,
   objectContaining(value: Object): void,
   /** Matches any received string that contains the exact expected string. */
   stringContaining(value: string): void,
-  stringMatching(value: string | RegExp): void,
+  stringMatching(value: string | RegExp): void
 };
 
 // TODO handle return type
@@ -430,7 +506,7 @@ declare var expect: {
 declare function spyOn(value: mixed, method: string): Object;
 
 /** Holds all functions related to manipulating test runner */
-declare var jest: JestObjectType
+declare var jest: JestObjectType;
 
 /**
  * The global Jamine object, this is generally not exposed as the public API,
@@ -443,7 +519,10 @@ declare var jasmine: {
   arrayContaining(value: Array<mixed>): void,
   clock(): JestClockType,
   createSpy(name: string): JestSpyType,
-  createSpyObj(baseName: string, methodNames: Array<string>): {[methodName: string]: JestSpyType},
+  createSpyObj(
+    baseName: string,
+    methodNames: Array<string>
+  ): { [methodName: string]: JestSpyType },
   objectContaining(value: Object): void,
-  stringMatching(value: string): void,
-}
+  stringMatching(value: string): void
+};

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-jsx-a11y": "^3.0.2",
     "eslint-plugin-prettier": "2.1.2",
     "eslint-plugin-react": "^6.9.0",
-    "flow-bin": "^0.45.0",
+    "flow-bin": "^0.50.0",
     "flow-copy-source": "1.1.0",
     "glob": "7.1.1",
     "mkdirp": "0.5.1",

--- a/packages/gluestick/shared/lib/createStore.js
+++ b/packages/gluestick/shared/lib/createStore.js
@@ -6,7 +6,7 @@ import _gluestick from './reducers';
 import promiseMiddleware from '../lib/promiseMiddleware';
 
 type Store = Object;
-type CreateStore = () => Store;
+type CreateStore = (reducer: Object, state: Object) => Store;
 
 export default function(
   client: () => Object,

--- a/packages/gluestick/src/commands/__tests__/start-client.test.js
+++ b/packages/gluestick/src/commands/__tests__/start-client.test.js
@@ -20,8 +20,8 @@ jest.mock('../build');
 const build = require('../build');
 
 let middlewares = [];
-let listenCallback = () => {};
-let engineHandler = () => {};
+let listenCallback; // = () => {};
+let engineHandler; // = () => {};
 jest.setMock('express', () => ({
   engine: (ext, hdl) => {
     engineHandler = hdl;
@@ -117,12 +117,12 @@ describe('commands/start-client', () => {
     waitUntilValidCallback();
     expect(middlewares.length).toBe(3);
     const res = { render: jest.fn() };
-    proxyOnErrorCallback(null, {}, res);
+    proxyOnErrorCallback(/* null, {}, res */);
     expect(res.render.mock.calls[0][0].includes('poll.html')).toBeTruthy();
     expect(res.render.mock.calls[0][1]).toEqual({
       port: commandApi.getContextConfig().GSConfig.ports.server,
     });
-    listenCallback('');
+    listenCallback();
     expect(
       successLogger.mock.calls[0][0].includes('Client server running on'),
     ).toBeTruthy();
@@ -130,6 +130,6 @@ describe('commands/start-client', () => {
 
   it('should throw error if express fails to listen for requests', () => {
     startClientCommand(commandApi, [{}]);
-    listenCallback('test error');
+    listenCallback();
   });
 });

--- a/packages/gluestick/src/types.js
+++ b/packages/gluestick/src/types.js
@@ -150,7 +150,7 @@ export type Response = {
   send: (value: string | Object | Buffer) => void,
   set: (header: { [key: string]: string }) => void,
   redirect: (code: number, location: string) => void,
-  header: (header: string) => void,
+  header: (header: string, value: string) => void,
   status: (code: number) => Response,
   json: (json: Object) => void,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1981,9 +1981,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.45.0:
-  version "0.45.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.45.0.tgz#009dd0f577a3f665c74ca8be827ae8c2dd8fd6b5"
+flow-bin@^0.50.0:
+  version "0.50.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.50.0.tgz#d4cdb2430dee1a3599f0eb6fe551146e3027256a"
 
 flow-copy-source@1.1.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2953,8 +2953,8 @@ jsx-ast-utils@^1.0.0, jsx-ast-utils@^1.3.4:
     object-assign "^4.1.0"
 
 kefir@^3.2.0:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/kefir/-/kefir-3.7.1.tgz#e77f56feeec46f4a2ee2997e5c3226e904877b5b"
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/kefir/-/kefir-3.7.3.tgz#c1d4e0a7a9f63cfd73720ae38e0630c14784ed97"
   dependencies:
     symbol-observable "^1.0.1"
 


### PR DESCRIPTION
Flow 0.46+ is a lot faster. This updates gluestick to the latest version.

There may be better flow coverage in `start-client.test.js` possible but I fixed the errors and coverage is not any worse.