### PR TITLE
Fix autoupgrade error

### DIFF
--- a/packages/gluestick/src/config/defaults/glueStickConfig.js
+++ b/packages/gluestick/src/config/defaults/glueStickConfig.js
@@ -54,7 +54,6 @@ const config: GSConfig = {
       'src/gluestick.plugins.js',
       'src/gluestick.hooks.js',
       'src/webpack.hooks.js',
-      'src/config/caching.server.js',
       // 1.x
       'src/gluestick.config.js',
       'src/vendor.js',


### PR DESCRIPTION
The caching.server.js file was removed in #1135 during the upgrade to React 16. Remove leftover file reference, which is causing an error whenever `gluestick auto-upgrade` is run.