### PR TITLE
Add Flow library definitions for Webpack-aliased imports.

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -10,8 +10,8 @@
 [include]
 
 [libs]
-flow/.*
-flow-typed/.*
+flow/
+flow-typed/
 
 [options]
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe

--- a/flow/application-config.js.flow
+++ b/flow/application-config.js.flow
@@ -1,0 +1,40 @@
+declare module 'application-config' {
+  declare type GSConfig = {
+    protocol: string,
+    host: string,
+    ports: {
+      client: number,
+      server: number,
+    },
+    publicPath: string,
+    buildStaticPath: string,
+    buildAssetsPath: string,
+    buildRendererPath: string,
+    buildDllPath: string,
+    assetsPath: string,
+    sourcePath: string,
+    sharedPath: string,
+    appsPath: string,
+    configPath: string,
+    entryWrapperPath: string,
+    clientEntryInitPath: string,
+    serverEntriesPath: string,
+    entriesPath: string,
+    reduxMiddlewares: string,
+    webpackChunks: string,
+    webpackStats: string,
+    proxyLogLevel: string,
+    debugWatchDirectories: string[],
+    defaultErrorTemplatePath: string,
+    customErrorTemplatePath: string,
+    vendorSourcePath: string,
+    autoUpgrade: {
+      added: string[],
+      changed: string[],
+    },
+    enableErrorOverlay: boolean,
+    [key: string]: any,
+  };
+
+  declare module.exports: GSConfig;
+}

--- a/flow/entry-wrapper.js.flow
+++ b/flow/entry-wrapper.js.flow
@@ -1,0 +1,3 @@
+declare module 'entry-wrapper' {
+  declare module.exports: Object;
+}

--- a/flow/gluestick-hooks.js.flow
+++ b/flow/gluestick-hooks.js.flow
@@ -1,0 +1,5 @@
+declare module 'gluestick-hooks' {
+  declare module.exports: {
+    default: Object,
+  };
+}

--- a/flow/project-entries-config.js.flow
+++ b/flow/project-entries-config.js.flow
@@ -1,0 +1,12 @@
+declare module 'project-entries-config' {
+  declare type EntriesConfig = {
+    [key: string]: {
+      component: string,
+      routes: string,
+      reducers: string,
+      name?: string,
+    },
+  };
+
+  declare module.exports: EntriesConfig;
+}

--- a/flow/project-entries.js.flow
+++ b/flow/project-entries.js.flow
@@ -1,0 +1,16 @@
+declare module 'project-entries' {
+  declare type Entries = {
+    [key: string]: {
+      component: Function,
+      routes: Function,
+      reducers: Object,
+      name?: string,
+      config?: Object,
+    },
+  };
+
+  declare module.exports: {
+    default: Entries,
+    plugins: Object[],
+  };
+}

--- a/flow/redux-middlewares.js.flow
+++ b/flow/redux-middlewares.js.flow
@@ -1,0 +1,11 @@
+declare module 'redux-middlewares' {
+  declare type ReduxMiddlewares = any[];
+  declare type ThunkMiddleware = ?Function;
+  declare type ReduxEnhancers = any[];
+
+  declare module.exports: {
+    default: ReduxMiddlewares,
+    thunkMiddleware: ThunkMiddleware,
+    enhancers: ReduxEnhancers,
+  };
+}

--- a/packages/gluestick/src/config/compileWebpackConfig.js
+++ b/packages/gluestick/src/config/compileWebpackConfig.js
@@ -198,11 +198,11 @@ module.exports = (
       external => typeof external === 'function',
     );
     const originalHandler: Function =
-      // $FlowIgnore flow is $hit, and doesn't know that `externals` was check for not being undefied
+      // $FlowIgnore
       serverEnvConfigFinal.externals[handlerIndex];
-    // $FlowIgnore flow is $hit, and doesn't know that `externals` was check for not being undefied
+    // $FlowIgnore
     serverEnvConfigFinal.externals.splice(handlerIndex, 1);
