### PR TITLE
move projectHooks higher up to support better profiling in preInit

### DIFF
--- a/packages/gluestick/src/renderer/main.js
+++ b/packages/gluestick/src/renderer/main.js
@@ -14,6 +14,10 @@ import type {
   BaseLogger,
 } from '../types';
 
+// Intentionally first require so things like require("newrelic") in
+// preInitHook get instantiated before anything else. This improves profiling
+const projectHooks = require('gluestick-hooks').default;
+
 const path = require('path');
 const fs = require('fs');
 const express = require('express');
@@ -29,7 +33,6 @@ const entriesConfig = require('project-entries-config');
 // $FlowIgnore
 const EntryWrapper = require('entry-wrapper').default;
 // $FlowIgnore
-const projectHooks = require('gluestick-hooks').default;
 const BodyWrapper = require('./components/Body').default;
 const reduxMiddlewares = require('redux-middlewares').default;
 // $FlowIgnore

--- a/packages/gluestick/src/renderer/main.js
+++ b/packages/gluestick/src/renderer/main.js
@@ -16,6 +16,7 @@ import type {
 
 // Intentionally first require so things like require("newrelic") in
 // preInitHook get instantiated before anything else. This improves profiling
+// $FlowIgnore
 const projectHooks = require('gluestick-hooks').default;
 
 const path = require('path');
@@ -32,7 +33,6 @@ const entries = require('project-entries').default;
 const entriesConfig = require('project-entries-config');
 // $FlowIgnore
 const EntryWrapper = require('entry-wrapper').default;
-// $FlowIgnore
 const BodyWrapper = require('./components/Body').default;
 const reduxMiddlewares = require('redux-middlewares').default;
 // $FlowIgnore


### PR DESCRIPTION
newrelic isn't giving us great output when it comes to express/connect because we are not including `newrelic` before we require `express`. We need to come up with a way to declare requirements before `express` is even included.