### PR TITLE
add `gluestick` CLI commands to `gluestick-cli` CLI help message

### DIFF
--- a/packages/gluestick-cli/src/__tests__/completion.test.js
+++ b/packages/gluestick-cli/src/__tests__/completion.test.js
@@ -59,6 +59,7 @@ const PROJECT_COMMANDS = [
   'destroy',
   'dockerize',
   'generate',
+  'print-help',
   'start',
   'start-client',
   'start-server',

--- a/packages/gluestick-cli/src/cli.js
+++ b/packages/gluestick-cli/src/cli.js
@@ -2,6 +2,7 @@ const path = require('path');
 const commander = require('commander');
 const spawn = require('cross-spawn');
 const chalk = require('chalk');
+const semver = require('semver');
 
 const newApp = require('./new');
 const reinstallDev = require('./reinstallDev');
@@ -106,6 +107,28 @@ commander.command('*', null, { noHelp: true }).action(() => {
     if (code !== 0) {
       process.exit(code);
     }
+  });
+});
+
+// Add the list of commands from the local project `gluestick` package CLI to
+// the help message for this global `gluestick-cli` package CLI.
+commander.on('--help', () => {
+  let localInstalledVersion = '';
+  try {
+    localInstalledVersion = require(path.join(
+      process.cwd(),
+      'node_modules/gluestick',
+      'package.json',
+    )).version;
+  } catch (e) {
+    // noop
+  }
+  // the 'print-help' command is not available in version <=2.0.0
+  if (!localInstalledVersion || semver.lte(localInstalledVersion, '2.0.0')) {
+    return;
+  }
+  spawn.sync('./node_modules/.bin/gluestick', ['print-help'], {
+    stdio: 'inherit',
   });
 });
 

--- a/packages/gluestick-cli/src/completion.js
+++ b/packages/gluestick-cli/src/completion.js
@@ -43,6 +43,7 @@ function loadCommanderProject(cwd) {
       'destroy',
       'dockerize',
       'generate',
+      'print-help',
       'start',
       'start-client',
       'start-server',

--- a/packages/gluestick/src/cli/index.js
+++ b/packages/gluestick/src/cli/index.js
@@ -205,6 +205,23 @@ commander
     }),
   );
 
+// This command is used by the global `gluestick-cli` package CLI to append
+// the commands listed in this file to its help message.
+commander.command('print-help', null, { noHelp: true }).action(() => {
+  commander.help(txt => {
+    // Remove the first 11 lines because the global `gluestick-cli` package CLI
+    // prints similar information. Note: `txt` passed to `.help()` uses '\n' to
+    // separate lines.
+    // https://github.com/tj/commander.js/blob/d8404f8de45c9ba780606878f4d35d0a45743d32/index.js#L1130
+    return txt
+      .split('\n')
+      .slice(11)
+      .map(line => line.replace('Commands:', 'Project commands:'))
+      .concat('')
+      .join('\n');
+  });
+});
+
 // This is a catch all command. DO NOT PLACE ANY COMMANDS BELOW THIS
 commander.command('*', null, { noHelp: true }).action(cmd => {
   const logger = commandApi.getLogger();


### PR DESCRIPTION
Hopefully I didn't miss something, but running `gluestick --help` doesn't return all the available commands for me:

```
$ gluestick --help

  Usage: gluestick [options] [command]


  Commands:

    new [options] <appName>  generate a new application
    reinstall-dev            reinstall gluestick dependency
    watch                    watch and apply changes from gluestick to project
    reset-hard               remove gluestick and build, cache clean and reinstall-dev
    completion               output the bash_completion shell script contents

  Options:

    -h, --help     output usage information
    -V, --version  output the version number

```

This changes the output so that it includes the commands from the local `gluestick` CLI:

```
$ gluestick --help

  Usage: gluestick [options] [command]


  Commands:

    new [options] <appName>  generate a new application
    reinstall-dev            reinstall gluestick dependency
    watch                    watch and apply changes from gluestick to project
    reset-hard               remove gluestick and build, cache clean and reinstall-dev
    completion               output the bash_completion shell script contents

  Options:

    -h, --help     output usage information
    -V, --version  output the version number

  Project commands:

    generate [options] <container|component|reducer|generator> <name>  generate a new entity from given template
    destroy [options] <container|component|reducer> <name>             destroy a generated container
    auto-upgrade                                                       perform automatic dependency and gluestick files upgrade
    start|s [options]                                                  start everything
    build [options]                                                    create production asset build
    bin                                                                access dependencies bin directory
    dockerize <name>                                                   create docker image
    test [options]                                                     start tests

```

Let me know if there's another way. Just wanted to see all the available commands using `--help`.