### PR TITLE
Add semver dependency for #1167

### DIFF
--- a/packages/gluestick-cli/package-lock.json
+++ b/packages/gluestick-cli/package-lock.json
@@ -92,6 +92,7 @@
 			"requires": {
 				"anymatch": "1.3.2",
 				"async-each": "1.0.1",
+				"fsevents": "1.1.3",
 				"glob-parent": "2.0.0",
 				"inherits": "2.0.3",
 				"is-binary-path": "1.0.1",
@@ -208,6 +209,795 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"fsevents": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+			"optional": true,
+			"requires": {
+				"nan": "2.10.0",
+				"node-pre-gyp": "0.6.39"
+			},
+			"dependencies": {
+				"abbrev": {
+					"version": "1.1.0",
+					"bundled": true,
+					"optional": true
+				},
+				"ajv": {
+					"version": "4.11.8",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"aproba": {
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"delegates": "1.0.0",
+						"readable-stream": "2.2.9"
+					}
+				},
+				"asn1": {
+					"version": "0.2.3",
+					"bundled": true,
+					"optional": true
+				},
+				"assert-plus": {
+					"version": "0.2.0",
+					"bundled": true,
+					"optional": true
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"bundled": true,
+					"optional": true
+				},
+				"aws-sign2": {
+					"version": "0.6.0",
+					"bundled": true,
+					"optional": true
+				},
+				"aws4": {
+					"version": "1.6.0",
+					"bundled": true,
+					"optional": true
+				},
+				"balanced-match": {
+					"version": "0.4.2",
+					"bundled": true
+				},
+				"bcrypt-pbkdf": {
+					"version": "1.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"tweetnacl": "0.14.5"
+					}
+				},
+				"block-stream": {
+					"version": "0.0.9",
+					"bundled": true,
+					"requires": {
+						"inherits": "2.0.3"
+					}
+				},
+				"boom": {
+					"version": "2.10.1",
+					"bundled": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.7",
+					"bundled": true,
+					"requires": {
+						"balanced-match": "0.4.2",
+						"concat-map": "0.0.1"
+					}
+				},
+				"buffer-shims": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"bundled": true,
+					"optional": true
+				},
+				"co": {
+					"version": "4.6.0",
+					"bundled": true,
+					"optional": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"combined-stream": {
+					"version": "1.0.5",
+					"bundled": true,
+					"requires": {
+						"delayed-stream": "1.0.0"
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"cryptiles": {
+					"version": "2.0.5",
+					"bundled": true,
+					"requires": {
+						"boom": "2.10.1"
+					}
+				},
+				"dashdash": {
+					"version": "1.14.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.8",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"deep-extend": {
+					"version": "0.4.2",
+					"bundled": true,
+					"optional": true
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"ecc-jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"extend": {
+					"version": "3.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"extsprintf": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"forever-agent": {
+					"version": "0.6.1",
+					"bundled": true,
+					"optional": true
+				},
+				"form-data": {
+					"version": "2.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"asynckit": "0.4.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.15"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"fstream": {
+					"version": "1.0.11",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"inherits": "2.0.3",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.1"
+					}
+				},
+				"fstream-ignore": {
+					"version": "1.0.5",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"fstream": "1.0.11",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4"
+					}
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"aproba": "1.1.1",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
+					}
+				},
+				"getpass": {
+					"version": "0.1.7",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true
+				},
+				"har-schema": {
+					"version": "1.0.5",
+					"bundled": true,
+					"optional": true
+				},
+				"har-validator": {
+					"version": "4.2.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ajv": "4.11.8",
+						"har-schema": "1.0.5"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"hawk": {
+					"version": "3.1.3",
+					"bundled": true,
+					"requires": {
+						"boom": "2.10.1",
+						"cryptiles": "2.0.5",
+						"hoek": "2.16.3",
+						"sntp": "1.0.9"
+					}
+				},
+				"hoek": {
+					"version": "2.16.3",
+					"bundled": true
+				},
+				"http-signature": {
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "0.2.0",
+						"jsprim": "1.4.0",
+						"sshpk": "1.13.0"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"ini": {
+					"version": "1.3.4",
+					"bundled": true,
+					"optional": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"isstream": {
+					"version": "0.1.2",
+					"bundled": true,
+					"optional": true
+				},
+				"jodid25519": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"json-schema": {
+					"version": "0.2.3",
+					"bundled": true,
+					"optional": true
+				},
+				"json-stable-stringify": {
+					"version": "1.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsonify": "0.0.0"
+					}
+				},
+				"json-stringify-safe": {
+					"version": "5.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"jsonify": {
+					"version": "0.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"jsprim": {
+					"version": "1.4.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.0.2",
+						"json-schema": "0.2.3",
+						"verror": "1.3.6"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"mime-db": {
+					"version": "1.27.0",
+					"bundled": true
+				},
+				"mime-types": {
+					"version": "2.1.15",
+					"bundled": true,
+					"requires": {
+						"mime-db": "1.27.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"brace-expansion": "1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"node-pre-gyp": {
+					"version": "0.6.39",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"detect-libc": "1.0.2",
+						"hawk": "3.1.3",
+						"mkdirp": "0.5.1",
+						"nopt": "4.0.1",
+						"npmlog": "4.1.0",
+						"rc": "1.2.1",
+						"request": "2.81.0",
+						"rimraf": "2.6.1",
+						"semver": "5.3.0",
+						"tar": "2.2.1",
+						"tar-pack": "3.4.0"
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"abbrev": "1.1.0",
+						"osenv": "0.1.4"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"oauth-sign": {
+					"version": "0.8.2",
+					"bundled": true,
+					"optional": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"osenv": {
+					"version": "0.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"performance-now": {
+					"version": "0.2.0",
+					"bundled": true,
+					"optional": true
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"bundled": true
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"bundled": true,
+					"optional": true
+				},
+				"qs": {
+					"version": "6.4.0",
+					"bundled": true,
+					"optional": true
+				},
+				"rc": {
+					"version": "1.2.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"deep-extend": "0.4.2",
+						"ini": "1.3.4",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.2.9",
+					"bundled": true,
+					"requires": {
+						"buffer-shims": "1.0.0",
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "1.0.1",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"request": {
+					"version": "2.81.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.1.4",
+						"har-validator": "4.2.1",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.15",
+						"oauth-sign": "0.8.2",
+						"performance-now": "0.2.0",
+						"qs": "6.4.0",
+						"safe-buffer": "5.0.1",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.2",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.1",
+					"bundled": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.0.1",
+					"bundled": true
+				},
+				"semver": {
+					"version": "5.3.0",
+					"bundled": true,
+					"optional": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"sntp": {
+					"version": "1.0.9",
+					"bundled": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"sshpk": {
+					"version": "1.13.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"asn1": "0.2.3",
+						"assert-plus": "1.0.0",
+						"bcrypt-pbkdf": "1.0.1",
+						"dashdash": "1.14.1",
+						"ecc-jsbn": "0.1.1",
+						"getpass": "0.1.7",
+						"jodid25519": "1.0.2",
+						"jsbn": "0.1.1",
+						"tweetnacl": "0.14.5"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"stringstream": {
+					"version": "0.0.5",
+					"bundled": true,
+					"optional": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"tar": {
+					"version": "2.2.1",
+					"bundled": true,
+					"requires": {
+						"block-stream": "0.0.9",
+						"fstream": "1.0.11",
+						"inherits": "2.0.3"
+					}
+				},
+				"tar-pack": {
+					"version": "3.4.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"debug": "2.6.8",
+						"fstream": "1.0.11",
+						"fstream-ignore": "1.0.5",
+						"once": "1.4.0",
+						"readable-stream": "2.2.9",
+						"rimraf": "2.6.1",
+						"tar": "2.2.1",
+						"uid-number": "0.0.6"
+					}
+				},
+				"tough-cookie": {
+					"version": "2.3.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"punycode": "1.4.1"
+					}
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "0.14.5",
+					"bundled": true,
+					"optional": true
+				},
+				"uid-number": {
+					"version": "0.0.6",
+					"bundled": true,
+					"optional": true
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"uuid": {
+					"version": "3.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"verror": {
+					"version": "1.3.6",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"extsprintf": "1.0.2"
+					}
+				},
+				"wide-align": {
+					"version": "1.1.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"string-width": "1.0.2"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				}
+			}
 		},
 		"glob": {
 			"version": "7.1.1",
@@ -427,6 +1217,12 @@
 				"minimist": "0.0.8"
 			}
 		},
+		"nan": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+			"optional": true
+		},
 		"node-fetch": {
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -589,6 +1385,11 @@
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
 			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+		},
+		"semver": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",

--- a/packages/gluestick-cli/package.json
+++ b/packages/gluestick-cli/package.json
@@ -37,6 +37,7 @@
     "gluestick-generators": "2.0.0",
     "mkdirp": "0.5.1",
     "node-fetch": "^1.6.3",
-    "rimraf": "2.6.1"
+    "rimraf": "2.6.1",
+    "semver": "5.5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8725,13 +8725,13 @@ semver@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.1.0.tgz#85f2cf8550465c4df000cf7d86f6b054106ab9e5"
 
+semver@5.5.0, semver@^5.2:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
 semver@^4.1.0:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
-
-semver@^5.2:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 semver@~5.0.1:
   version "5.0.3"


### PR DESCRIPTION
The current prerelease throws an error whenever the gluestick CLI is invoked, due to a missing dependency that was introduced in #1167. This adds that dependency.

Commands demonstrating the issue:
```
› docker run -it truecar/gluestick:2.1.0-prerelease.1 /bin/bash
root@0760d5bf4e92:/app# which gluestick
/usr/local/bin/gluestick
root@0760d5bf4e92:/app# gluestick
module.js:549
    throw err;
    ^

Error: Cannot find module 'semver'
    at Function.Module._resolveFilename (module.js:547:15)
    at Function.Module._load (module.js:474:25)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/gluestick-cli/build/cli.js:7:16)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
```