-    // $FlowIgnore flow is $hit, and doesn't know that `externals` was check for not being undefied
+    // $FlowIgnore
     serverEnvConfigFinal.externals.push((ctx, req, cb) => {
       const packageName = extract_package_name(req);
       return Object.keys(

--- a/packages/gluestick/src/renderer/main.js
+++ b/packages/gluestick/src/renderer/main.js
@@ -30,7 +30,6 @@ const onFinished = require('on-finished');
 const applicationConfig = require('application-config').default;
 const entries = require('project-entries').default;
 const entriesConfig = require('project-entries-config');
-// $FlowIgnore
 const EntryWrapper = require('entry-wrapper').default;
 const BodyWrapper = require('./components/Body').default;
 const reduxMiddlewares = require('redux-middlewares').default;

--- a/packages/gluestick/src/renderer/main.js
+++ b/packages/gluestick/src/renderer/main.js
@@ -29,7 +29,6 @@ const readAssets = require('./helpers/readAssets');
 const onFinished = require('on-finished');
 const applicationConfig = require('application-config').default;
 const entries = require('project-entries').default;
-// $FlowIgnore
 const entriesConfig = require('project-entries-config');
 // $FlowIgnore
 const EntryWrapper = require('entry-wrapper').default;

--- a/packages/gluestick/src/renderer/main.js
+++ b/packages/gluestick/src/renderer/main.js
@@ -27,7 +27,6 @@ const compression = require('compression');
 const middleware = require('./middleware');
 const readAssets = require('./helpers/readAssets');
 const onFinished = require('on-finished');
-// $FlowIgnore
 const applicationConfig = require('application-config').default;
 const entries = require('project-entries').default;
 // $FlowIgnore

--- a/packages/gluestick/src/renderer/main.js
+++ b/packages/gluestick/src/renderer/main.js
@@ -17,7 +17,6 @@ import type {
 
 // Intentionally first require so things like require("newrelic") in
 // preInitHook get instantiated before anything else. This improves profiling
-// $FlowIgnore
 const projectHooks = require('gluestick-hooks').default;
 
 const path = require('path');
@@ -34,9 +33,7 @@ const EntryWrapper = require('entry-wrapper').default;
 const BodyWrapper = require('./components/Body').default;
 const reduxMiddlewares = require('redux-middlewares').default;
 const thunkMiddleware = require('redux-middlewares').thunkMiddleware;
-// $FlowIgnore
 const reduxEnhancers = require('redux-middlewares').enhancers;
-// $FlowIgnore
 const entriesPlugins = require('project-entries').plugins;
 
 const hooksHelper = require('./helpers/hooks');

--- a/packages/gluestick/src/types.js
+++ b/packages/gluestick/src/types.js
@@ -151,16 +151,6 @@ export type RenderOutput = {
   rootElement: Object,
 };
 
-export type ComponentCachingConfig = {
-  strategy: string,
-  enable: boolean,
-  genCacheKey: (*) => string,
-  preserveKeys?: string[],
-  preserveEmptyKeys?: string[],
-  ignoreKeys?: string[],
-  whiteListNonStringKeys?: string[],
-};
-
 export type GetCachedIfProd = (req: Request, cache?: Object) => string | null;
 export type SetCacheIfProd = (
   req: Request,

--- a/packages/gluestick/src/types.js
+++ b/packages/gluestick/src/types.js
@@ -1,43 +1,7 @@
 /* @flow */
+export type { GSConfig } from 'application-config';
 
 export type ProjectConfig = {
-  [key: string]: any,
-};
-
-export type GSConfig = {
-  protocol: string,
-  host: string,
-  ports: {
-    client: number,
-    server: number,
-  },
-  publicPath: string,
-  buildStaticPath: string,
-  buildAssetsPath: string,
-  buildRendererPath: string,
-  buildDllPath: string,
-  assetsPath: string,
-  sourcePath: string,
-  sharedPath: string,
-  appsPath: string,
-  configPath: string,
-  entryWrapperPath: string,
-  clientEntryInitPath: string,
-  serverEntriesPath: string,
-  entriesPath: string,
-  reduxMiddlewares: string,
-  webpackChunks: string,
-  webpackStats: string,
-  proxyLogLevel: string,
-  debugWatchDirectories: string[],
-  defaultErrorTemplatePath: string,
-  customErrorTemplatePath: string,
-  vendorSourcePath: string,
-  autoUpgrade: {
-    added: string[],
-    changed: string[],
-  },
-  enableErrorOverlay: boolean,
   [key: string]: any,
 };
 

--- a/packages/gluestick/src/types.js
+++ b/packages/gluestick/src/types.js
@@ -1,5 +1,9 @@
 /* @flow */
+import type { GSConfig } from 'application-config';
+
 export type { GSConfig } from 'application-config';
+export type { Entries } from 'project-entries';
+export type { EntriesConfig } from 'project-entries-config';
 
 export type ProjectConfig = {
   [key: string]: any,
@@ -131,25 +135,6 @@ export type Request = {
   hostname: string,
   headers: Object,
   method: string,
-};
-
-export type Entries = {
-  [key: string]: {
-    component: Function,
-    routes: Function,
-    reducers: Object,
-    name?: string,
-    config?: Object,
-  },
-};
-
-export type EntriesConfig = {
-  [key: string]: {
-    component: string,
-    routes: string,
-    reducers: string,
-    name?: string,
-  },
 };
 
 export type RenderRequirements = {


### PR DESCRIPTION
Gluestick uses lots of Webpack aliases to reference files in the user project. The Flow error (unknown module) was suppressed for all of them.

This takes all the existing typings and moves them to library definitions, so that imports are correctly typed.