### PR TITLE
Change hooks import to be static.

### DIFF
--- a/packages/gluestick/src/config/compileGlueStickConfig.js
+++ b/packages/gluestick/src/config/compileGlueStickConfig.js
@@ -1,7 +1,7 @@
 /* @flow */
 import type { ConfigPlugin, GSConfig, Logger } from '../types';
-import { callHook } from '../renderer/helpers/hooks';
 
+const callHook = require('../renderer/helpers/callHook');
 const clone = require('clone');
 const path = require('path');
 const defaultConfig = require('./defaults/glueStickConfig');

--- a/packages/gluestick/src/config/compileGlueStickConfig.js
+++ b/packages/gluestick/src/config/compileGlueStickConfig.js
@@ -1,10 +1,10 @@
 /* @flow */
 import type { ConfigPlugin, GSConfig, Logger } from '../types';
+import { callHook } from '../renderer/helpers/hooks';
 
 const clone = require('clone');
 const path = require('path');
 const defaultConfig = require('./defaults/glueStickConfig');
-const hooksHelper = require('../renderer/helpers/hooks');
 const { requireModule } = require('../utils');
 
 const getConfigHook = (logger: Logger): Function => {
@@ -12,7 +12,7 @@ const getConfigHook = (logger: Logger): Function => {
     const configHooks: Function = requireModule(
       path.join(process.cwd(), defaultConfig.gluestickConfigPath),
     );
-    return config => hooksHelper.call(configHooks, config);
+    return config => callHook(configHooks, config);
   } catch (e) {
     logger.warn(
       'GlueStick config hook was not found. Consider running `gluestick auto-upgrade`.',

--- a/packages/gluestick/src/config/compileWebpackConfig.js
+++ b/packages/gluestick/src/config/compileWebpackConfig.js
@@ -12,8 +12,6 @@ import type {
   WebpackHooks,
 } from '../types';
 
-import { callHook } from '../renderer/helpers/hooks';
-
 const path = require('path');
 const clone = require('clone');
 const getSharedConfig = require('./webpack/webpack.config');
@@ -22,6 +20,7 @@ const getServerConfig = require('./webpack/webpack.config.server');
 const prepareEntries = require('./webpack/prepareEntries');
 const readRuntimePlugins = require('../plugins/readRuntimePlugins');
 const readServerPlugins = require('../plugins/readServerPlugins');
+const callHook = require('../renderer/helpers/callHook');
 const { requireModule } = require('../utils');
 const {
   extract_package_name,

--- a/packages/gluestick/src/config/compileWebpackConfig.js
+++ b/packages/gluestick/src/config/compileWebpackConfig.js
@@ -12,6 +12,8 @@ import type {
   WebpackHooks,
 } from '../types';
 
+import { callHook } from '../renderer/helpers/hooks';
+
 const path = require('path');
 const clone = require('clone');
 const getSharedConfig = require('./webpack/webpack.config');
@@ -20,7 +22,6 @@ const getServerConfig = require('./webpack/webpack.config.server');
 const prepareEntries = require('./webpack/prepareEntries');
 const readRuntimePlugins = require('../plugins/readRuntimePlugins');
 const readServerPlugins = require('../plugins/readServerPlugins');
-const hookHelper = require('../renderer/helpers/hooks');
 const { requireModule } = require('../utils');
 const {
   extract_package_name,
@@ -180,13 +181,13 @@ module.exports = (
   }
 
   // Applies client hooks provided by user
-  const clientEnvConfigFinal: WebpackConfig = hookHelper.call(
+  const clientEnvConfigFinal: WebpackConfig = callHook(
     webpackConfigHooks.webpackClientConfig,
     clientEnvConfigOverwriten,
   );
 
   // Applies server hooks provided by user
-  const serverEnvConfigFinal: WebpackConfig = hookHelper.call(
+  const serverEnvConfigFinal: WebpackConfig = callHook(
     webpackConfigHooks.webpackServerConfig,
     serverEnvConfigOverwriten,
   );

--- a/packages/gluestick/src/config/vendorDll.js
+++ b/packages/gluestick/src/config/vendorDll.js
@@ -7,6 +7,7 @@ import type {
   WebpackConfig,
   WebpackHooks,
 } from '../types';
+import { callHook } from '../renderer/helpers/hooks';
 
 const path = require('path');
 const fs = require('fs');
@@ -15,7 +16,6 @@ const sha1 = require('sha1');
 const clone = require('clone');
 const progressHandler = require('./webpack/progressHandler');
 const { requireModule } = require('../utils');
-const hookHelper = require('../renderer/helpers/hooks');
 
 const manifestFilename: string = 'vendor-manifest.json';
 // Need to set env variable, so that server can access it
@@ -237,7 +237,7 @@ const getConfig = (
     logger.warn(e);
   }
 
-  return hookHelper.call(
+  return callHook(
     webpackConfigHooks.webpackVendorDllConfig,
     intermediateConfig,
   );

--- a/packages/gluestick/src/config/vendorDll.js
+++ b/packages/gluestick/src/config/vendorDll.js
@@ -7,7 +7,6 @@ import type {
   WebpackConfig,
   WebpackHooks,
 } from '../types';
-import { callHook } from '../renderer/helpers/hooks';
 
 const path = require('path');
 const fs = require('fs');
@@ -16,6 +15,7 @@ const sha1 = require('sha1');
 const clone = require('clone');
 const progressHandler = require('./webpack/progressHandler');
 const { requireModule } = require('../utils');
+const callHook = require('../renderer/helpers/callHook');
 
 const manifestFilename: string = 'vendor-manifest.json';
 // Need to set env variable, so that server can access it

--- a/packages/gluestick/src/renderer/__tests__/middleware.test.js
+++ b/packages/gluestick/src/renderer/__tests__/middleware.test.js
@@ -87,7 +87,7 @@ describe('renderer/middleware', () => {
   });
 
   it('should render output', async () => {
-    jest.doMock('project-entries', () =>
+    jest.mock('project-entries', () =>
       getEntries({
         mockBehaviour: {
           renderProps: {
@@ -97,10 +97,10 @@ describe('renderer/middleware', () => {
       }),
     );
     const hooks = getHooks();
+    jest.mock('gluestick-hooks', () => ({ default: hooks }));
     const middleware = require('../middleware');
     await middleware(request, response, {
       assets,
-      hooks,
     });
     expect(hooks.preRenderFromCache).toHaveBeenCalledTimes(0);
     expect(hooks.postRenderRequirements).toHaveBeenCalledTimes(1);
@@ -114,7 +114,7 @@ describe('renderer/middleware', () => {
   });
 
   it('should redirect', async () => {
-    jest.doMock('project-entries', () =>
+    jest.mock('project-entries', () =>
       getEntries({
         mockBehaviour: {
           redirect: true,
@@ -122,6 +122,7 @@ describe('renderer/middleware', () => {
       }),
     );
     const hooks = getHooks();
+    jest.mock('gluestick-hooks', () => ({ default: hooks }));
     const middleware = require('../middleware');
     await middleware(request, response, {
       assets,
@@ -138,7 +139,7 @@ describe('renderer/middleware', () => {
   });
 
   it('should send 404 status', async () => {
-    jest.doMock('project-entries', () =>
+    jest.mock('project-entries', () =>
       getEntries({
         mockBehaviour: {
           renderProps: null,
@@ -146,6 +147,7 @@ describe('renderer/middleware', () => {
       }),
     );
     const hooks = getHooks();
+    jest.mock('gluestick-hooks', () => ({ default: hooks }));
     const middleware = require('../middleware');
     await middleware(request, response, {
       assets,
@@ -162,8 +164,9 @@ describe('renderer/middleware', () => {
   });
 
   it('should call errorHandler', async () => {
-    jest.doMock('project-entries', () => ({ default: {}, plugins: [] }));
+    jest.mock('project-entries', () => ({ default: {}, plugins: [] }));
     const hooks = getHooks();
+    jest.mock('gluestick-hooks', () => ({ default: hooks }));
     const errorHandler = require('../helpers/errorHandler');
     const middleware = require('../middleware');
     await middleware(request, response, {
@@ -176,7 +179,7 @@ describe('renderer/middleware', () => {
 
   describe('in production', () => {
     it('should send cached output', async () => {
-      jest.doMock('project-entries', () =>
+      jest.mock('project-entries', () =>
         getEntries({
           mockBehaviour: {
             renderProps: {
@@ -186,6 +189,7 @@ describe('renderer/middleware', () => {
         }),
       );
       const hooks = getHooks();
+      jest.mock('gluestick-hooks', () => ({ default: hooks }));
       const middleware = require('../middleware');
       await middleware(Object.assign(request, { url: '/cached' }), response, {
         assets,

--- a/packages/gluestick/src/renderer/helpers/callHook.js
+++ b/packages/gluestick/src/renderer/helpers/callHook.js
@@ -1,0 +1,11 @@
+// @flow
+const callHook = (hooks: ?(Function | Function[]), arg?: any): any => {
+  if (hooks) {
+    return Array.isArray(hooks)
+      ? hooks.reduce((val, hook) => hook(val), arg)
+      : hooks(arg);
+  }
+  return arg;
+};
+
+module.exports = callHook;

--- a/packages/gluestick/src/renderer/helpers/hooks.js
+++ b/packages/gluestick/src/renderer/helpers/hooks.js
@@ -1,44 +1,46 @@
 /* @flow */
-import type { ServerPlugin } from '../../types';
+import type { GSHooks, ServerPlugin } from '../../types';
 
-module.exports = {
-  // by making hooks static, we don't need to do any null checks on call
-  // this can be refactored out
-  call: (hooks: ?(Function | Function[]), arg?: any): any => {
-    if (hooks) {
-      return Array.isArray(hooks)
-        ? hooks.reduce((val, hook) => hook(val), arg)
-        : hooks(arg);
-    }
-    return arg;
-  },
-  // should be done once on import of hooks! this way we won't even
-  // interact with raw gluestick-hooks import directly
-  merge: (projectHooks: Object, plugins: ServerPlugin[]): Object => {
-    const mergedHooks = plugins
-      .filter((plugin: ServerPlugin): boolean => {
-        return plugin.hooks && !!Object.keys(plugin.hooks).length;
-      })
-      .reduce((prev: Object, curr: ServerPlugin): Object => {
-        const hooks = prev;
-        Object.keys(curr.hooks).forEach(hookName => {
-          if (Array.isArray(hooks[hookName])) {
-            hooks[hookName] = hooks[hookName].concat(curr.hooks[hookName]);
-          } else {
-            hooks[hookName] = [].concat(curr.hooks[hookName]);
-          }
-        });
-        return hooks;
-      }, {});
-    Object.keys(projectHooks).forEach((hookName: string) => {
-      if (Array.isArray(mergedHooks[hookName])) {
-        mergedHooks[hookName] = mergedHooks[hookName].concat(
-          projectHooks[hookName],
-        );
-      } else {
-        mergedHooks[hookName] = [].concat(projectHooks[hookName]);
-      }
-    });
-    return mergedHooks;
-  },
+const projectHooks = require('gluestick-hooks').default;
+const serverPlugins = require('../../plugins/serverPlugins');
+
+export const callHook = (hooks: ?(Function | Function[]), arg?: any): any => {
+  if (hooks) {
+    return Array.isArray(hooks)
+      ? hooks.reduce((val, hook) => hook(val), arg)
+      : hooks(arg);
+  }
+  return arg;
 };
+
+const merge = (): GSHooks => {
+  const mergedHooks = serverPlugins
+    .filter((plugin: ServerPlugin): boolean => {
+      return plugin.hooks && !!Object.keys(plugin.hooks).length;
+    })
+    .reduce((prev: Object, curr: ServerPlugin): Object => {
+      const hooks = prev;
+      Object.keys(curr.hooks).forEach(hookName => {
+        if (Array.isArray(hooks[hookName])) {
+          hooks[hookName] = hooks[hookName].concat(curr.hooks[hookName]);
+        } else {
+          hooks[hookName] = [].concat(curr.hooks[hookName]);
+        }
+      });
+      return hooks;
+    }, {});
+  Object.keys(projectHooks).forEach((hookName: string) => {
+    if (Array.isArray(mergedHooks[hookName])) {
+      mergedHooks[hookName] = mergedHooks[hookName].concat(
+        projectHooks[hookName],
+      );
+    } else {
+      mergedHooks[hookName] = [].concat(projectHooks[hookName]);
+    }
+  });
+  return mergedHooks;
+};
+
+const hooks = merge();
+
+export default hooks;

--- a/packages/gluestick/src/renderer/helpers/hooks.js
+++ b/packages/gluestick/src/renderer/helpers/hooks.js
@@ -4,15 +4,6 @@ import type { GSHooks, ServerPlugin } from '../../types';
 const projectHooks = require('gluestick-hooks').default;
 const serverPlugins = require('../../plugins/serverPlugins');
 
-export const callHook = (hooks: ?(Function | Function[]), arg?: any): any => {
-  if (hooks) {
-    return Array.isArray(hooks)
-      ? hooks.reduce((val, hook) => hook(val), arg)
-      : hooks(arg);
-  }
-  return arg;
-};
-
 const merge = (): GSHooks => {
   const mergedHooks = serverPlugins
     .filter((plugin: ServerPlugin): boolean => {

--- a/packages/gluestick/src/renderer/main.js
+++ b/packages/gluestick/src/renderer/main.js
@@ -3,7 +3,8 @@ import type { Request, Response, BaseLogger } from '../types';
 
 // Intentionally first require so things like require("newrelic") in
 // preInitHook get instantiated before anything else. This improves profiling
-import hooks, { callHook } from './helpers/hooks';
+import hooks from './helpers/hooks';
+import callHook from './helpers/callHook';
 
 import config from '../config';
 import logger from '../logger';

--- a/packages/gluestick/src/renderer/middleware.js
+++ b/packages/gluestick/src/renderer/middleware.js
@@ -8,7 +8,9 @@ import type {
   RenderMethod,
 } from '../types';
 
-import hooks, { callHook } from './helpers/hooks';
+import hooks from './helpers/hooks';
+import callHook from './helpers/callHook';
+
 import config from '../config';
 import logger from '../logger';
 

--- a/packages/gluestick/src/renderer/middleware.js
+++ b/packages/gluestick/src/renderer/middleware.js
@@ -1,6 +1,5 @@
 /* @flow */
 import type {
-  GSHooks,
   Request,
   Response,
   RenderRequirements,
@@ -9,6 +8,7 @@ import type {
   RenderMethod,
 } from '../types';
 
+import hooks, { callHook } from './helpers/hooks';
 import config from '../config';
 import logger from '../logger';
 
@@ -22,7 +22,6 @@ const errorHandler = require('./helpers/errorHandler');
 const getCacheManager = require('./helpers/cacheManager');
 const getStatusCode = require('./response/getStatusCode');
 const createPluginUtils = require('../plugins/utils');
-const hooksHelper = require('./helpers/hooks');
 const serverPlugins = require('../plugins/serverPlugins');
 
 const entries = require('project-entries').default;
@@ -46,12 +45,11 @@ type Middleware = (
   req: Request,
   res: Response,
   additional: {
-    hooks: GSHooks,
     assets: Object,
   },
 ) => any;
 
-const middleware: Middleware = async (req, res, { hooks, assets }) => {
+const middleware: Middleware = async (req, res, { assets }) => {
   /**
    * TODO: better logging
    */
@@ -59,10 +57,7 @@ const middleware: Middleware = async (req, res, { hooks, assets }) => {
   try {
     const cachedBeforeHooks: string | null = cacheManager.getCachedIfProd(req);
     if (cachedBeforeHooks) {
-      const cached = hooksHelper.call(
-        hooks.preRenderFromCache,
-        cachedBeforeHooks,
-      );
+      const cached = callHook(hooks.preRenderFromCache, cachedBeforeHooks);
       res.send(cached);
       return;
     }
@@ -72,7 +67,7 @@ const middleware: Middleware = async (req, res, { hooks, assets }) => {
       req,
       entries,
     );
-    const requirements = hooksHelper.call(
+    const requirements = callHook(
       hooks.postRenderRequirements,
       requirementsBeforeHooks,
     );
@@ -120,12 +115,12 @@ const middleware: Middleware = async (req, res, { hooks, assets }) => {
       store,
       httpClient,
     );
-    const renderPropsAfterHooks: Object = hooksHelper.call(
+    const renderPropsAfterHooks: Object = callHook(
       hooks.postRenderProps,
       renderProps,
     );
     if (redirectLocation) {
-      hooksHelper.call(hooks.preRedirect, redirectLocation);
+      callHook(hooks.preRedirect, redirectLocation);
       res.redirect(
         301,
         `${redirectLocation.pathname}${redirectLocation.search}`,
@@ -148,7 +143,7 @@ const middleware: Middleware = async (req, res, { hooks, assets }) => {
 
     const currentRouteBeforeHooks: Object =
       renderPropsAfterHooks.routes[renderPropsAfterHooks.routes.length - 1];
-    const currentRoute: Object = hooksHelper.call(
+    const currentRoute: Object = callHook(
       hooks.postGetCurrentRoute,
       currentRouteBeforeHooks,
     );
@@ -194,13 +189,10 @@ const middleware: Middleware = async (req, res, { hooks, assets }) => {
       },
       { renderMethod },
     );
-    const output: RenderOutput = hooksHelper.call(
-      hooks.postRender,
-      outputBeforeHooks,
-    );
+    const output: RenderOutput = callHook(hooks.postRender, outputBeforeHooks);
     res.status(statusCode).send(output.responseString);
   } catch (error) {
-    hooksHelper.call(hooks.error, error);
+    callHook(hooks.error, error);
     logger.error(error instanceof Error ? error.stack : error);
     errorHandler({ config, logger }, req, res, error);
   }


### PR DESCRIPTION
Remove hooks argument from middleware.js.
Move hooksHelper.call to a separate file so it can be used outside the server.

This is the last argument needed to be removed before the addition of webpackHotServerMiddleware, as "assets" will be replaced by webpack stats.