### PR TITLE
Move static imports to middleware.js and set up test mocks.

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "moduleNameMapper": {
       "^application-config$": "<rootDir>/packages/gluestick/src/__tests__/mocks/applicationConfig.js",
       "^entry-wrapper$": "<rootDir>/packages/gluestick/src/__tests__/mocks/EntryWrapper.js",
+      "^gluestick-hooks$": "<rootDir>/packages/gluestick/src/__tests__/mocks/gluestickHooks.js",
       "^redux-middlewares$": "<rootDir>/packages/gluestick/src/__tests__/mocks/reduxMiddlewares.js",
       "^project-entries$": "<rootDir>/packages/gluestick/src/__tests__/mocks/projectEntries.js",
       "^project-entries-config$": "<rootDir>/packages/gluestick/src/__tests__/mocks/projectEntriesConfig.js"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "install:yarn:ci": "yarn install --frozen-lockfile && yarn run build && yarn run yarn:install:ci && lerna bootstrap --concurrency=1",
     "clean": "lerna clean --yes",
     "test": "jest --bail --no-cache -i",
+    "test:watch": "jest --watch",
     "test-coverage": "npm run test -- --coverage",
     "lint": "eslint ./packages",
     "flow": "flow",
@@ -64,7 +65,10 @@
     "transform": {
       "\\.js$": "<rootDir>/jestTransform.js"
     },
-    "testRegex": "(src|shared)/(.*/)?__tests__/.*\\.test\\.js$"
+    "testRegex": "(src|shared)/(.*/)?__tests__/.*\\.test\\.js$",
+    "moduleNameMapper": {
+      "project-entries": "<rootDir>/packages/gluestick/src/__tests__/mocks/context.js"
+    }
   },
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "moduleNameMapper": {
       "^application-config$": "<rootDir>/packages/gluestick/src/__tests__/mocks/applicationConfig.js",
       "^entry-wrapper$": "<rootDir>/packages/gluestick/src/__tests__/mocks/EntryWrapper.js",
+      "^redux-middlewares$": "<rootDir>/packages/gluestick/src/__tests__/mocks/reduxMiddlewares.js",
       "^project-entries$": "<rootDir>/packages/gluestick/src/__tests__/mocks/projectEntries.js",
       "^project-entries-config$": "<rootDir>/packages/gluestick/src/__tests__/mocks/projectEntriesConfig.js"
     }

--- a/package.json
+++ b/package.json
@@ -67,9 +67,10 @@
     },
     "testRegex": "(src|shared)/(.*/)?__tests__/.*\\.test\\.js$",
     "moduleNameMapper": {
+      "^application-config$": "<rootDir>/packages/gluestick/src/__tests__/mocks/applicationConfig.js",
+      "^entry-wrapper$": "<rootDir>/packages/gluestick/src/__tests__/mocks/EntryWrapper.js",
       "^project-entries$": "<rootDir>/packages/gluestick/src/__tests__/mocks/projectEntries.js",
-      "^project-entries-config$": "<rootDir>/packages/gluestick/src/__tests__/mocks/projectEntriesConfig.js",
-      "^entry-wrapper$": "<rootDir>/packages/gluestick/src/__tests__/mocks/EntryWrapper.js"
+      "^project-entries-config$": "<rootDir>/packages/gluestick/src/__tests__/mocks/projectEntriesConfig.js"
     }
   },
   "private": true,

--- a/package.json
+++ b/package.json
@@ -67,7 +67,9 @@
     },
     "testRegex": "(src|shared)/(.*/)?__tests__/.*\\.test\\.js$",
     "moduleNameMapper": {
-      "project-entries": "<rootDir>/packages/gluestick/src/__tests__/mocks/context.js"
+      "^project-entries$": "<rootDir>/packages/gluestick/src/__tests__/mocks/projectEntries.js",
+      "^project-entries-config$": "<rootDir>/packages/gluestick/src/__tests__/mocks/projectEntriesConfig.js",
+      "^entry-wrapper$": "<rootDir>/packages/gluestick/src/__tests__/mocks/EntryWrapper.js"
     }
   },
   "private": true,

--- a/packages/gluestick/src/__tests__/mocks/EntryWrapper.js
+++ b/packages/gluestick/src/__tests__/mocks/EntryWrapper.js
@@ -1,0 +1,1 @@
+module.exports = () => {};

