### PR TITLE
Use `develop` now in place of of `next`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,13 +198,13 @@ workflows:
             - build
           filters:
             branches:
-              only: next
+              only: develop
       - docs:
           requires:
             - build
           filters:
             branches:
-              only: next
+              only: develop
       - deploy:
           requires:
             - build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,11 +68,11 @@ You can run development GitBook server by running `yarn run docs:watch`, then op
 
 ### Pull Requests
 
-**You can submit your pull request to the `next` branch**.
+**You can submit your pull request to the `develop` branch**.
 
 Before submitting a pull request, please make sure the following is done…
 
-1. Fork the repo and create your branch from `next`.
+1. Fork the repo and create your branch from `develop`.
 2. **Describe your test plan in your commit.** If you've added code that should be tested, add tests!
 3. If you've changed APIs, update the documentation (`docs` folder).
 4. Ensure tests, lints and flow-check pass on *Circle CI*.
@@ -108,9 +108,9 @@ We are using GitHub Issues for our public bugs. We keep a close eye on this and 
 
 # Git flow
 
-`next` -> `staging`
+`develop` -> `staging`
 
-* All new features, enhancements and contributions go to `next`
+* All new features, enhancements and contributions go to `develop`
 * We cut release candidates using git tags from `staging`
   * QA and testing are done on `staging`  
-  * High priority bugs are worked on `staging`. Once the PR is reviewed and merged, then we open another PR that `cherry-pick` those changes into `next`
+  * High priority bugs are worked on `staging`. Once the PR is reviewed and merged, then we open another PR that `cherry-pick` those changes into `develop`

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ gluestick start
 ## Terms & Definitions
 
 * [`Gluestick`](https://github.com/TrueCar/gluestick) is a monorepo. It is published to npm with `Lerna` and contains depdent modules or "packages" for building Gluestick apps. The Gluestick repo uses Lerna [1](https://www.npmjs.com/package/lerna),[2](https://lernajs.io/) to help break what would otherwise be a potentially large code base in to smaller, versioned packages.
-* [`gluestick-cli`](https://github.com/TrueCar/gluestick/tree/next/packages/gluestick-cli) - A package in the Gluestick monorepo that acts as a thin wrapper for managing Gluestick apps from the command-line. With it you can create an app, destroy it, auto upgrade all of its dependent packages, etc... It has a few commands of its own, but several are proxied to your local Gluestick package.
-* [`gluestick`](https://github.com/TrueCar/gluestick/tree/next/packages/gluestick) - A package in the Gluestick monorepo that provides additional command line functionality for building for universal-React apps as well as the internals (guts) for driving the Gluestickm Universal React apps themselves.
+* [`gluestick-cli`](https://github.com/TrueCar/gluestick/tree/develop/packages/gluestick-cli) - A package in the Gluestick monorepo that acts as a thin wrapper for managing Gluestick apps from the command-line. With it you can create an app, destroy it, auto upgrade all of its dependent packages, etc... It has a few commands of its own, but several are proxied to your local Gluestick package.
+* [`gluestick`](https://github.com/TrueCar/gluestick/tree/develop/packages/gluestick) - A package in the Gluestick monorepo that provides additional command line functionality for building for universal-React apps as well as the internals (guts) for driving the Gluestickm Universal React apps themselves.
 * [`Lerna`](https://github.com/lerna/lerna) - "A tool for managing JavaScript projects with multiple packages", or put another way: "Lerna is a tool that optimizes the workflow around managing multi-package repositories with git and npm." Packages are independent codebases that can be versioned and published to `npm`.
 
 ## F.A.Q.s

--- a/book.json
+++ b/book.json
@@ -4,7 +4,7 @@
   "plugins": ["edit-link", "prism", "-highlight", "github", "anchorjs"],
   "pluginsConfig": {
     "edit-link": {
-      "base": "https://github.com/TrueCar/gluestick/tree/next",
+      "base": "https://github.com/TrueCar/gluestick/tree/develop",
       "label": "Edit This Page"
     },
     "github": {


### PR DESCRIPTION
We'd like to move back to `develop` as the default branch, getting rid of `next`. This PR replaces any references to the `next` branch with `develop`. 