### PR TITLE
resolve regex support bug

### DIFF
--- a/packages/gluestick/src/renderer/helpers/__tests__/parseRoutePath.test.js
+++ b/packages/gluestick/src/renderer/helpers/__tests__/parseRoutePath.test.js
@@ -27,4 +27,12 @@ describe('renderer/helpers/parseRoutePath', () => {
     testPath('/:var', ['/test'], ['/']);
     testPath('/test/:var', ['/test/index'], ['/', '/test']);
   });
+
+  it('should match routes that begin with regex on non regex paths', () => {
+    testPath(
+      '/x',
+      ['/x/123', '/x', '/x/123/abc/whatever'],
+      ['/', '/t', '/test1'],
+    );
+  });
 });

--- a/packages/gluestick/src/renderer/helpers/parseRoutePath.js
+++ b/packages/gluestick/src/renderer/helpers/parseRoutePath.js
@@ -18,7 +18,7 @@ module.exports = function parseRoutePath(routePath: string): PathRegexp {
   }
 
   const keys = [];
-  const results = pathToRegexp(routePath, keys);
+  const results = pathToRegexp(routePath, keys, { end: false });
   results.keys = keys;
   return results;
 };


### PR DESCRIPTION
Non regex entrypoint keys were converted to a regex that required the
path to end on the key. It did not support routes that begin with that
key. This update takes advantage of path-to-regex's options and adds
`end:false` so that it will match on routes that begin with the matched
key.