### PR TITLE
Newly generated apps should run on enzyme 3

### DIFF
--- a/packages/gluestick-generators/src/templates/package.js
+++ b/packages/gluestick-generators/src/templates/package.js
@@ -64,13 +64,17 @@ const templatePackage = createTemplate`
     "babel-eslint": "7.1.1",
     "babel-jest": "18.0.0",
     "babel-plugin-react-transform": "2.0.2",
-    "enzyme": "2.7.1",
+    "enzyme": "3.3.0",
+    "enzyme-adapter-react-16": "1.1.1",
     "eslint": "3.14.1",
     "eslint-plugin-react": "6.9.0",
     "flow-bin": "0.45.0",
     "flow-typed": "^2.0.0",
     "react-addons-test-utils": "15.4.2",
     "redbox-react": "1.3.3"
+  },
+  "jest": {
+    "setupTestFrameworkScriptFile": "./src/__tests__/configureEnzyme.js"
   }
 }
 `;

--- a/packages/gluestick/src/generator/predefined/new.js
+++ b/packages/gluestick/src/generator/predefined/new.js
@@ -13,7 +13,9 @@ const templateDockerignore = require('../templates/dockerignore')(
   createTemplate,
 );
 const templateBabelrc = require('../templates/babelrc')(createTemplate);
-const templateConfigureEnzyme = require('../templates/configureEnzyme')(createTemplate);
+const templateConfigureEnzyme = require('../templates/configureEnzyme')(
+  createTemplate,
+);
 const templateHomeTest = require('../templates/HomeTest')(createTemplate);
 const templateMasterLayoutTest = require('../templates/MasterLayoutTest')(
   createTemplate,

--- a/packages/gluestick/src/generator/predefined/new.js
+++ b/packages/gluestick/src/generator/predefined/new.js
@@ -13,6 +13,7 @@ const templateDockerignore = require('../templates/dockerignore')(
   createTemplate,
 );
 const templateBabelrc = require('../templates/babelrc')(createTemplate);
+const templateConfigureEnzyme = require('../templates/configureEnzyme')(createTemplate);
 const templateHomeTest = require('../templates/HomeTest')(createTemplate);
 const templateMasterLayoutTest = require('../templates/MasterLayoutTest')(
   createTemplate,
@@ -233,6 +234,11 @@ module.exports = (options: GeneratorOptions) => {
       path: 'src/shared/reducers',
       filename: 'index.js',
       template: templateReducer,
+    },
+    {
+      path: 'src/__tests__',
+      filename: 'configureEnzyme.js',
+      template: templateConfigureEnzyme,
     },
     {
       path: 'src/apps/main/components/__tests__',

--- a/packages/gluestick/src/generator/templates/configureEnzyme.js
+++ b/packages/gluestick/src/generator/templates/configureEnzyme.js
@@ -1,0 +1,11 @@
+/* @flow */
+import type { CreateTemplate } from '../../types';
+
+module.exports = (createTemplate: CreateTemplate) => createTemplate`
+/* @flow */
+import "raf/polyfill";
+import enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+
+enzyme.configure({ adapter: new Adapter() });
+`;


### PR DESCRIPTION
This is a patch to the GlueStick 2.0.0 pre-release. All newly generated apps should run on Enzyme 3. This PR upgrades that dependency for new apps  .