--- a/packages/gluestick/src/__tests__/mocks/applicationConfig.js
+++ b/packages/gluestick/src/__tests__/mocks/applicationConfig.js
@@ -1,0 +1,2 @@
+// @flow
+export default {};

--- a/packages/gluestick/src/__tests__/mocks/gluestickHooks.js
+++ b/packages/gluestick/src/__tests__/mocks/gluestickHooks.js
@@ -1,0 +1,4 @@
+// @flow
+export default {
+  default: {},
+};

--- a/packages/gluestick/src/__tests__/mocks/projectEntries.js
+++ b/packages/gluestick/src/__tests__/mocks/projectEntries.js
@@ -1,2 +1,17 @@
 /* @flow */
-export default {};
+import React from 'react';
+
+export default {
+  default: {
+    '/': {
+      component: class extends React.Component {
+        render() {
+          return <div>Index</div>;
+        }
+      },
+      reducers: {},
+      routes: () => [{}],
+    },
+  },
+  plugins: [],
+};

--- a/packages/gluestick/src/__tests__/mocks/projectEntries.js
+++ b/packages/gluestick/src/__tests__/mocks/projectEntries.js
@@ -1,0 +1,2 @@
+/* @flow */
+export default {};

--- a/packages/gluestick/src/__tests__/mocks/projectEntriesConfig.js
+++ b/packages/gluestick/src/__tests__/mocks/projectEntriesConfig.js
@@ -1,0 +1,2 @@
+/* @flow */
+export default {};

--- a/packages/gluestick/src/__tests__/mocks/reduxMiddlewares.js
+++ b/packages/gluestick/src/__tests__/mocks/reduxMiddlewares.js
@@ -1,0 +1,6 @@
+// @flow
+export default {
+  default: [],
+  thunkMiddleware: null,
+  enhancers: [],
+};

--- a/packages/gluestick/src/renderer/__tests__/middleware.test.js
+++ b/packages/gluestick/src/renderer/__tests__/middleware.test.js
@@ -106,7 +106,6 @@ const getEntries = (routes): { default: Entries, plugins: Plugin[] } => ({
 });
 
 const assets = {};
