### PR TITLE
Resolve 500 on invalid cookies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "transform": {
       "\\.js$": "<rootDir>/jestTransform.js"
     },
-    "testRegex": "src/(.*/)?__tests__/.*\\.test\\.js$"
+    "testRegex": "(src|shared)/(.*/)?__tests__/.*\\.test\\.js$"
   }
 }

--- a/packages/gluestick/shared/lib/__tests__/cookies.test.js
+++ b/packages/gluestick/shared/lib/__tests__/cookies.test.js
@@ -74,6 +74,10 @@ describe('lib/cookies', () => {
       expect(cookieJar[1].name).toEqual('a');
       expect(cookieJar[1].value).toEqual('bcdef');
     });
+
+    it("doesn't crash on invalid cookie value", () => {
+      expect(() => parse('name=asdf%asdf==; path=/xyz; a=bcdef')).not.toThrow();
+    });
   });
 
   describe('merge', () => {

--- a/packages/gluestick/shared/lib/cookies.js
+++ b/packages/gluestick/shared/lib/cookies.js
@@ -83,7 +83,11 @@ export function parse(cookieString: string): Object[] {
         c = new Cookie();
       }
       c.name = k;
-      c.value = v && decodeURIComponent(v);
+      try {
+        c.value = v && decodeURIComponent(v);
+      } catch (e) {
+        // NOOP
+      }
     }
   });
   cookies.push(c);


### PR DESCRIPTION
# Overview
There is an error with certain cookies that cause 500 error on server side rendering.

## Reproduction steps
1. Create app that does an API request using the httpClient. Open page that sends request.
2. In Chrome Dev tools add a cookie: `name: "asdf%asdf"`
3. Refresh page

### Current Result
500 Error

### Expected Result
No error

#### Notes
In order to get rid of the error, delete the cookie that was just created. I would guess that this is an issue with decodeURIComponent crashing when it comes across a cookie value that it cannot decode. Instead of blowing up we should handle these cookies more gracefully.
