### PR TITLE
Log error on development start failure.

### DIFF
--- a/packages/gluestick/src/commands/start.js
+++ b/packages/gluestick/src/commands/start.js
@@ -108,8 +108,8 @@ module.exports = (commandApi: CommandAPI, commandArguments: any[]) => {
         });
       }
     })
-    .catch((error) => {
-      logger.error(error);
+    .catch(e => {
+      logger.error(e);
       logger.fatal(
         "Some tests have failed, client and server won't be compiled and executed",
       );

--- a/packages/gluestick/src/commands/start.js
+++ b/packages/gluestick/src/commands/start.js
@@ -108,7 +108,8 @@ module.exports = (commandApi: CommandAPI, commandArguments: any[]) => {
         });
       }
     })
-    .catch(() => {
+    .catch((error) => {
+      logger.error(error);
       logger.fatal(
         "Some tests have failed, client and server won't be compiled and executed",
       );


### PR DESCRIPTION
Log error object from promise rejection instead of logging a generic error.