### PR TITLE
Ignore file dependencies when checking mismatches.

### DIFF
--- a/packages/gluestick/src/commands/autoUpgrade/__tests__/checkForMismatch.test.js
+++ b/packages/gluestick/src/commands/autoUpgrade/__tests__/checkForMismatch.test.js
@@ -17,20 +17,22 @@ jest.mock('gluestick-generators', () => ({
 }));
 
 const utils = require('../utils');
-const checkForMismatch = require('../checkForMismatch');
 
-const orignialPromptModulesUpdate = utils.promptModulesUpdate;
+const originalPromptModulesUpdate = utils.promptModulesUpdate;
 
 describe('autoUpgrade/checkForMismatch', () => {
+  let checkForMismatch;
   beforeEach(() => {
     utils.promptModulesUpdate = jest.fn(() =>
       Promise.resolve({ shouldFix: false, mismatchedModules: {} }),
     );
+    checkForMismatch = require('../checkForMismatch');
   });
 
   afterEach(() => {
     jest.resetAllMocks();
-    utils.promptModulesUpdate = orignialPromptModulesUpdate;
+    jest.resetModules();
+    utils.promptModulesUpdate = originalPromptModulesUpdate;
   });
 
   it('detects mismatched modules', () => {

--- a/packages/gluestick/src/commands/autoUpgrade/__tests__/utils.test.js
+++ b/packages/gluestick/src/commands/autoUpgrade/__tests__/utils.test.js
@@ -5,13 +5,7 @@ jest.mock('fs', () => ({
 jest.mock('inquirer', () => ({
   prompt: () => Promise.resolve({ confirm: true }),
 }));
-const {
-  isValidVersion,
-  replaceFile,
-  promptModulesUpdate,
-} = require('../utils');
-const fs = require('fs');
-const path = require('path');
+const { isValidVersion, promptModulesUpdate } = require('../utils');
 
 describe('autoUpgrade/utils.isValidVersion', () => {
   it('should return true when version is greater than or equal requiredVersion', () => {
@@ -49,23 +43,6 @@ describe('autoUpgrade/utils.isValidVersion', () => {
 
   it('should return false if version is invalid', () => {
     expect(isValidVersion('a.b.c', '')).toBeFalsy();
-  });
-});
-
-describe('autoUpgrade/utils.replaceFile', () => {
-  it('should replace file', () => {
-    // $FlowIgnore only info from logger is used
-    replaceFile(
-      {
-        info: jest.fn(),
-      },
-      'test',
-      'data',
-    );
-    expect(fs.writeFileSync.mock.calls[0]).toEqual([
-      path.join(process.cwd(), 'test'),
-      'data',
-    ]);
   });
 });
 

--- a/packages/gluestick/src/commands/autoUpgrade/checkForMismatch.js
+++ b/packages/gluestick/src/commands/autoUpgrade/checkForMismatch.js
@@ -12,6 +12,10 @@ type ProjectPackage = {
   devDependencies: Object,
 };
 
+const isFileDependency = (name: string) => {
+  return name.startsWith('file');
+};
+
 /**
  * Open the package.json file in both the project as well as the one used by
  * this command line interface, then compare the versions for shared modules.
@@ -74,19 +78,21 @@ const checkForMismatch = (
     };
   };
   Object.keys(templatePackage.dependencies).forEach((dep: string): void => {
+    const projectDependency = projectPackage.dependencies[dep];
     if (
       dev &&
       dep === 'gluestick' &&
-      !/\d+\.\d+\.\d+.*/.test(projectPackage.dependencies[dep])
+      !/\d+\.\d+\.\d+.*/.test(projectDependency)
     ) {
       return;
     }
     if (
-      !projectPackage.dependencies[dep] ||
-      !isValidVersion(
-        projectPackage.dependencies[dep],
-        templatePackage.dependencies[dep],
-      )
+      (!projectDependency ||
+        !isValidVersion(
+          projectDependency,
+          templatePackage.dependencies[dep],
+        )) &&
+      !isFileDependency(projectDependency)
     ) {
       markMissing(dep, 'dependencies');
     }

--- a/packages/gluestick/src/commands/autoUpgrade/checkForMismatch.js
+++ b/packages/gluestick/src/commands/autoUpgrade/checkForMismatch.js
@@ -4,7 +4,7 @@ import type { MismatchedModules, UpdateDepsPromptResults } from '../../types';
 const path = require('path');
 const getSingleEntryFromGenerator = require('./getSingleEntryFromGenerator');
 const parseConfig = require('gluestick-generators').parseConfig;
-const utils = require('./utils');
+const { isValidVersion, promptModulesUpdate } = require('./utils');
 const version = require('../../../package.json').version;
 
 type ProjectPackage = {
@@ -14,6 +14,13 @@ type ProjectPackage = {
 
 const isFileDependency = (name: string) => {
   return name.startsWith('file');
+};
+
+const isMismatched = (project, template) => {
+  return (
+    !project ||
+    (!isValidVersion(project, template) && !isFileDependency(project))
+  );
 };
 
 /**
@@ -44,7 +51,6 @@ const checkForMismatch = (
   dev: boolean,
 ): Promise<UpdateDepsPromptResults> => {
   // This is done to keep live reference to mock single function in testing
-  const { isValidVersion, promptModulesUpdate } = utils;
   const projectPackage: ProjectPackage = {
     dependencies: {},
     devDependencies: {},
@@ -78,33 +84,20 @@ const checkForMismatch = (
     };
   };
   Object.keys(templatePackage.dependencies).forEach((dep: string): void => {
-    const projectDependency = projectPackage.dependencies[dep];
-    if (
-      dev &&
-      dep === 'gluestick' &&
-      !/\d+\.\d+\.\d+.*/.test(projectDependency)
-    ) {
+    const project = projectPackage.dependencies[dep];
+    const template = templatePackage.dependencies[dep];
+    if (dev && dep === 'gluestick' && !/\d+\.\d+\.\d+.*/.test(project)) {
       return;
     }
-    if (
-      (!projectDependency ||
-        !isValidVersion(
-          projectDependency,
-          templatePackage.dependencies[dep],
-        )) &&
-      !isFileDependency(projectDependency)
-    ) {
+    if (isMismatched(project, template)) {
       markMissing(dep, 'dependencies');
     }
   });
   Object.keys(templatePackage.devDependencies).forEach((dep: string): void => {
-    if (
-      !projectPackage.devDependencies[dep] ||
-      !isValidVersion(
-        projectPackage.devDependencies[dep],
-        templatePackage.devDependencies[dep],
-      )
-    ) {
+    const project = projectPackage.devDependencies[dep];
+    const template = templatePackage.devDependencies[dep];
+
+    if (isMismatched(project, template)) {
       markMissing(dep, 'devDependencies');
     }
   });

--- a/packages/gluestick/src/commands/autoUpgrade/utils.js
+++ b/packages/gluestick/src/commands/autoUpgrade/utils.js
@@ -1,30 +1,13 @@
 /* @flow */
 import type {
-  Logger,
   Question,
   MismatchedModules,
   UpdateDepsPromptResults,
 } from '../../types';
 
-const path = require('path');
-const fs = require('fs');
 const semver = require('semver');
 const chalk = require('chalk');
 const inquirer = require('inquirer');
-
-/**
- * Let the user know that we are updating the file and copy the contents over.
- *
- * @param {String} name the name of the file
- * @param {String} data the data for the new file
- */
-const replaceFile = (logger: Logger, name: string, data: string): void => {
-  const filePath: string = path.join(process.cwd(), name);
-
-  logger.info(`${name} file is out of date.`);
-  logger.info(`Updating ${filePath}`);
-  fs.writeFileSync(filePath, data);
-};
 
 /**
  * Determine a version meets or exceeds a requirement.
@@ -90,6 +73,5 @@ const promptModulesUpdate = (
 
 module.exports = {
   isValidVersion,
-  replaceFile,
   promptModulesUpdate,
 };


### PR DESCRIPTION
This prevents the "would you like to update your dependencies" dialog when developing Gluestick locally.