### PR TITLE
add unzip to list of build packages

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -51,6 +51,7 @@ ENV BUILD_PACKAGES "autoconf \
                     procps \
                     python-dev \
                     subversion \
+                    unzip \
                     xz-utils \
                     zlib1g-dev"
 


### PR DESCRIPTION
Unzip is a very small and very common library needed in many deployment environments. This is needed by TrueCar in our production environment.

Should only add <400 KB (~0.05%) extra size to the docker image.