### PR TITLE
Allow passing redux enhancers without `applyMiddleware()`

### DIFF
--- a/packages/gluestick/shared/lib/createStore.js
+++ b/packages/gluestick/shared/lib/createStore.js
@@ -15,6 +15,7 @@ export default function(
   hotCallback: (cb: Function) => void,
   devMode: Boolean,
   thunkMiddleware: Function,
+  enhancers: Array<Function> = [],
 ): Store {
   const reducers = Object.assign({}, { _gluestick }, customRequire());
   const reducer: Object = combineReducers(reducers);
@@ -41,6 +42,7 @@ export default function(
 
   const composeArgs: Function[] = [
     applyMiddleware.apply(this, middleware),
+    ...enhancers,
     typeof window === 'object' &&
     typeof window.devToolsExtension !== 'undefined' &&
     process.env.NODE_ENV !== 'production'

--- a/packages/gluestick/src/generator/predefined/clientEntryInit.js
+++ b/packages/gluestick/src/generator/predefined/clientEntryInit.js
@@ -6,7 +6,12 @@ const template = createTemplate`
 import getRoutes from "${args => args.routes}";
 import EntryWrapper from "../EntryWrapper";
 import { createStore } from "compiled/gluestick";
-import globalMiddlewares, { thunkMiddleware as globalThunkMiddleware } from "config/redux-middleware";
+import globalMiddlewares,
+{
+  thunkMiddleware as globalThunkMiddleware,
+  enhancers as globalEnhancers,
+}
+from "config/redux-middleware";
 ${args =>
   args.config ? `import config from "${args.config}";` : 'const config = {};'}
 
@@ -33,6 +38,9 @@ export const getStore = (httpClient) => {
     config.reduxOptions && config.reduxOptions.thunk
       ? config.reduxOptions.thunk
       : globalThunkMiddleware,
+    config.reduxOptions && config.reduxOptions.enhancers
+      ? config.reduxOptions.enhancers
+      : globalEnhancers,
   );
 };
 

--- a/packages/gluestick/src/generator/templates/ReduxMiddleware.js
+++ b/packages/gluestick/src/generator/templates/ReduxMiddleware.js
@@ -14,4 +14,5 @@ module.exports = (createTemplate: CreateTemplate) => createTemplate`
 // export default [logger];
 export default [];
 export const thunkMiddleware = null;
+export const enhancers = [];
 `;


### PR DESCRIPTION
Needed for `redux-localstorage`