### PR TITLE
Apply patches to properly load bunyan config file

### DIFF
--- a/packages/gluestick-plugin-bunyan/src/__tests__/server.test.js
+++ b/packages/gluestick-plugin-bunyan/src/__tests__/server.test.js
@@ -3,12 +3,38 @@
 import gluestickPluginBunyan from '../server.js';
 import type { Logger } from '../server.js';
 
-test('Bunyan plugin should return logger with all methods', () => {
-  const { logger }: { logger: Logger } = gluestickPluginBunyan();
-  expect(logger).toBeDefined();
-  expect(logger.success).toBeDefined();
-  expect(logger.info).toBeDefined();
-  expect(logger.warn).toBeDefined();
-  expect(logger.debug).toBeDefined();
-  expect(logger.error).toBeDefined();
+describe('Bunyan plugin', () => {
+  it('should return logger with all methods when given a valid config', () => {
+    const mockRequireModule = jest.fn();
+    mockRequireModule.mockReturnValue({
+      name: 'test',
+      stream: process.stdout,
+      level: 'warn',
+    });
+    const { logger }: { logger?: Logger } = gluestickPluginBunyan(
+      {},
+      { requireModule: mockRequireModule },
+    );
+    if (!logger) {
+      // Force a failure for Flow: https://github.com/facebook/jest/issues/3764
+      expect(false).toBeTruthy();
+      return;
+    }
+    expect(logger).toBeDefined();
+    expect(logger.success).toBeDefined();
+    expect(logger.info).toBeDefined();
+    expect(logger.warn).toBeDefined();
+    expect(logger.debug).toBeDefined();
+    expect(logger.error).toBeDefined();
+  });
+
+  it('should return logger with all methods when given an empty config', () => {
+    const mockRequireModule = jest.fn();
+    mockRequireModule.mockReturnValue({});
+    const { logger }: { logger?: Logger } = gluestickPluginBunyan(
+      {},
+      { requireModule: mockRequireModule },
+    );
+    expect(logger).not.toBeDefined();
+  });
 });

--- a/packages/gluestick-plugin-bunyan/src/__tests__/server.test.js
+++ b/packages/gluestick-plugin-bunyan/src/__tests__/server.test.js
@@ -29,8 +29,8 @@ describe('Bunyan plugin', () => {
         defaultLogger: mockLogger,
       },
     );
+    // Force a failure for Flow: https://github.com/facebook/jest/issues/3764
     if (!logger) {
-      // Force a failure for Flow: https://github.com/facebook/jest/issues/3764
       expect(false).toBeTruthy();
       return;
     }
@@ -42,7 +42,7 @@ describe('Bunyan plugin', () => {
     expect(logger.error).toBeDefined();
   });
 
-  it('should return logger with all methods when given an empty config', () => {
+  it('should return the default logger if the config is empty', () => {
     const mockRequireModule = jest.fn();
     mockRequireModule.mockReturnValue({});
     const { logger }: { logger?: Logger } = gluestickPluginBunyan(
@@ -52,25 +52,15 @@ describe('Bunyan plugin', () => {
         defaultLogger: mockLogger,
       },
     );
-    expect(logger).not.toBeDefined();
-  });
-
-  it('should fail with a useful message if the config contains errors', () => {
-    const mockRequireModule = jest.fn();
-    mockRequireModule.mockReturnValue({
-      name: 'test',
-      serializers: 1,
-    });
-    const { logger }: { logger?: Logger } = gluestickPluginBunyan(
-      {},
-      {
-        requireModule: mockRequireModule,
-        defaultLogger: mockLogger,
-      },
-    );
-    expect(mockLogger.error.mock.calls[0][1]).toContain(
-      'config file contains errors',
-    );
-    expect(logger).not.toBeDefined();
+    // Force a failure for Flow: https://github.com/facebook/jest/issues/3764
+    if (!logger) {
+      expect(false).toBeTruthy();
+      return;
+    }
+    expect(logger).toBeDefined();
+    expect(logger).toHaveProperty('fields');
+    if (logger.fields && logger.fields.name) {
+      expect(logger.fields.name).toEqual('default name');
+    }
   });
 });

--- a/packages/gluestick-plugin-bunyan/src/__tests__/server.test.js
+++ b/packages/gluestick-plugin-bunyan/src/__tests__/server.test.js
@@ -4,6 +4,17 @@ import gluestickPluginBunyan from '../server.js';
 import type { Logger } from '../server.js';
 
 describe('Bunyan plugin', () => {
+  let mockLogger;
+  beforeEach(() => {
+    mockLogger = {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      success: jest.fn(),
+      warn: jest.fn(),
+    };
+  });
+
   it('should return logger with all methods when given a valid config', () => {
     const mockRequireModule = jest.fn();
     mockRequireModule.mockReturnValue({
@@ -13,7 +24,10 @@ describe('Bunyan plugin', () => {
     });
     const { logger }: { logger?: Logger } = gluestickPluginBunyan(
       {},
-      { requireModule: mockRequireModule },
+      {
+        requireModule: mockRequireModule,
+        defaultLogger: mockLogger,
+      },
     );
     if (!logger) {
       // Force a failure for Flow: https://github.com/facebook/jest/issues/3764
@@ -33,7 +47,29 @@ describe('Bunyan plugin', () => {
     mockRequireModule.mockReturnValue({});
     const { logger }: { logger?: Logger } = gluestickPluginBunyan(
       {},
-      { requireModule: mockRequireModule },
+      {
+        requireModule: mockRequireModule,
+        defaultLogger: mockLogger,
+      },
+    );
+    expect(logger).not.toBeDefined();
+  });
+
+  it('should fail with a useful message if the config contains errors', () => {
+    const mockRequireModule = jest.fn();
+    mockRequireModule.mockReturnValue({
+      name: 'test',
+      serializers: 1,
+    });
+    const { logger }: { logger?: Logger } = gluestickPluginBunyan(
+      {},
+      {
+        requireModule: mockRequireModule,
+        defaultLogger: mockLogger,
+      },
+    );
+    expect(mockLogger.error.mock.calls[0][1]).toContain(
+      'config file contains errors',
     );
     expect(logger).not.toBeDefined();
   });

--- a/packages/gluestick-plugin-bunyan/src/server.js
+++ b/packages/gluestick-plugin-bunyan/src/server.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import bunyan from 'bunyan';
+import path from 'path';
 
 export type Options = {
   name: string,
@@ -19,18 +20,29 @@ export type Logger = {
   error: Function,
 };
 
+type PluginUtilities = {
+  requireModule: Function,
+};
+
 const defaultSettings: Options = {
   name: 'default name',
 };
 
-const bunyanPlugin = (): { logger: Logger } => {
-  let options: Options = defaultSettings;
+const bunyanPlugin = (
+  opts: Object,
+  { requireModule }: PluginUtilities,
+): { logger?: Logger } => {
+  let options: Options = { ...defaultSettings };
   try {
-    // $FlowIgnore
-    const userSettings: Options = require('src/bunyan.config.js').default;
+    const userSettings: Options = requireModule(
+      path.join(process.cwd(), 'src/bunyan.config.js'),
+    );
     options = Object.assign(options, userSettings);
   } catch (error) {
     // NOOP if we haven't settings from user we use default.
+  }
+  if (Object.keys(options).length <= Object.keys(defaultSettings).length) {
+    return {};
   }
   const loggerWithSuccessMethod: Logger = bunyan.createLogger(options);
   loggerWithSuccessMethod.success = loggerWithSuccessMethod.info;

--- a/packages/gluestick-plugin-bunyan/src/server.js
+++ b/packages/gluestick-plugin-bunyan/src/server.js
@@ -22,6 +22,7 @@ export type Logger = {
 
 type PluginUtilities = {
   requireModule: Function,
+  defaultLogger: Logger,
 };
 
 const defaultSettings: Options = {
@@ -30,7 +31,7 @@ const defaultSettings: Options = {
 
 const bunyanPlugin = (
   opts: Object,
-  { requireModule }: PluginUtilities,
+  { requireModule, defaultLogger }: PluginUtilities,
 ): { logger?: Logger } => {
   let options: Options = { ...defaultSettings };
   try {
@@ -44,11 +45,16 @@ const bunyanPlugin = (
   if (Object.keys(options).length <= Object.keys(defaultSettings).length) {
     return {};
   }
-  const loggerWithSuccessMethod: Logger = bunyan.createLogger(options);
-  loggerWithSuccessMethod.success = loggerWithSuccessMethod.info;
-  return {
-    logger: loggerWithSuccessMethod,
-  };
+  try {
+    const loggerWithSuccessMethod: Logger = bunyan.createLogger(options);
+    loggerWithSuccessMethod.success = loggerWithSuccessMethod.info;
+    return {
+      logger: loggerWithSuccessMethod,
+    };
+  } catch (error) {
+    defaultLogger.error({ error }, 'The Bunyan config file contains errors.');
+    return {};
+  }
 };
 
 bunyanPlugin.meta = { name: 'gluestick-plugin-bunyan' };

--- a/packages/gluestick/src/plugins/prepareServerPlugins.js
+++ b/packages/gluestick/src/plugins/prepareServerPlugins.js
@@ -3,6 +3,7 @@
 import type { ServerPlugin, Plugin, BaseLogger } from '../types';
 
 const { createArrowList } = require('../cli/helpers');
+const { requireModule } = require('../utils');
 
 type CopilationResults = {
   [key: string]: Function | Object,
@@ -84,6 +85,7 @@ module.exports = (logger: BaseLogger, plugins: PluginRef[]): ServerPlugin[] => {
         // will be available for plugins to use.
         const compilationResults: Object = compilePlugin(normalizedPlugin, {
           logger,
+          requireModule,
         });
         if (compilationResults.error) {
           throw compilationResults.error;


### PR DESCRIPTION
The Bunyan plugin was not actually loading in an app's config file, therefore always using a default Bunyan configuration.

Changes made:
* Use requireModule to digest bunyan config file
* Update test to mock requireModule
* Add test for empty config case