-const loadjsConfig = {};
 
 const clearHookMock = (key: string) => {
   if (hooks[key]) {
@@ -144,7 +143,7 @@ describe('renderer/middleware', () => {
       context,
       request,
       response,
-      { assets, loadjsConfig },
+      { assets },
       options,
       { hooks, hooksHelper },
       [],
@@ -169,14 +168,10 @@ describe('renderer/middleware', () => {
       }),
     );
     const middleware = require('../middleware');
-    await middleware(
-      context,
-      request,
-      response,
-      { assets, loadjsConfig },
-      options,
-      { hooks, hooksHelper },
-    );
+    await middleware(context, request, response, { assets }, options, {
+      hooks,
+      hooksHelper,
+    });
     expect(hooks.preRenderFromCache).toHaveBeenCalledTimes(0);
     expect(hooks.postRenderRequirements).toHaveBeenCalledTimes(1);
     expect(hooks.preRedirect).toHaveBeenCalledTimes(1);
@@ -196,14 +191,10 @@ describe('renderer/middleware', () => {
       }),
     );
     const middleware = require('../middleware');
-    await middleware(
-      context,
-      request,
-      response,
-      { assets, loadjsConfig },
-      options,
-      { hooks, hooksHelper },
-    );
+    await middleware(context, request, response, { assets }, options, {
+      hooks,
+      hooksHelper,
+    });
     expect(hooks.preRenderFromCache).toHaveBeenCalledTimes(0);
     expect(hooks.postRenderRequirements).toHaveBeenCalledTimes(1);
     expect(hooks.preRedirect).toHaveBeenCalledTimes(0);
@@ -218,14 +209,10 @@ describe('renderer/middleware', () => {
     jest.doMock('project-entries', () => ({ default: {}, plugins: [] }));
     const errorHandler = require('../helpers/errorHandler');
     const middleware = require('../middleware');
-    await middleware(
-      context,
-      request,
-      response,
-      { assets, loadjsConfig },
-      options,
-      { hooks, hooksHelper },
-    );
+    await middleware(context, request, response, { assets }, options, {
+      hooks,
+      hooksHelper,
+    });
     expect(hooks.error).toHaveBeenCalledTimes(1);
     expect(errorHandler).toHaveBeenCalledTimes(1);
   });
@@ -246,7 +233,7 @@ describe('renderer/middleware', () => {
         context,
         Object.assign(request, { url: '/cached' }),
         response,
-        { assets, loadjsConfig },
+        { assets },
         options,
         { hooks, hooksHelper },
       );

--- a/packages/gluestick/src/renderer/__tests__/middleware.test.js
+++ b/packages/gluestick/src/renderer/__tests__/middleware.test.js
@@ -1,5 +1,4 @@
 /* @flow */
-
 import type {
   Context,
   Request,
@@ -108,8 +107,6 @@ const getEntries = (routes): { default: Entries, plugins: Plugin[] } => ({
 
 const assets = {};
 const loadjsConfig = {};
-const EntryWrapper = {};
-const BodyWrapper = {};
 
 const clearHookMock = (key: string) => {
   if (hooks[key]) {
@@ -147,7 +144,6 @@ describe('renderer/middleware', () => {
       context,
       request,
       response,
-      { EntryWrapper, BodyWrapper },
       { assets, loadjsConfig },
       options,
       { hooks, hooksHelper },
@@ -177,7 +173,6 @@ describe('renderer/middleware', () => {
       context,
       request,
       response,
-      { EntryWrapper, BodyWrapper },
       { assets, loadjsConfig },
       options,
       { hooks, hooksHelper },
@@ -205,7 +200,6 @@ describe('renderer/middleware', () => {
       context,
       request,
       response,
-      { EntryWrapper, BodyWrapper },
       { assets, loadjsConfig },
       options,
       { hooks, hooksHelper },
@@ -220,7 +214,7 @@ describe('renderer/middleware', () => {
     expect(response.sendStatus.mock.calls[0]).toEqual([404]);
   });
 
-  it.only('should call errorHandler', async () => {
+  it('should call errorHandler', async () => {
     jest.doMock('project-entries', () => ({ default: {}, plugins: [] }));
     const errorHandler = require('../helpers/errorHandler');
     const middleware = require('../middleware');
@@ -228,7 +222,6 @@ describe('renderer/middleware', () => {
       context,
       request,
       response,
-      { EntryWrapper, BodyWrapper },
       { assets, loadjsConfig },
       options,
       { hooks, hooksHelper },
@@ -253,7 +246,6 @@ describe('renderer/middleware', () => {
         context,
         Object.assign(request, { url: '/cached' }),
         response,
-        { EntryWrapper, BodyWrapper },
         { assets, loadjsConfig },
         options,
         { hooks, hooksHelper },

--- a/packages/gluestick/src/renderer/__tests__/middleware.test.js
+++ b/packages/gluestick/src/renderer/__tests__/middleware.test.js
@@ -81,15 +81,6 @@ const hooks: GSHooks = {
   error: jest.fn(v => v),
 };
 
-const options = {
-  envVariables: [],
-  httpClient: {},
-  entryWrapperConfig: {},
-  reduxMiddlewares: [],
-  thunkMiddleware: null,
-  reduxEnhancers: [],
-};
-
 const getEntries = (routes): { default: Entries, plugins: Plugin[] } => ({
   default: {
     '/': {
@@ -144,7 +135,6 @@ describe('renderer/middleware', () => {
       request,
       response,
       { assets },
-      options,
       { hooks, hooksHelper },
       [],
     );
@@ -168,10 +158,16 @@ describe('renderer/middleware', () => {
       }),
     );
     const middleware = require('../middleware');
-    await middleware(context, request, response, { assets }, options, {
-      hooks,
-      hooksHelper,
-    });
+    await middleware(
+      context,
+      request,
+      response,
+      { assets },
+      {
+        hooks,
+        hooksHelper,
+      },
+    );
     expect(hooks.preRenderFromCache).toHaveBeenCalledTimes(0);
     expect(hooks.postRenderRequirements).toHaveBeenCalledTimes(1);
     expect(hooks.preRedirect).toHaveBeenCalledTimes(1);
@@ -191,10 +187,16 @@ describe('renderer/middleware', () => {
       }),
     );
     const middleware = require('../middleware');
-    await middleware(context, request, response, { assets }, options, {
-      hooks,
-      hooksHelper,
-    });
+    await middleware(
+      context,
+      request,
+      response,
+      { assets },
+      {
+        hooks,
+        hooksHelper,
+      },
+    );
     expect(hooks.preRenderFromCache).toHaveBeenCalledTimes(0);
     expect(hooks.postRenderRequirements).toHaveBeenCalledTimes(1);
     expect(hooks.preRedirect).toHaveBeenCalledTimes(0);
@@ -209,10 +211,16 @@ describe('renderer/middleware', () => {
     jest.doMock('project-entries', () => ({ default: {}, plugins: [] }));
     const errorHandler = require('../helpers/errorHandler');
     const middleware = require('../middleware');
-    await middleware(context, request, response, { assets }, options, {
-      hooks,
-      hooksHelper,
-    });
+    await middleware(
+      context,
+      request,
+      response,
+      { assets },
+      {
+        hooks,
+        hooksHelper,
+      },
+    );
     expect(hooks.error).toHaveBeenCalledTimes(1);
     expect(errorHandler).toHaveBeenCalledTimes(1);
   });
@@ -234,7 +242,6 @@ describe('renderer/middleware', () => {
         Object.assign(request, { url: '/cached' }),
         response,
         { assets },
-        options,
         { hooks, hooksHelper },
       );
       expect(hooks.preRenderFromCache).toHaveBeenCalledTimes(1);

--- a/packages/gluestick/src/renderer/main.js
+++ b/packages/gluestick/src/renderer/main.js
@@ -120,14 +120,11 @@ module.exports = function startRenderer({ config, logger }: Context) {
 
     readAssets(assetsFilename)
       .then((assets: Object): Promise<void> => {
-        return middleware(
-          { config, logger },
-          req,
-          res,
-          { assets },
-          { hooks, hooksHelper: hooksHelper.call },
+        return middleware({ config, logger }, req, res, {
+          assets,
+          hooks,
           serverPlugins,
-        );
+        });
       })
       .catch((error: Error) => {
         logger.error(error);

--- a/packages/gluestick/src/renderer/main.js
+++ b/packages/gluestick/src/renderer/main.js
@@ -28,9 +28,6 @@ const readAssets = require('./helpers/readAssets');
 const onFinished = require('on-finished');
 const applicationConfig = require('application-config').default;
 const entries = require('project-entries').default;
-const reduxMiddlewares = require('redux-middlewares').default;
-const thunkMiddleware = require('redux-middlewares').thunkMiddleware;
-const reduxEnhancers = require('redux-middlewares').enhancers;
 const entriesPlugins = require('project-entries').plugins;
 
 const hooksHelper = require('./helpers/hooks');
@@ -38,11 +35,6 @@ const prepareServerPlugins = require('../plugins/prepareServerPlugins');
 const createPluginUtils = require('../plugins/utils');
 const setProxies = require('./helpers/setProxies');
 const parseRoutePath = require('./helpers/parseRoutePath');
-
-const envVariables: string[] =
-  process.env.ENV_VARIABLES && Array.isArray(process.env.ENV_VARIABLES)
-    ? process.env.ENV_VARIABLES
-    : [];
 
 module.exports = function startRenderer({ config, logger }: Context) {
   const assetsFilename = path.join(
@@ -132,15 +124,7 @@ module.exports = function startRenderer({ config, logger }: Context) {
           { config, logger },
           req,
           res,
-          { assets, loadjsConfig: applicationConfig.loadjs || {} },
-          {
-            reduxMiddlewares,
-            thunkMiddleware,
-            reduxEnhancers,
-            envVariables,
-            httpClient: applicationConfig.httpClient || {},
-            entryWrapperConfig: {},
-          },
+          { assets },
           { hooks, hooksHelper: hooksHelper.call },
           serverPlugins,
         );

--- a/packages/gluestick/src/renderer/main.js
+++ b/packages/gluestick/src/renderer/main.js
@@ -28,8 +28,6 @@ const readAssets = require('./helpers/readAssets');
 const onFinished = require('on-finished');
 const applicationConfig = require('application-config').default;
 const entries = require('project-entries').default;
-const EntryWrapper = require('entry-wrapper').default;
-const BodyWrapper = require('./components/Body').default;
 const reduxMiddlewares = require('redux-middlewares').default;
 const thunkMiddleware = require('redux-middlewares').thunkMiddleware;
 const reduxEnhancers = require('redux-middlewares').enhancers;
@@ -134,7 +132,6 @@ module.exports = function startRenderer({ config, logger }: Context) {
           { config, logger },
           req,
           res,
-          { EntryWrapper, BodyWrapper },
           { assets, loadjsConfig: applicationConfig.loadjs || {} },
           {
             reduxMiddlewares,

--- a/packages/gluestick/src/renderer/main.js
+++ b/packages/gluestick/src/renderer/main.js
@@ -28,7 +28,6 @@ const readAssets = require('./helpers/readAssets');
 const onFinished = require('on-finished');
 const applicationConfig = require('application-config').default;
 const entries = require('project-entries').default;
-const entriesConfig = require('project-entries-config');
 const EntryWrapper = require('entry-wrapper').default;
 const BodyWrapper = require('./components/Body').default;
 const reduxMiddlewares = require('redux-middlewares').default;
@@ -78,11 +77,6 @@ module.exports = function startRenderer({ config, logger }: Context) {
   if (hooks.preInitServer) {
     hooksHelper.call(hooks.preInitServer);
   }
-
-  // Get runtime plugins that will be passed to EntryWrapper.
-  const runtimePlugins: Object[] = entriesPlugins
-    .filter((plugin: Object) => plugin.type === 'runtime')
-    .map((plugin: Object) => plugin.ref);
 
   const app: Object = express();
   app.use(compression());
@@ -140,7 +134,6 @@ module.exports = function startRenderer({ config, logger }: Context) {
           { config, logger },
           req,
           res,
-          { entries, entriesConfig, entriesPlugins: runtimePlugins },
           { EntryWrapper, BodyWrapper },
           { assets, loadjsConfig: applicationConfig.loadjs || {} },
           {

--- a/packages/gluestick/src/renderer/middleware.js
+++ b/packages/gluestick/src/renderer/middleware.js
@@ -28,6 +28,7 @@ const entriesConfig = require('project-entries-config');
 const entriesPlugins = require('project-entries').plugins;
 const EntryWrapper = require('entry-wrapper').default;
 const BodyWrapper = require('./components/Body').default;
+const applicationConfig = require('application-config').default;
 
 const isProduction = process.env.NODE_ENV === 'production';
 
@@ -44,7 +45,7 @@ module.exports = async function gluestickMiddleware(
   { config, logger }: Context,
   req: Request,
   res: Response,
-  { assets, loadjsConfig }: { assets: Object, loadjsConfig: Object },
+  { assets }: { assets: Object },
   options: Options = {
     envVariables: [],
     httpClient: {},
@@ -188,7 +189,7 @@ module.exports = async function gluestickMiddleware(
         entryWrapperConfig: options.entryWrapperConfig,
         envVariables: options.envVariables,
       },
-      { assets, loadjsConfig, cacheManager },
+      { assets, loadjsConfig: applicationConfig.loadjsConfig, cacheManager },
       { renderMethod },
     );
     const output: RenderOutput = hooksHelper(

--- a/packages/gluestick/src/renderer/middleware.js
+++ b/packages/gluestick/src/renderer/middleware.js
@@ -26,6 +26,8 @@ const createPluginUtils = require('../plugins/utils');
 const entries = require('project-entries').default;
 const entriesConfig = require('project-entries-config');
 const entriesPlugins = require('project-entries').plugins;
+const EntryWrapper = require('entry-wrapper').default;
+const BodyWrapper = require('./components/Body').default;
 
 const isProduction = process.env.NODE_ENV === 'production';
 
@@ -42,7 +44,6 @@ module.exports = async function gluestickMiddleware(
   { config, logger }: Context,
   req: Request,
   res: Response,
-  { EntryWrapper, BodyWrapper }: { EntryWrapper: Object, BodyWrapper: Object },
   { assets, loadjsConfig }: { assets: Object, loadjsConfig: Object },
   options: Options = {
     envVariables: [],
@@ -59,7 +60,6 @@ module.exports = async function gluestickMiddleware(
    * TODO: better logging
    */
   const cacheManager: CacheManager = getCacheManager(logger, isProduction);
-  console.log(entries);
   try {
     // Get runtime plugins that will be passed to EntryWrapper.
     const runtimePlugins: Object[] = entriesPlugins


### PR DESCRIPTION
Refactor main.js, middleware.js, and renderer.js to import aliased files instead of passing them along from one to the other. The goal is to have middleware match the signature of Express middleware of `(request, response)`. This is easier to understand, but also sets us up to use webpack-hot-server-middleware.

Stop renaming arguments as they flow through each file. Make import naming more consistent.
Update tests to allow mocking of alias imports.