### PR TITLE
Add snapshot tests for Webpack configuration.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - attach_workspace:
           at: ~/gluestick
 
-      - run: yarn run test -i --coverage
+      - run: yarn run test --runInBand --coverage
 
       - store_artifacts:
           path: coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - attach_workspace:
           at: ~/gluestick
 
-      - run: yarn run test --coverage
+      - run: yarn run test -i --coverage
 
       - store_artifacts:
           path: coverage

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ _book/
 
 # Gluestick uses yarn at the moment
 package-lock.json
+yarn-error.log

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "mkdirp": "0.5.1",
     "node-fetch": "^1.7.1",
     "prettier": "^1.5.3",
-    "rimraf": "2.6.1"
+    "rimraf": "2.6.1",
+    "traverse": "0.6.6"
   },
   "jest": {
     "notify": true,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "install:yarn": "yarn install && yarn run build && yarn run yarn:install && lerna bootstrap --concurrency=1",
     "install:yarn:ci": "yarn install --frozen-lockfile && yarn run build && yarn run yarn:install:ci && lerna bootstrap --concurrency=1",
     "clean": "lerna clean --yes",
-    "test": "jest --bail --no-cache -i",
+    "test": "jest",
     "test:watch": "jest --watch",
     "test-coverage": "npm run test -- --coverage",
     "lint": "eslint ./packages",

--- a/packages/gluestick/jest.js
+++ b/packages/gluestick/jest.js
@@ -1,4 +1,0 @@
-/**
- * Always mock npmDependencies lib since we never want to really install dependencies while testing
- */
-jest.mock('./src/lib/npmDependencies');

--- a/packages/gluestick/package.json
+++ b/packages/gluestick/package.json
@@ -8,8 +8,6 @@
   "bugs": "https://github.com/TrueCar/gluestick/issues",
   "license": "MIT",
   "scripts": {
-    "lint": "eslint src",
-    "debug": "node --inspect --debug-brk ./node_modules/.bin/jest -i --env ./test/jestEnvironmentNodeDebug.js"
   },
   "keywords": [
     "react",
@@ -93,7 +91,6 @@
     "http-proxy-middleware": "0.17.4",
     "ignore-loader": "0.1.2",
     "inquirer": "3.2.0",
-    "jest": "20.0.4",
     "lru-cache": "4.1.1",
     "mkdirp": "0.5.1",
     "node-fetch": "^1.7.1",
@@ -119,16 +116,5 @@
     "webpack-dev-middleware": "^1.11.0",
     "webpack-hot-middleware": "^2.18.2",
     "webpack-node-externals": "1.7.2"
-  },
-  "jest": {
-    "roots": [
-      "src"
-    ],
-    "setupFiles": [
-      "./jest.js"
-    ],
-    "transformIgnorePatterns": [
-      "node_modules/(?!gluestick*)"
-    ]
   }
 }

--- a/packages/gluestick/src/config/__tests__/__snapshots__/compileWebpackConfig.test.js.snap
+++ b/packages/gluestick/src/config/__tests__/__snapshots__/compileWebpackConfig.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`config/compileWebpackConfig in dev environment returns the correct client config 1`] = `
 Object {
-  "context": "/Users/dedmondson/src/tc/gluestick",
+  "context": "/project",
   "devtool": "cheap-module-source-map",
   "entry": Object {},
   "module": Object {
@@ -85,7 +85,7 @@ Object {
     "chunkFilename": "[name].[hash].js",
     "crossOriginLoading": "anonymous",
     "filename": "[name].[hash].js",
-    "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+    "path": "/project/build/assets",
     "publicPath": "http://0.0.0.0:8888/assets/",
   },
   "performance": Object {
@@ -95,9 +95,9 @@ Object {
     LoaderOptionsPlugin {
       "options": Object {
         "options": Object {
-          "context": "/Users/dedmondson/src/tc/gluestick",
+          "context": "/project",
           "output": Object {
-            "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+            "path": "/project/build/assets",
           },
           "postcss": Array [
             [Function],
@@ -109,7 +109,7 @@ Object {
       },
     },
     NormalModuleReplacementPlugin {
-      "newResource": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/src/config/webpack/mocks/nullMock.js",
+      "newResource": "/project/packages/gluestick/src/config/webpack/mocks/nullMock.js",
       "resourceRegExp": /\\\\\\.server\\(\\\\\\.js\\)\\?\\$/,
     },
     DuplicatePackageCheckerPlugin {
@@ -131,14 +131,14 @@ Object {
       ],
       "deepChildren": undefined,
       "filenameTemplate": "vendor.bundle.js",
-      "ident": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/node_modules/webpack/lib/optimize/CommonsChunkPlugin.js0",
+      "ident": "/project/packages/gluestick/node_modules/webpack/lib/optimize/CommonsChunkPlugin.js0",
       "minChunks": undefined,
       "minSize": undefined,
       "selectedChunks": undefined,
     },
     ChunksPlugin {
       "configuration": Object {
-        "context": "/Users/dedmondson/src/tc/gluestick",
+        "context": "/project",
         "module": Object {
           "rules": Array [
             Object {
@@ -212,16 +212,16 @@ Object {
         "output": Object {
           "chunkFilename": "[name].[hash].js",
           "filename": "[name].[hash].js",
-          "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+          "path": "/project/build/assets",
           "publicPath": "/assets/",
         },
         "plugins": Array [
           LoaderOptionsPlugin {
             "options": Object {
               "options": Object {
-                "context": "/Users/dedmondson/src/tc/gluestick",
+                "context": "/project",
                 "output": Object {
-                  "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+                  "path": "/project/build/assets",
                 },
                 "postcss": Array [
                   [Function],
@@ -235,13 +235,13 @@ Object {
         ],
         "resolve": Object {
           "alias": Object {
-            "apps": "/Users/dedmondson/src/tc/gluestick/src/apps",
-            "assets": "/Users/dedmondson/src/tc/gluestick/assets",
-            "compiled": "/Users/dedmondson/src/tc/gluestick/node_modules",
-            "config": "/Users/dedmondson/src/tc/gluestick/src/config",
-            "root": "/Users/dedmondson/src/tc/gluestick",
-            "shared": "/Users/dedmondson/src/tc/gluestick/src/shared",
-            "src": "/Users/dedmondson/src/tc/gluestick/src",
+            "apps": "/project/src/apps",
+            "assets": "/project/assets",
+            "compiled": "/project/node_modules",
+            "config": "/project/src/config",
+            "root": "/project",
+            "shared": "/project/src/shared",
+            "src": "/project/src",
           },
           "extensions": Array [
             ".js",
@@ -275,13 +275,13 @@ Object {
   ],
   "resolve": Object {
     "alias": Object {
-      "apps": "/Users/dedmondson/src/tc/gluestick/src/apps",
-      "assets": "/Users/dedmondson/src/tc/gluestick/assets",
-      "compiled": "/Users/dedmondson/src/tc/gluestick/node_modules",
-      "config": "/Users/dedmondson/src/tc/gluestick/src/config",
-      "root": "/Users/dedmondson/src/tc/gluestick",
-      "shared": "/Users/dedmondson/src/tc/gluestick/src/shared",
-      "src": "/Users/dedmondson/src/tc/gluestick/src",
+      "apps": "/project/src/apps",
+      "assets": "/project/assets",
+      "compiled": "/project/node_modules",
+      "config": "/project/src/config",
+      "root": "/project",
+      "shared": "/project/src/shared",
+      "src": "/project/src",
     },
     "extensions": Array [
       ".js",
@@ -294,10 +294,10 @@ Object {
 
 exports[`config/compileWebpackConfig in dev environment returns the correct server config 1`] = `
 Object {
-  "context": "/Users/dedmondson/src/tc/gluestick",
+  "context": "/project",
   "devtool": "source-map",
   "entry": Object {
-    "renderer": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/src/renderer/entry.js",
+    "renderer": "/project/packages/gluestick/src/renderer/entry.js",
   },
   "externals": Array [
     [Function],
@@ -378,7 +378,7 @@ Object {
     "chunkFilename": "[name].js",
     "filename": "[name].js",
     "libraryTarget": "commonjs2",
-    "path": "/Users/dedmondson/src/tc/gluestick/build/server",
+    "path": "/project/build/server",
     "pathinfo": true,
     "publicPath": "http://localhost:8888undefined",
   },
@@ -386,9 +386,9 @@ Object {
     LoaderOptionsPlugin {
       "options": Object {
         "options": Object {
-          "context": "/Users/dedmondson/src/tc/gluestick",
+          "context": "/project",
           "output": Object {
-            "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+            "path": "/project/build/assets",
           },
           "postcss": Array [
             [Function],
@@ -424,20 +424,20 @@ Object {
   ],
   "resolve": Object {
     "alias": Object {
-      "application-config": "/Users/dedmondson/src/tc/gluestick/src/config/application",
-      "apps": "/Users/dedmondson/src/tc/gluestick/src/apps",
-      "assets": "/Users/dedmondson/src/tc/gluestick/assets",
-      "compiled": "/Users/dedmondson/src/tc/gluestick/node_modules",
-      "config": "/Users/dedmondson/src/tc/gluestick/src/config",
-      "entry-wrapper": "/Users/dedmondson/src/tc/gluestick/gluestick/EntryWrapper",
-      "gluestick-hooks": "/Users/dedmondson/src/tc/gluestick/src/gluestick.hooks.js",
+      "application-config": "/project/src/config/application",
+      "apps": "/project/src/apps",
+      "assets": "/project/assets",
+      "compiled": "/project/node_modules",
+      "config": "/project/src/config",
+      "entry-wrapper": "/project/gluestick/EntryWrapper",
+      "gluestick-hooks": "/project/src/gluestick.hooks.js",
       "plugins-config-path": undefined,
-      "project-entries": "/Users/dedmondson/src/tc/gluestick/gluestick/entries",
-      "project-entries-config": "/Users/dedmondson/src/tc/gluestick/src/entries.json",
-      "redux-middlewares": "/Users/dedmondson/src/tc/gluestick/src/config/redux-middleware",
-      "root": "/Users/dedmondson/src/tc/gluestick",
-      "shared": "/Users/dedmondson/src/tc/gluestick/src/shared",
-      "src": "/Users/dedmondson/src/tc/gluestick/src",
+      "project-entries": "/project/gluestick/entries",
+      "project-entries-config": "/project/src/entries.json",
+      "redux-middlewares": "/project/src/config/redux-middleware",
+      "root": "/project",
+      "shared": "/project/src/shared",
+      "src": "/project/src",
     },
     "extensions": Array [
       ".js",
@@ -452,7 +452,7 @@ Object {
 exports[`config/compileWebpackConfig in production environment returns the correct client config 1`] = `
 Object {
   "bail": true,
-  "context": "/Users/dedmondson/src/tc/gluestick",
+  "context": "/project",
   "devtool": "hidden-source-map",
   "entry": Object {},
   "module": Object {
@@ -486,7 +486,7 @@ Object {
         "test": /\\\\\\.\\(scss\\)\\$/,
         "use": Array [
           Object {
-            "loader": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/node_modules/extract-text-webpack-plugin/loader.js",
+            "loader": "/project/packages/gluestick/node_modules/extract-text-webpack-plugin/loader.js",
             "options": Object {
               "omit": 1,
               "remove": true,
@@ -510,7 +510,7 @@ Object {
         "test": /\\\\\\.\\(css\\)\\$/,
         "use": Array [
           Object {
-            "loader": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/node_modules/extract-text-webpack-plugin/loader.js",
+            "loader": "/project/packages/gluestick/node_modules/extract-text-webpack-plugin/loader.js",
             "options": Object {
               "omit": 1,
               "remove": true,
@@ -561,16 +561,16 @@ Object {
   "output": Object {
     "chunkFilename": "[name].[hash].js",
     "filename": "[name].[hash].js",
-    "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+    "path": "/project/build/assets",
     "publicPath": "/assets/",
   },
   "plugins": Array [
     LoaderOptionsPlugin {
       "options": Object {
         "options": Object {
-          "context": "/Users/dedmondson/src/tc/gluestick",
+          "context": "/project",
           "output": Object {
-            "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+            "path": "/project/build/assets",
           },
           "postcss": Array [
             [Function],
@@ -582,7 +582,7 @@ Object {
       },
     },
     NormalModuleReplacementPlugin {
-      "newResource": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/src/config/webpack/mocks/nullMock.js",
+      "newResource": "/project/packages/gluestick/src/config/webpack/mocks/nullMock.js",
       "resourceRegExp": /\\\\\\.server\\(\\\\\\.js\\)\\?\\$/,
     },
     DuplicatePackageCheckerPlugin {
@@ -604,14 +604,14 @@ Object {
       ],
       "deepChildren": undefined,
       "filenameTemplate": "vendor-[hash].bundle.js",
-      "ident": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/node_modules/webpack/lib/optimize/CommonsChunkPlugin.js2",
+      "ident": "/project/packages/gluestick/node_modules/webpack/lib/optimize/CommonsChunkPlugin.js2",
       "minChunks": undefined,
       "minSize": undefined,
       "selectedChunks": undefined,
     },
     ChunksPlugin {
       "configuration": Object {
-        "context": "/Users/dedmondson/src/tc/gluestick",
+        "context": "/project",
         "module": Object {
           "rules": Array [
             Object {
@@ -685,16 +685,16 @@ Object {
         "output": Object {
           "chunkFilename": "[name].[hash].js",
           "filename": "[name].[hash].js",
-          "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+          "path": "/project/build/assets",
           "publicPath": "/assets/",
         },
         "plugins": Array [
           LoaderOptionsPlugin {
             "options": Object {
               "options": Object {
-                "context": "/Users/dedmondson/src/tc/gluestick",
+                "context": "/project",
                 "output": Object {
-                  "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+                  "path": "/project/build/assets",
                 },
                 "postcss": Array [
                   [Function],
@@ -708,13 +708,13 @@ Object {
         ],
         "resolve": Object {
           "alias": Object {
-            "apps": "/Users/dedmondson/src/tc/gluestick/src/apps",
-            "assets": "/Users/dedmondson/src/tc/gluestick/assets",
-            "compiled": "/Users/dedmondson/src/tc/gluestick/node_modules",
-            "config": "/Users/dedmondson/src/tc/gluestick/src/config",
-            "root": "/Users/dedmondson/src/tc/gluestick",
-            "shared": "/Users/dedmondson/src/tc/gluestick/src/shared",
-            "src": "/Users/dedmondson/src/tc/gluestick/src",
+            "apps": "/project/src/apps",
+            "assets": "/project/assets",
+            "compiled": "/project/node_modules",
+            "config": "/project/src/config",
+            "root": "/project",
+            "shared": "/project/src/shared",
+            "src": "/project/src",
           },
           "extensions": Array [
             ".js",
@@ -761,19 +761,19 @@ Object {
       },
     },
     NormalModuleReplacementPlugin {
-      "newResource": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/src/config/webpack/mocks/emptyObjMock.js",
+      "newResource": "/project/packages/gluestick/src/config/webpack/mocks/emptyObjMock.js",
       "resourceRegExp": /gluestick\\\\/shared\\\\/lib\\\\/errorUtils/,
     },
   ],
   "resolve": Object {
     "alias": Object {
-      "apps": "/Users/dedmondson/src/tc/gluestick/src/apps",
-      "assets": "/Users/dedmondson/src/tc/gluestick/assets",
-      "compiled": "/Users/dedmondson/src/tc/gluestick/node_modules",
-      "config": "/Users/dedmondson/src/tc/gluestick/src/config",
-      "root": "/Users/dedmondson/src/tc/gluestick",
-      "shared": "/Users/dedmondson/src/tc/gluestick/src/shared",
-      "src": "/Users/dedmondson/src/tc/gluestick/src",
+      "apps": "/project/src/apps",
+      "assets": "/project/assets",
+      "compiled": "/project/node_modules",
+      "config": "/project/src/config",
+      "root": "/project",
+      "shared": "/project/src/shared",
+      "src": "/project/src",
     },
     "extensions": Array [
       ".js",
@@ -787,10 +787,10 @@ Object {
 exports[`config/compileWebpackConfig in production environment returns the correct server config 1`] = `
 Object {
   "bail": true,
-  "context": "/Users/dedmondson/src/tc/gluestick",
+  "context": "/project",
   "devtool": "source-map",
   "entry": Object {
-    "renderer": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/src/renderer/entry.js",
+    "renderer": "/project/packages/gluestick/src/renderer/entry.js",
   },
   "externals": Array [
     [Function],
@@ -871,16 +871,16 @@ Object {
     "chunkFilename": "[name].js",
     "filename": "[name].js",
     "libraryTarget": "commonjs2",
-    "path": "/Users/dedmondson/src/tc/gluestick/build/server",
+    "path": "/project/build/server",
     "pathinfo": true,
   },
   "plugins": Array [
     LoaderOptionsPlugin {
       "options": Object {
         "options": Object {
-          "context": "/Users/dedmondson/src/tc/gluestick",
+          "context": "/project",
           "output": Object {
-            "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+            "path": "/project/build/assets",
           },
           "postcss": Array [
             [Function],
@@ -908,23 +908,23 @@ Object {
   ],
   "resolve": Object {
     "alias": Object {
-      "application-config": "/Users/dedmondson/src/tc/gluestick/src/config/application",
-      "apps": "/Users/dedmondson/src/tc/gluestick/src/apps",
-      "assets": "/Users/dedmondson/src/tc/gluestick/assets",
-      "compiled": "/Users/dedmondson/src/tc/gluestick/node_modules",
-      "config": "/Users/dedmondson/src/tc/gluestick/src/config",
-      "entry-wrapper": "/Users/dedmondson/src/tc/gluestick/gluestick/EntryWrapper",
-      "gluestick-hooks": "/Users/dedmondson/src/tc/gluestick/src/gluestick.hooks.js",
+      "application-config": "/project/src/config/application",
+      "apps": "/project/src/apps",
+      "assets": "/project/assets",
+      "compiled": "/project/node_modules",
+      "config": "/project/src/config",
+      "entry-wrapper": "/project/gluestick/EntryWrapper",
+      "gluestick-hooks": "/project/src/gluestick.hooks.js",
       "plugins-config-path": undefined,
-      "project-entries": "/Users/dedmondson/src/tc/gluestick/gluestick/entries",
-      "project-entries-config": "/Users/dedmondson/src/tc/gluestick/src/entries.json",
-      "react": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/node_modules/react/cjs/react.production.min.js",
-      "react-dom": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/node_modules/react-dom/cjs/react-dom.production.min.js",
-      "react-dom/server": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/node_modules/react-dom/cjs/react-dom-server.node.production.min.js",
-      "redux-middlewares": "/Users/dedmondson/src/tc/gluestick/src/config/redux-middleware",
-      "root": "/Users/dedmondson/src/tc/gluestick",
-      "shared": "/Users/dedmondson/src/tc/gluestick/src/shared",
-      "src": "/Users/dedmondson/src/tc/gluestick/src",
+      "project-entries": "/project/gluestick/entries",
+      "project-entries-config": "/project/src/entries.json",
+      "react": "/project/packages/gluestick/node_modules/react/cjs/react.production.min.js",
+      "react-dom": "/project/packages/gluestick/node_modules/react-dom/cjs/react-dom.production.min.js",
+      "react-dom/server": "/project/packages/gluestick/node_modules/react-dom/cjs/react-dom-server.node.production.min.js",
+      "redux-middlewares": "/project/src/config/redux-middleware",
+      "root": "/project",
+      "shared": "/project/src/shared",
+      "src": "/project/src",
     },
     "extensions": Array [
       ".js",

--- a/packages/gluestick/src/config/__tests__/__snapshots__/compileWebpackConfig.test.js.snap
+++ b/packages/gluestick/src/config/__tests__/__snapshots__/compileWebpackConfig.test.js.snap
@@ -292,7 +292,7 @@ Object {
 }
 `;
 
-exports[`config/compileWebpackConfig in dev environment returns the correct client config 2`] = `
+exports[`config/compileWebpackConfig in dev environment returns the correct server config 1`] = `
 Object {
   "context": "/Users/dedmondson/src/tc/gluestick",
   "devtool": "source-map",
@@ -784,7 +784,7 @@ Object {
 }
 `;
 
-exports[`config/compileWebpackConfig in production environment returns the correct client config 2`] = `
+exports[`config/compileWebpackConfig in production environment returns the correct server config 1`] = `
 Object {
   "bail": true,
   "context": "/Users/dedmondson/src/tc/gluestick",

--- a/packages/gluestick/src/config/__tests__/__snapshots__/compileWebpackConfig.test.js.snap
+++ b/packages/gluestick/src/config/__tests__/__snapshots__/compileWebpackConfig.test.js.snap
@@ -1,0 +1,937 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`config/compileWebpackConfig in dev environment returns the correct client config 1`] = `
+Object {
+  "context": "/Users/dedmondson/src/tc/gluestick",
+  "devtool": "cheap-module-source-map",
+  "entry": Object {},
+  "module": Object {
+    "rules": Array [
+      Object {
+        "exclude": /\\(node_modules\\\\/\\(\\?!gluestick\\)\\)\\|\\(build\\\\/assets\\)/,
+        "test": /\\\\\\.js\\$/,
+        "use": Array [
+          Object {
+            "loader": "babel-loader",
+            "options": Object {
+              "babelrc": false,
+              "plugins": Array [
+                "transform-flow-strip-types",
+                "react-hot-loader/babel",
+              ],
+              "presets": Array [
+                Array [
+                  "es2015",
+                  Object {
+                    "modules": false,
+                  },
+                ],
+                "react",
+                "stage-0",
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "test": /\\\\\\.\\(scss\\)\\$/,
+        "use": Array [
+          "style-loader",
+          "css-loader?importLoaders=2&sourceMap",
+          "postcss-loader",
+          "sass-loader?outputStyle=expanded&sourceMap=true&sourceMapContents=true",
+        ],
+      },
+      Object {
+        "test": /\\\\\\.\\(css\\)\\$/,
+        "use": Array [
+          "style-loader",
+          "css-loader?importLoaders=1&sourceMap",
+          "postcss-loader",
+        ],
+      },
+      Object {
+        "test": /\\\\\\.\\(png\\|jpg\\|gif\\|ico\\|svg\\)\\(\\\\\\?v=\\\\d\\+\\\\\\.\\\\d\\+\\\\\\.\\\\d\\+\\)\\?\\$/,
+        "use": Array [
+          Object {
+            "loader": "file-loader",
+            "options": Object {
+              "name": "[name]-[hash].[ext]",
+            },
+          },
+          Object {
+            "loader": "image-webpack-loader",
+            "options": Object {},
+          },
+        ],
+      },
+      Object {
+        "test": /\\\\\\.\\(woff\\|woff2\\|ttf\\|eot\\)\\(\\\\\\?v=\\\\d\\+\\\\\\.\\\\d\\+\\\\\\.\\\\d\\+\\)\\?\\$/,
+        "use": Array [
+          Object {
+            "loader": "file-loader",
+            "options": Object {
+              "name": "[name]-[hash].[ext]",
+            },
+          },
+        ],
+      },
+    ],
+  },
+  "node": Object {
+    "net": "empty",
+  },
+  "output": Object {
+    "chunkFilename": "[name].[hash].js",
+    "crossOriginLoading": "anonymous",
+    "filename": "[name].[hash].js",
+    "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+    "publicPath": "http://0.0.0.0:8888/assets/",
+  },
+  "performance": Object {
+    "hints": false,
+  },
+  "plugins": Array [
+    LoaderOptionsPlugin {
+      "options": Object {
+        "options": Object {
+          "context": "/Users/dedmondson/src/tc/gluestick",
+          "output": Object {
+            "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+          },
+          "postcss": Array [
+            [Function],
+            [Function],
+            [Function],
+          ],
+        },
+        "test": /\\\\\\.\\(scss\\|css\\)\\$/,
+      },
+    },
+    NormalModuleReplacementPlugin {
+      "newResource": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/src/config/webpack/mocks/nullMock.js",
+      "resourceRegExp": /\\\\\\.server\\(\\\\\\.js\\)\\?\\$/,
+    },
+    DuplicatePackageCheckerPlugin {
+      "options": Object {
+        "emitError": false,
+        "exclude": null,
+        "verbose": false,
+      },
+    },
+    ProgressPlugin {
+      "handler": undefined,
+      "profile": undefined,
+    },
+    CommonsChunkPlugin {
+      "async": undefined,
+      "children": undefined,
+      "chunkNames": Array [
+        "vendor",
+      ],
+      "deepChildren": undefined,
+      "filenameTemplate": "vendor.bundle.js",
+      "ident": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/node_modules/webpack/lib/optimize/CommonsChunkPlugin.js0",
+      "minChunks": undefined,
+      "minSize": undefined,
+      "selectedChunks": undefined,
+    },
+    ChunksPlugin {
+      "configuration": Object {
+        "context": "/Users/dedmondson/src/tc/gluestick",
+        "module": Object {
+          "rules": Array [
+            Object {
+              "exclude": /\\(node_modules\\\\/\\(\\?!gluestick\\)\\)\\|\\(build\\\\/assets\\)/,
+              "test": /\\\\\\.js\\$/,
+              "use": Array [
+                Object {
+                  "loader": "babel-loader",
+                  "options": Object {
+                    "babelrc": false,
+                    "plugins": Array [
+                      "transform-flow-strip-types",
+                    ],
+                    "presets": Array [
+                      "es2015",
+                      "react",
+                      "stage-0",
+                    ],
+                  },
+                },
+              ],
+            },
+            Object {
+              "test": /\\\\\\.\\(scss\\)\\$/,
+              "use": Array [
+                "style-loader",
+                "css-loader?importLoaders=2&sourceMap",
+                "postcss-loader",
+                "sass-loader?outputStyle=expanded&sourceMap=true&sourceMapContents=true",
+              ],
+            },
+            Object {
+              "test": /\\\\\\.\\(css\\)\\$/,
+              "use": Array [
+                "style-loader",
+                "css-loader?importLoaders=1&sourceMap",
+                "postcss-loader",
+              ],
+            },
+            Object {
+              "test": /\\\\\\.\\(png\\|jpg\\|gif\\|ico\\|svg\\)\\(\\\\\\?v=\\\\d\\+\\\\\\.\\\\d\\+\\\\\\.\\\\d\\+\\)\\?\\$/,
+              "use": Array [
+                Object {
+                  "loader": "file-loader",
+                  "options": Object {
+                    "name": "[name]-[hash].[ext]",
+                  },
+                },
+                Object {
+                  "loader": "image-webpack-loader",
+                  "options": Object {},
+                },
+              ],
+            },
+            Object {
+              "test": /\\\\\\.\\(woff\\|woff2\\|ttf\\|eot\\)\\(\\\\\\?v=\\\\d\\+\\\\\\.\\\\d\\+\\\\\\.\\\\d\\+\\)\\?\\$/,
+              "use": Array [
+                Object {
+                  "loader": "file-loader",
+                  "options": Object {
+                    "name": "[name]-[hash].[ext]",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        "node": Object {
+          "net": "empty",
+        },
+        "output": Object {
+          "chunkFilename": "[name].[hash].js",
+          "filename": "[name].[hash].js",
+          "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+          "publicPath": "/assets/",
+        },
+        "plugins": Array [
+          LoaderOptionsPlugin {
+            "options": Object {
+              "options": Object {
+                "context": "/Users/dedmondson/src/tc/gluestick",
+                "output": Object {
+                  "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+                },
+                "postcss": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+              },
+              "test": /\\\\\\.\\(scss\\|css\\)\\$/,
+            },
+          },
+        ],
+        "resolve": Object {
+          "alias": Object {
+            "apps": "/Users/dedmondson/src/tc/gluestick/src/apps",
+            "assets": "/Users/dedmondson/src/tc/gluestick/assets",
+            "compiled": "/Users/dedmondson/src/tc/gluestick/node_modules",
+            "config": "/Users/dedmondson/src/tc/gluestick/src/config",
+            "root": "/Users/dedmondson/src/tc/gluestick",
+            "shared": "/Users/dedmondson/src/tc/gluestick/src/shared",
+            "src": "/Users/dedmondson/src/tc/gluestick/src",
+          },
+          "extensions": Array [
+            ".js",
+            ".css",
+            ".json",
+          ],
+        },
+      },
+      "options": Object {},
+    },
+    DefinePlugin {
+      "definitions": Object {
+        "process.env.NODE_ENV": "\\"development\\"",
+      },
+    },
+    HotModuleReplacementPlugin {
+      "fullBuildTimeout": 200,
+      "multiStep": undefined,
+      "options": Object {},
+      "requestTimeout": 10000,
+    },
+    NamedModulesPlugin {
+      "options": Object {},
+    },
+    LoaderOptionsPlugin {
+      "options": Object {
+        "debug": true,
+        "test": /\\\\\\.\\(scss\\|css\\)\\$/,
+      },
+    },
+  ],
+  "resolve": Object {
+    "alias": Object {
+      "apps": "/Users/dedmondson/src/tc/gluestick/src/apps",
+      "assets": "/Users/dedmondson/src/tc/gluestick/assets",
+      "compiled": "/Users/dedmondson/src/tc/gluestick/node_modules",
+      "config": "/Users/dedmondson/src/tc/gluestick/src/config",
+      "root": "/Users/dedmondson/src/tc/gluestick",
+      "shared": "/Users/dedmondson/src/tc/gluestick/src/shared",
+      "src": "/Users/dedmondson/src/tc/gluestick/src",
+    },
+    "extensions": Array [
+      ".js",
+      ".css",
+      ".json",
+    ],
+  },
+}
+`;
+
+exports[`config/compileWebpackConfig in dev environment returns the correct client config 2`] = `
+Object {
+  "context": "/Users/dedmondson/src/tc/gluestick",
+  "devtool": "source-map",
+  "entry": Object {
+    "renderer": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/src/renderer/entry.js",
+  },
+  "externals": Array [
+    [Function],
+  ],
+  "module": Object {
+    "noParse": Array [
+      /cli\\\\/helpers/,
+    ],
+    "rules": Array [
+      Object {
+        "exclude": /\\(node_modules\\\\/\\(\\?!gluestick\\)\\)\\|\\(build\\\\/assets\\)/,
+        "test": /\\\\\\.js\\$/,
+        "use": Array [
+          Object {
+            "loader": "babel-loader",
+            "options": Object {
+              "babelrc": false,
+              "plugins": Array [
+                "transform-flow-strip-types",
+              ],
+              "presets": Array [
+                "es2015",
+                "react",
+                "stage-0",
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "test": /\\\\\\.\\(scss\\)\\$/,
+        "use": Array [
+          "ignore-loader",
+        ],
+      },
+      Object {
+        "test": /\\\\\\.\\(css\\)\\$/,
+        "use": Array [
+          "ignore-loader",
+        ],
+      },
+      Object {
+        "test": /\\\\\\.\\(png\\|jpg\\|gif\\|ico\\|svg\\)\\(\\\\\\?v=\\\\d\\+\\\\\\.\\\\d\\+\\\\\\.\\\\d\\+\\)\\?\\$/,
+        "use": Array [
+          Object {
+            "loader": "file-loader",
+            "options": Object {
+              "emitFile": false,
+              "name": "[name]-[hash].[ext]",
+            },
+          },
+          Object {
+            "loader": "image-webpack-loader",
+            "options": Object {},
+          },
+        ],
+      },
+      Object {
+        "test": /\\\\\\.\\(woff\\|woff2\\|ttf\\|eot\\)\\(\\\\\\?v=\\\\d\\+\\\\\\.\\\\d\\+\\\\\\.\\\\d\\+\\)\\?\\$/,
+        "use": Array [
+          Object {
+            "loader": "file-loader",
+            "options": Object {
+              "emitFile": false,
+              "name": "[name]-[hash].[ext]",
+            },
+          },
+        ],
+      },
+    ],
+  },
+  "node": Object {
+    "__dirname": false,
+    "__filename": false,
+    "net": "empty",
+  },
+  "output": Object {
+    "chunkFilename": "[name].js",
+    "filename": "[name].js",
+    "libraryTarget": "commonjs2",
+    "path": "/Users/dedmondson/src/tc/gluestick/build/server",
+    "pathinfo": true,
+    "publicPath": "http://localhost:8888undefined",
+  },
+  "plugins": Array [
+    LoaderOptionsPlugin {
+      "options": Object {
+        "options": Object {
+          "context": "/Users/dedmondson/src/tc/gluestick",
+          "output": Object {
+            "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+          },
+          "postcss": Array [
+            [Function],
+            [Function],
+            [Function],
+          ],
+        },
+        "test": /\\\\\\.\\(scss\\|css\\)\\$/,
+      },
+    },
+    ProgressPlugin {
+      "handler": undefined,
+      "profile": undefined,
+    },
+    DefinePlugin {
+      "definitions": Object {
+        "process.env.NODE_ENV": "\\"development\\"",
+      },
+    },
+    LimitChunkCountPlugin {
+      "options": Object {
+        "maxChunks": 1,
+      },
+    },
+    BannerPlugin {
+      "banner": "require(\\"source-map-support\\").install();",
+      "options": Object {
+        "banner": "require(\\"source-map-support\\").install();",
+        "entryOnly": false,
+        "raw": true,
+      },
+    },
+  ],
+  "resolve": Object {
+    "alias": Object {
+      "application-config": "/Users/dedmondson/src/tc/gluestick/src/config/application",
+      "apps": "/Users/dedmondson/src/tc/gluestick/src/apps",
+      "assets": "/Users/dedmondson/src/tc/gluestick/assets",
+      "compiled": "/Users/dedmondson/src/tc/gluestick/node_modules",
+      "config": "/Users/dedmondson/src/tc/gluestick/src/config",
+      "entry-wrapper": "/Users/dedmondson/src/tc/gluestick/gluestick/EntryWrapper",
+      "gluestick-hooks": "/Users/dedmondson/src/tc/gluestick/src/gluestick.hooks.js",
+      "plugins-config-path": undefined,
+      "project-entries": "/Users/dedmondson/src/tc/gluestick/gluestick/entries",
+      "project-entries-config": "/Users/dedmondson/src/tc/gluestick/src/entries.json",
+      "redux-middlewares": "/Users/dedmondson/src/tc/gluestick/src/config/redux-middleware",
+      "root": "/Users/dedmondson/src/tc/gluestick",
+      "shared": "/Users/dedmondson/src/tc/gluestick/src/shared",
+      "src": "/Users/dedmondson/src/tc/gluestick/src",
+    },
+    "extensions": Array [
+      ".js",
+      ".css",
+      ".json",
+    ],
+  },
+  "target": "node",
+}
+`;
+
+exports[`config/compileWebpackConfig in production environment returns the correct client config 1`] = `
+Object {
+  "bail": true,
+  "context": "/Users/dedmondson/src/tc/gluestick",
+  "devtool": "hidden-source-map",
+  "entry": Object {},
+  "module": Object {
+    "rules": Array [
+      Object {
+        "exclude": /\\(node_modules\\\\/\\(\\?!gluestick\\)\\)\\|\\(build\\\\/assets\\)/,
+        "test": /\\\\\\.js\\$/,
+        "use": Array [
+          Object {
+            "loader": "babel-loader",
+            "options": Object {
+              "babelrc": false,
+              "plugins": Array [
+                "transform-flow-strip-types",
+              ],
+              "presets": Array [
+                Array [
+                  "es2015",
+                  Object {
+                    "modules": false,
+                  },
+                ],
+                "react",
+                "stage-0",
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "test": /\\\\\\.\\(scss\\)\\$/,
+        "use": Array [
+          Object {
+            "loader": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/node_modules/extract-text-webpack-plugin/loader.js",
+            "options": Object {
+              "omit": 1,
+              "remove": true,
+            },
+          },
+          Object {
+            "loader": "style-loader",
+          },
+          Object {
+            "loader": "css-loader?importLoaders=2&sourceMap",
+          },
+          Object {
+            "loader": "postcss-loader",
+          },
+          Object {
+            "loader": "sass-loader?outputStyle=expanded&sourceMap=true&sourceMapContents=true",
+          },
+        ],
+      },
+      Object {
+        "test": /\\\\\\.\\(css\\)\\$/,
+        "use": Array [
+          Object {
+            "loader": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/node_modules/extract-text-webpack-plugin/loader.js",
+            "options": Object {
+              "omit": 1,
+              "remove": true,
+            },
+          },
+          Object {
+            "loader": "style-loader",
+          },
+          Object {
+            "loader": "css-loader?importLoaders=1&sourceMap",
+          },
+          Object {
+            "loader": "postcss-loader",
+          },
+        ],
+      },
+      Object {
+        "test": /\\\\\\.\\(png\\|jpg\\|gif\\|ico\\|svg\\)\\(\\\\\\?v=\\\\d\\+\\\\\\.\\\\d\\+\\\\\\.\\\\d\\+\\)\\?\\$/,
+        "use": Array [
+          Object {
+            "loader": "file-loader",
+            "options": Object {
+              "name": "[name]-[hash].[ext]",
+            },
+          },
+          Object {
+            "loader": "image-webpack-loader",
+            "options": Object {},
+          },
+        ],
+      },
+      Object {
+        "test": /\\\\\\.\\(woff\\|woff2\\|ttf\\|eot\\)\\(\\\\\\?v=\\\\d\\+\\\\\\.\\\\d\\+\\\\\\.\\\\d\\+\\)\\?\\$/,
+        "use": Array [
+          Object {
+            "loader": "file-loader",
+            "options": Object {
+              "name": "[name]-[hash].[ext]",
+            },
+          },
+        ],
+      },
+    ],
+  },
+  "node": Object {
+    "net": "empty",
+  },
+  "output": Object {
+    "chunkFilename": "[name].[hash].js",
+    "filename": "[name].[hash].js",
+    "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+    "publicPath": "/assets/",
+  },
+  "plugins": Array [
+    LoaderOptionsPlugin {
+      "options": Object {
+        "options": Object {
+          "context": "/Users/dedmondson/src/tc/gluestick",
+          "output": Object {
+            "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+          },
+          "postcss": Array [
+            [Function],
+            [Function],
+            [Function],
+          ],
+        },
+        "test": /\\\\\\.\\(scss\\|css\\)\\$/,
+      },
+    },
+    NormalModuleReplacementPlugin {
+      "newResource": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/src/config/webpack/mocks/nullMock.js",
+      "resourceRegExp": /\\\\\\.server\\(\\\\\\.js\\)\\?\\$/,
+    },
+    DuplicatePackageCheckerPlugin {
+      "options": Object {
+        "emitError": false,
+        "exclude": null,
+        "verbose": false,
+      },
+    },
+    ProgressPlugin {
+      "handler": undefined,
+      "profile": undefined,
+    },
+    CommonsChunkPlugin {
+      "async": undefined,
+      "children": undefined,
+      "chunkNames": Array [
+        "vendor",
+      ],
+      "deepChildren": undefined,
+      "filenameTemplate": "vendor-[hash].bundle.js",
+      "ident": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/node_modules/webpack/lib/optimize/CommonsChunkPlugin.js2",
+      "minChunks": undefined,
+      "minSize": undefined,
+      "selectedChunks": undefined,
+    },
+    ChunksPlugin {
+      "configuration": Object {
+        "context": "/Users/dedmondson/src/tc/gluestick",
+        "module": Object {
+          "rules": Array [
+            Object {
+              "exclude": /\\(node_modules\\\\/\\(\\?!gluestick\\)\\)\\|\\(build\\\\/assets\\)/,
+              "test": /\\\\\\.js\\$/,
+              "use": Array [
+                Object {
+                  "loader": "babel-loader",
+                  "options": Object {
+                    "babelrc": false,
+                    "plugins": Array [
+                      "transform-flow-strip-types",
+                    ],
+                    "presets": Array [
+                      "es2015",
+                      "react",
+                      "stage-0",
+                    ],
+                  },
+                },
+              ],
+            },
+            Object {
+              "test": /\\\\\\.\\(scss\\)\\$/,
+              "use": Array [
+                "style-loader",
+                "css-loader?importLoaders=2&sourceMap",
+                "postcss-loader",
+                "sass-loader?outputStyle=expanded&sourceMap=true&sourceMapContents=true",
+              ],
+            },
+            Object {
+              "test": /\\\\\\.\\(css\\)\\$/,
+              "use": Array [
+                "style-loader",
+                "css-loader?importLoaders=1&sourceMap",
+                "postcss-loader",
+              ],
+            },
+            Object {
+              "test": /\\\\\\.\\(png\\|jpg\\|gif\\|ico\\|svg\\)\\(\\\\\\?v=\\\\d\\+\\\\\\.\\\\d\\+\\\\\\.\\\\d\\+\\)\\?\\$/,
+              "use": Array [
+                Object {
+                  "loader": "file-loader",
+                  "options": Object {
+                    "name": "[name]-[hash].[ext]",
+                  },
+                },
+                Object {
+                  "loader": "image-webpack-loader",
+                  "options": Object {},
+                },
+              ],
+            },
+            Object {
+              "test": /\\\\\\.\\(woff\\|woff2\\|ttf\\|eot\\)\\(\\\\\\?v=\\\\d\\+\\\\\\.\\\\d\\+\\\\\\.\\\\d\\+\\)\\?\\$/,
+              "use": Array [
+                Object {
+                  "loader": "file-loader",
+                  "options": Object {
+                    "name": "[name]-[hash].[ext]",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        "node": Object {
+          "net": "empty",
+        },
+        "output": Object {
+          "chunkFilename": "[name].[hash].js",
+          "filename": "[name].[hash].js",
+          "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+          "publicPath": "/assets/",
+        },
+        "plugins": Array [
+          LoaderOptionsPlugin {
+            "options": Object {
+              "options": Object {
+                "context": "/Users/dedmondson/src/tc/gluestick",
+                "output": Object {
+                  "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+                },
+                "postcss": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+              },
+              "test": /\\\\\\.\\(scss\\|css\\)\\$/,
+            },
+          },
+        ],
+        "resolve": Object {
+          "alias": Object {
+            "apps": "/Users/dedmondson/src/tc/gluestick/src/apps",
+            "assets": "/Users/dedmondson/src/tc/gluestick/assets",
+            "compiled": "/Users/dedmondson/src/tc/gluestick/node_modules",
+            "config": "/Users/dedmondson/src/tc/gluestick/src/config",
+            "root": "/Users/dedmondson/src/tc/gluestick",
+            "shared": "/Users/dedmondson/src/tc/gluestick/src/shared",
+            "src": "/Users/dedmondson/src/tc/gluestick/src",
+          },
+          "extensions": Array [
+            ".js",
+            ".css",
+            ".json",
+          ],
+        },
+      },
+      "options": Object {},
+    },
+    ExtractTextPlugin {
+      "filename": "[name]-[chunkhash].css",
+      "id": 1,
+      "options": Object {},
+    },
+    OptimizeCssAssetsPlugin {
+      "options": Object {
+        "assetNameRegExp": /\\\\\\.css\\$/g,
+        "canPrint": false,
+        "cssProcessor": [Function],
+        "cssProcessorOptions": Object {},
+      },
+    },
+    DefinePlugin {
+      "definitions": Object {
+        "process.env.NODE_ENV": "\\"production\\"",
+      },
+    },
+    LoaderOptionsPlugin {
+      "options": Object {
+        "debug": false,
+        "minimize": true,
+        "test": Object {
+          "test": [Function],
+        },
+      },
+    },
+    UglifyJsPlugin {
+      "options": Object {
+        "compress": Object {
+          "warnings": false,
+        },
+        "sourceMap": true,
+      },
+    },
+    NormalModuleReplacementPlugin {
+      "newResource": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/src/config/webpack/mocks/emptyObjMock.js",
+      "resourceRegExp": /gluestick\\\\/shared\\\\/lib\\\\/errorUtils/,
+    },
+  ],
+  "resolve": Object {
+    "alias": Object {
+      "apps": "/Users/dedmondson/src/tc/gluestick/src/apps",
+      "assets": "/Users/dedmondson/src/tc/gluestick/assets",
+      "compiled": "/Users/dedmondson/src/tc/gluestick/node_modules",
+      "config": "/Users/dedmondson/src/tc/gluestick/src/config",
+      "root": "/Users/dedmondson/src/tc/gluestick",
+      "shared": "/Users/dedmondson/src/tc/gluestick/src/shared",
+      "src": "/Users/dedmondson/src/tc/gluestick/src",
+    },
+    "extensions": Array [
+      ".js",
+      ".css",
+      ".json",
+    ],
+  },
+}
+`;
+
+exports[`config/compileWebpackConfig in production environment returns the correct client config 2`] = `
+Object {
+  "bail": true,
+  "context": "/Users/dedmondson/src/tc/gluestick",
+  "devtool": "source-map",
+  "entry": Object {
+    "renderer": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/src/renderer/entry.js",
+  },
+  "externals": Array [
+    [Function],
+  ],
+  "module": Object {
+    "noParse": Array [
+      /cli\\\\/helpers/,
+    ],
+    "rules": Array [
+      Object {
+        "exclude": /\\(node_modules\\\\/\\(\\?!gluestick\\)\\)\\|\\(build\\\\/assets\\)/,
+        "test": /\\\\\\.js\\$/,
+        "use": Array [
+          Object {
+            "loader": "babel-loader",
+            "options": Object {
+              "babelrc": false,
+              "plugins": Array [
+                "transform-flow-strip-types",
+              ],
+              "presets": Array [
+                "es2015",
+                "react",
+                "stage-0",
+              ],
+            },
+          },
+        ],
+      },
+      Object {
+        "test": /\\\\\\.\\(scss\\)\\$/,
+        "use": Array [
+          "ignore-loader",
+        ],
+      },
+      Object {
+        "test": /\\\\\\.\\(css\\)\\$/,
+        "use": Array [
+          "ignore-loader",
+        ],
+      },
+      Object {
+        "test": /\\\\\\.\\(png\\|jpg\\|gif\\|ico\\|svg\\)\\(\\\\\\?v=\\\\d\\+\\\\\\.\\\\d\\+\\\\\\.\\\\d\\+\\)\\?\\$/,
+        "use": Array [
+          Object {
+            "loader": "file-loader",
+            "options": Object {
+              "emitFile": false,
+              "name": "[name]-[hash].[ext]",
+            },
+          },
+          Object {
+            "loader": "image-webpack-loader",
+            "options": Object {},
+          },
+        ],
+      },
+      Object {
+        "test": /\\\\\\.\\(woff\\|woff2\\|ttf\\|eot\\)\\(\\\\\\?v=\\\\d\\+\\\\\\.\\\\d\\+\\\\\\.\\\\d\\+\\)\\?\\$/,
+        "use": Array [
+          Object {
+            "loader": "file-loader",
+            "options": Object {
+              "emitFile": false,
+              "name": "[name]-[hash].[ext]",
+            },
+          },
+        ],
+      },
+    ],
+  },
+  "node": Object {
+    "__dirname": false,
+    "__filename": false,
+    "net": "empty",
+  },
+  "output": Object {
+    "chunkFilename": "[name].js",
+    "filename": "[name].js",
+    "libraryTarget": "commonjs2",
+    "path": "/Users/dedmondson/src/tc/gluestick/build/server",
+    "pathinfo": true,
+  },
+  "plugins": Array [
+    LoaderOptionsPlugin {
+      "options": Object {
+        "options": Object {
+          "context": "/Users/dedmondson/src/tc/gluestick",
+          "output": Object {
+            "path": "/Users/dedmondson/src/tc/gluestick/build/assets",
+          },
+          "postcss": Array [
+            [Function],
+            [Function],
+            [Function],
+          ],
+        },
+        "test": /\\\\\\.\\(scss\\|css\\)\\$/,
+      },
+    },
+    ProgressPlugin {
+      "handler": undefined,
+      "profile": undefined,
+    },
+    DefinePlugin {
+      "definitions": Object {
+        "process.env.NODE_ENV": "\\"production\\"",
+      },
+    },
+    LimitChunkCountPlugin {
+      "options": Object {
+        "maxChunks": 1,
+      },
+    },
+  ],
+  "resolve": Object {
+    "alias": Object {
+      "application-config": "/Users/dedmondson/src/tc/gluestick/src/config/application",
+      "apps": "/Users/dedmondson/src/tc/gluestick/src/apps",
+      "assets": "/Users/dedmondson/src/tc/gluestick/assets",
+      "compiled": "/Users/dedmondson/src/tc/gluestick/node_modules",
+      "config": "/Users/dedmondson/src/tc/gluestick/src/config",
+      "entry-wrapper": "/Users/dedmondson/src/tc/gluestick/gluestick/EntryWrapper",
+      "gluestick-hooks": "/Users/dedmondson/src/tc/gluestick/src/gluestick.hooks.js",
+      "plugins-config-path": undefined,
+      "project-entries": "/Users/dedmondson/src/tc/gluestick/gluestick/entries",
+      "project-entries-config": "/Users/dedmondson/src/tc/gluestick/src/entries.json",
+      "react": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/node_modules/react/cjs/react.production.min.js",
+      "react-dom": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/node_modules/react-dom/cjs/react-dom.production.min.js",
+      "react-dom/server": "/Users/dedmondson/src/tc/gluestick/packages/gluestick/node_modules/react-dom/cjs/react-dom-server.node.production.min.js",
+      "redux-middlewares": "/Users/dedmondson/src/tc/gluestick/src/config/redux-middleware",
+      "root": "/Users/dedmondson/src/tc/gluestick",
+      "shared": "/Users/dedmondson/src/tc/gluestick/src/shared",
+      "src": "/Users/dedmondson/src/tc/gluestick/src",
+    },
+    "extensions": Array [
+      ".js",
+      ".css",
+      ".json",
+    ],
+  },
+  "target": "node",
+}
+`;

--- a/packages/gluestick/src/config/__tests__/compileWebpackConfig.test.js
+++ b/packages/gluestick/src/config/__tests__/compileWebpackConfig.test.js
@@ -13,72 +13,71 @@ jest.mock(
   { virtual: true },
 );
 jest.mock('src/config/application.js', () => ({}), { virtual: true });
-
 const compileWebpackConfig = require('../compileWebpackConfig');
-const defaultGSConfig = require('../defaults/glueStickConfig');
+const gluestickConfig = require('../defaults/glueStickConfig');
 
-const loggerMock = require('../../__tests__/mocks/context').commandApi.getLogger();
-
-const originalProcessCwd = process.cwd.bind(process);
-const compileMockedWebpackConfig = () =>
-  compileWebpackConfig(
-    loggerMock,
-    [
-      {
-        name: 'test',
-        meta: {},
-        preOverwrites: {},
-        postOverwrites: {
-          clientWebpackConfig: config =>
-            Object.assign(config, { testProp: true }),
-          serverWebpackConfig: config =>
-            Object.assign(config, { testProp: true }),
-        },
-      },
-      {
-        name: 'test',
-        meta: {},
-        preOverwrites: {
-          sharedWebpackConfig: config =>
-            Object.assign(config, { preTestProp: true }),
-        },
-        postOverwrites: {
-          clientWebpackConfig: config =>
-            Object.assign(config, { testPropNew: true }),
-        },
-      },
-    ],
-    defaultGSConfig,
-  );
+// may want to move this to a central place
+const mockLogger = () => ({
+  warn: jest.fn(),
+  info: jest.fn(),
+  success: jest.fn(),
+  debug: jest.fn(),
+  error: jest.fn(),
+  pretty: false,
+  clear: jest.fn(),
+  log: jest.fn(),
+  print: jest.fn(),
+  printCommandInfo: jest.fn(),
+  fatal: jest.fn(),
+  resetLine: jest.fn(),
+});
 
 describe('config/compileWebpackConfig', () => {
-  beforeAll(() => {
-    // $FlowIgnore
-    process.cwd = () => '.';
+  let logger;
+  let originalNodeEnv;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV;
+    logger = mockLogger();
   });
 
-  afterAll(() => {
-    // $FlowIgnore
-    process.cwd = originalProcessCwd;
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
   });
 
-  it('should return webpack config', () => {
-    const webpackConfig = compileMockedWebpackConfig();
+  describe('in dev environment', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'development';
+    });
 
-    expect(webpackConfig.universalSettings).not.toBeNull();
-    expect(webpackConfig.client).not.toBeNull();
-    expect(webpackConfig.server).not.toBeNull();
-    expect(webpackConfig.client.testProp).toBeTruthy();
-    expect(webpackConfig.server.testProp).toBeTruthy();
-    expect(webpackConfig.client.preTestProp).toBeTruthy();
-    expect(webpackConfig.server.preTestProp).toBeTruthy();
-    expect(webpackConfig.client.testPropNew).toBeTruthy();
+    it('returns the correct client config', () => {
+      expect(
+        compileWebpackConfig(logger, [], gluestickConfig).client,
+      ).toMatchSnapshot();
+    });
+
+    it('returns the correct server config', () => {
+      expect(
+        compileWebpackConfig(logger, [], gluestickConfig).server,
+      ).toMatchSnapshot();
+    });
   });
 
-  it('should mutate webpack config when hooks are present', () => {
-    const webpackConfig = compileMockedWebpackConfig();
+  describe('in production environment', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production';
+    });
 
-    expect(webpackConfig.client.mutated).toBeTruthy();
-    expect(webpackConfig.server.mutated).toBeTruthy();
+    it('returns the correct client config', () => {
+      expect(
+        compileWebpackConfig(logger, [], gluestickConfig).client,
+      ).toMatchSnapshot();
+    });
+
+    it('returns the correct server config', () => {
+      expect(
+        compileWebpackConfig(logger, [], gluestickConfig).server,
+      ).toMatchSnapshot();
+    });
   });
 });

--- a/packages/gluestick/src/config/__tests__/compileWebpackConfig.test.js
+++ b/packages/gluestick/src/config/__tests__/compileWebpackConfig.test.js
@@ -1,4 +1,6 @@
 /* @flow */
+import traverse from 'traverse';
+
 jest.mock('../../utils', () => ({ requireModule: v => require(v) }));
 jest.mock('../webpack/buildEntries.js', () => () => ({}));
 jest.mock('../webpack/buildServerEntries.js', () => jest.fn());
@@ -32,6 +34,15 @@ const mockLogger = () => ({
   resetLine: jest.fn(),
 });
 
+const replacePaths = obj => {
+  traverse(obj).forEach(function search(value) {
+    if (typeof value === 'string') {
+      this.update(value.replace(process.cwd(), '/project'));
+    }
+  });
+  return obj;
+};
+
 describe('config/compileWebpackConfig', () => {
   let logger;
   let originalNodeEnv;
@@ -52,13 +63,13 @@ describe('config/compileWebpackConfig', () => {
 
     it('returns the correct client config', () => {
       expect(
-        compileWebpackConfig(logger, [], gluestickConfig).client,
+        replacePaths(compileWebpackConfig(logger, [], gluestickConfig).client),
       ).toMatchSnapshot();
     });
 
     it('returns the correct server config', () => {
       expect(
-        compileWebpackConfig(logger, [], gluestickConfig).server,
+        replacePaths(compileWebpackConfig(logger, [], gluestickConfig).server),
       ).toMatchSnapshot();
     });
   });
@@ -70,13 +81,13 @@ describe('config/compileWebpackConfig', () => {
 
     it('returns the correct client config', () => {
       expect(
-        compileWebpackConfig(logger, [], gluestickConfig).client,
+        replacePaths(compileWebpackConfig(logger, [], gluestickConfig).client),
       ).toMatchSnapshot();
     });
 
     it('returns the correct server config', () => {
       expect(
-        compileWebpackConfig(logger, [], gluestickConfig).server,
+        replacePaths(compileWebpackConfig(logger, [], gluestickConfig).server),
       ).toMatchSnapshot();
     });
   });

--- a/packages/gluestick/src/config/compileWebpackConfig.js
+++ b/packages/gluestick/src/config/compileWebpackConfig.js
@@ -189,6 +189,7 @@ module.exports = (
   );
 
   return {
+    // this is used in one place, refactor it out
     universalSettings: universalWebpackSettings,
     client: clientEnvConfigFinal,
     server: serverEnvConfigFinal,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,13 +9,9 @@ JSONStream@^1.0.4, JSONStream@~1.3.1:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-abab@^1.0.0:
+abab@^1.0.0, abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
-
-abab@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
 
 abbrev@1, abbrev@~1.1.0:
   version "1.1.0"
@@ -68,13 +64,9 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^4.0.3:
+acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
-
-acorn@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
 
 acorn@^5.0.0:
   version "5.3.0"
@@ -196,17 +188,17 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.0.0, ansi-styles@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.1.0.tgz#09c202d5c917ec23188caa5c9cb9179cd9547750"
-  dependencies:
-    color-convert "^1.0.0"
-
-ansi-styles@^3.2.1:
+ansi-styles@^3.0.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.1.0.tgz#09c202d5c917ec23188caa5c9cb9179cd9547750"
+  dependencies:
+    color-convert "^1.0.0"
 
 ansi@^0.3.0, ansi@~0.3.1:
   version "0.3.1"
@@ -282,9 +274,17 @@ arr-diff@^2.0.0:
   dependencies:
     arr-flatten "^1.0.1"
 
-arr-flatten@^1.0.1:
+arr-diff@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
+
+arr-flatten@^1.0.1, arr-flatten@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+
+arr-union@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
 
 array-difference@0.0.1:
   version "0.0.1"
@@ -338,6 +338,10 @@ array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
+array-unique@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+
 arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
@@ -378,6 +382,10 @@ assert@^1.1.1:
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
   dependencies:
     util "0.10.3"
+
+assign-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
 ast-types-flow@0.0.7:
   version "0.0.7"
@@ -429,6 +437,10 @@ async@^2.1.2:
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+
+atob@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
 
 autoprefixer@^6.3.1, autoprefixer@^6.7.7:
   version "6.7.7"
@@ -718,12 +730,13 @@ babel-plugin-gluestick@0.0.1:
     babel-preset-react "^6.11.1"
 
 babel-plugin-istanbul@^4.0.0:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz#18dde84bf3ce329fddf3f4103fae921456d8e587"
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
   dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
     find-up "^2.1.0"
-    istanbul-lib-instrument "^1.7.2"
-    test-exclude "^4.1.1"
+    istanbul-lib-instrument "^1.10.1"
+    test-exclude "^4.2.1"
 
 babel-plugin-jest-hoist@^20.0.3:
   version "20.0.3"
@@ -777,7 +790,7 @@ babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
-babel-plugin-syntax-object-rest-spread@^6.8.0:
+babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
@@ -1326,7 +1339,7 @@ babylon@^6.11.0:
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
 
-babylon@^6.15.0, babylon@^6.17.0, babylon@^6.17.4:
+babylon@^6.15.0, babylon@^6.17.0:
   version "6.17.4"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
 
@@ -1345,6 +1358,18 @@ balanced-match@^1.0.0:
 base64-js@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
+
+base@^0.11.1:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
+  dependencies:
+    cache-base "^1.0.1"
+    class-utils "^0.3.5"
+    component-emitter "^1.2.1"
+    define-property "^1.0.0"
+    isobject "^3.0.1"
+    mixin-deep "^1.2.0"
+    pascalcase "^0.1.1"
 
 bash-color@0.0.4:
   version "0.0.4"
@@ -1468,6 +1493,21 @@ braces@^1.8.2:
     expand-range "^1.8.1"
     preserve "^0.2.0"
     repeat-element "^1.1.2"
+
+braces@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
+  dependencies:
+    arr-flatten "^1.1.0"
+    array-unique "^0.3.2"
+    extend-shallow "^2.0.1"
+    fill-range "^4.0.0"
+    isobject "^3.0.1"
+    repeat-element "^1.1.2"
+    snapdragon "^0.8.1"
+    snapdragon-node "^2.0.1"
+    split-string "^3.0.2"
+    to-regex "^3.0.1"
 
 brorand@^1.0.1:
   version "1.1.0"
@@ -1635,6 +1675,20 @@ cacache@^9.2.9, cacache@~9.2.9:
     ssri "^4.1.6"
     unique-filename "^1.1.0"
     y18n "^3.2.1"
+
+cache-base@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
+  dependencies:
+    collection-visit "^1.0.0"
+    component-emitter "^1.2.1"
+    get-value "^2.0.6"
+    has-value "^1.0.0"
+    isobject "^3.0.1"
+    set-value "^2.0.0"
+    to-object-path "^0.3.0"
+    union-value "^1.0.0"
+    unset-value "^1.0.0"
 
 call-limit@~1.1.0:
   version "1.1.0"
@@ -1857,6 +1911,15 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
+class-utils@^0.3.5:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
+  dependencies:
+    arr-union "^3.1.0"
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    static-extend "^0.1.1"
+
 clean-css@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-1.1.7.tgz#601ef9cf7642b982cb33efc9488a6444c986686e"
@@ -1955,6 +2018,13 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+collection-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
+  dependencies:
+    map-visit "^1.0.0"
+    object-visit "^1.0.0"
+
 color-convert@^1.0.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
@@ -2051,6 +2121,14 @@ compare-func@^1.3.1:
     array-ify "^1.0.0"
     dot-prop "^3.0.0"
 
+compare-versions@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.1.0.tgz#43310256a5c555aaed4193c04d8f154cf9c6efd5"
+
+component-emitter@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+
 compressible@~2.0.10:
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.12.tgz#c59a5c99db76767e9876500e271ef63b3493bd66"
@@ -2122,8 +2200,8 @@ content-disposition@0.5.2:
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
 content-type-parser@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.1.tgz#c3e56988c53c65127fb46d4032a3a900246fdc94"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.2.tgz#caabe80623e63638b2502fd4c7f12ff4ce2352e7"
 
 content-type@~1.0.1, content-type@~1.0.2:
   version "1.0.4"
@@ -2308,6 +2386,10 @@ copy-concurrently@^1.0.0:
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
     run-queue "^1.0.0"
+
+copy-descriptor@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -2591,7 +2673,7 @@ dateformat@^1.0.11, dateformat@^1.0.12:
     get-stdin "^4.0.1"
     meow "^3.3.0"
 
-debug@*, debug@^3:
+debug@*, debug@^3, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -2615,7 +2697,7 @@ debug@2.6.7:
   dependencies:
     ms "2.0.0"
 
-debug@2.6.9, debug@^2.3.2:
+debug@2.6.9, debug@^2.3.2, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -2634,6 +2716,10 @@ debuglog@^1.0.1:
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
 decompress-response@^3.2.0:
   version "3.3.0"
@@ -2671,6 +2757,25 @@ define-properties@^1.1.2:
   dependencies:
     foreach "^2.0.5"
     object-keys "^1.0.8"
+
+define-property@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
+  dependencies:
+    is-descriptor "^0.1.0"
+
+define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
+  dependencies:
+    is-descriptor "^1.0.0"
+
+define-property@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
+  dependencies:
+    is-descriptor "^1.0.2"
+    isobject "^3.0.1"
 
 defined@^1.0.0:
   version "1.0.0"
@@ -2966,7 +3071,7 @@ err-code@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
 
-"errno@>=0.1.1 <0.2.0-0", errno@^0.1.4:
+"errno@>=0.1.1 <0.2.0-0":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
   dependencies:
@@ -2975,6 +3080,12 @@ err-code@^1.0.0:
 errno@^0.1.3:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.6.tgz#c386ce8a6283f14fc09563b71560908c9bf53026"
+  dependencies:
+    prr "~1.0.1"
+
+errno@~0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
   dependencies:
     prr "~1.0.1"
 
@@ -3439,6 +3550,18 @@ expand-brackets@^0.1.4:
   dependencies:
     is-posix-bracket "^0.1.0"
 
+expand-brackets@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
+  dependencies:
+    debug "^2.3.3"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    posix-character-classes "^0.1.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
 expand-range@^1.8.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
@@ -3478,6 +3601,19 @@ express@4.15.3:
     utils-merge "1.0.0"
     vary "~1.1.1"
 
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  dependencies:
+    is-extendable "^0.1.0"
+
+extend-shallow@^3.0.0, extend-shallow@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
+  dependencies:
+    assign-symbols "^1.0.0"
+    is-extendable "^1.0.1"
+
 extend@3, extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
@@ -3495,6 +3631,19 @@ extglob@^0.3.1:
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
   dependencies:
     is-extglob "^1.0.0"
+
+extglob@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
+  dependencies:
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    expand-brackets "^2.1.4"
+    extend-shallow "^2.0.1"
+    fragment-cache "^0.2.1"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 extract-text-webpack-plugin@2.1.2, extract-text-webpack-plugin@^2.1.0:
   version "2.1.2"
@@ -3603,6 +3752,15 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
+fill-range@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+    to-regex-range "^2.1.0"
+
 finalhandler@~1.0.3:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.6.tgz#007aea33d1a4d3e42017f624848ad58d212f814f"
@@ -3708,7 +3866,7 @@ follow-redirects@1.0.0:
   dependencies:
     debug "^2.2.0"
 
-for-in@^1.0.1:
+for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
 
@@ -3761,6 +3919,12 @@ form-data@~2.3.1:
 forwarded@~0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
+
+fragment-cache@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
+  dependencies:
+    map-cache "^0.2.2"
 
 fresh-require@1.0.3:
   version "1.0.3"
@@ -4012,6 +4176,10 @@ get-stream@^2.2.0:
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
+get-value@^2.0.3, get-value@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -4479,6 +4647,33 @@ has-unicode@^2.0.0, has-unicode@~2.0.0, has-unicode@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
+has-value@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
+  dependencies:
+    get-value "^2.0.3"
+    has-values "^0.1.4"
+    isobject "^2.0.0"
+
+has-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
+  dependencies:
+    get-value "^2.0.6"
+    has-values "^1.0.0"
+    isobject "^3.0.0"
+
+has-values@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
+
+has-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
+  dependencies:
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
+
 has@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
@@ -4580,8 +4775,8 @@ html-comment-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.1.tgz#668b93776eaae55ebde8f3ad464b307a4963625e"
 
 html-encoding-sniffer@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz#79bf7a785ea495fe66165e734153f363ff5437da"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
   dependencies:
     whatwg-encoding "^1.0.1"
 
@@ -4876,6 +5071,18 @@ is-absolute-url@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-2.1.0.tgz#50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6"
 
+is-accessor-descriptor@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-accessor-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
+  dependencies:
+    kind-of "^6.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -4906,9 +5113,37 @@ is-ci@^1.0.10:
   dependencies:
     ci-info "^1.0.0"
 
+is-data-descriptor@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-data-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
+  dependencies:
+    kind-of "^6.0.0"
+
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-descriptor@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
+  dependencies:
+    is-accessor-descriptor "^0.1.6"
+    is-data-descriptor "^0.1.4"
+    kind-of "^5.0.0"
+
+is-descriptor@^1.0.0, is-descriptor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
+  dependencies:
+    is-accessor-descriptor "^1.0.0"
+    is-data-descriptor "^1.0.0"
+    kind-of "^6.0.2"
 
 is-dotfile@^1.0.0:
   version "1.0.3"
@@ -4920,9 +5155,15 @@ is-equal-shallow@^0.1.3:
   dependencies:
     is-primitive "^2.0.0"
 
-is-extendable@^0.1.1:
+is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+
+is-extendable@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
+  dependencies:
+    is-plain-object "^2.0.4"
 
 is-extglob@^1.0.0:
   version "1.0.0"
@@ -4985,6 +5226,10 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-number@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
+
 is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
@@ -4992,6 +5237,12 @@ is-obj@^1.0.0:
 is-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+
+is-odd@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-odd/-/is-odd-2.0.0.tgz#7646624671fd7ea558ccd9a2795182f2958f1b24"
+  dependencies:
+    is-number "^4.0.0"
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -5012,6 +5263,12 @@ is-path-inside@^1.0.0:
 is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+
+is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  dependencies:
+    isobject "^3.0.1"
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
@@ -5085,6 +5342,10 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+is-windows@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
 is@^3.1.0, is@^3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/is/-/is-3.2.1.tgz#d0ac2ad55eb7b0bec926a5266f6c662aaa83dca5"
@@ -5119,6 +5380,10 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
+isobject@^3.0.0, isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+
 isomorphic-fetch@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
@@ -5131,65 +5396,76 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
 istanbul-api@^1.1.1:
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.1.10.tgz#f27e5e7125c8de13f6a80661af78f512e5439b2b"
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.3.1.tgz#4c3b05d18c0016d1022e079b98dc82c40f488954"
   dependencies:
     async "^2.1.4"
+    compare-versions "^3.1.0"
     fileset "^2.0.2"
-    istanbul-lib-coverage "^1.1.1"
-    istanbul-lib-hook "^1.0.7"
-    istanbul-lib-instrument "^1.7.3"
-    istanbul-lib-report "^1.1.1"
-    istanbul-lib-source-maps "^1.2.1"
-    istanbul-reports "^1.1.1"
+    istanbul-lib-coverage "^1.2.0"
+    istanbul-lib-hook "^1.2.0"
+    istanbul-lib-instrument "^1.10.1"
+    istanbul-lib-report "^1.1.4"
+    istanbul-lib-source-maps "^1.2.4"
+    istanbul-reports "^1.3.0"
     js-yaml "^3.7.0"
     mkdirp "^0.5.1"
     once "^1.4.0"
 
-istanbul-lib-coverage@^1.0.1, istanbul-lib-coverage@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
+istanbul-lib-coverage@^1.0.1, istanbul-lib-coverage@^1.1.2, istanbul-lib-coverage@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
 
-istanbul-lib-hook@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz#dd6607f03076578fe7d6f2a630cf143b49bacddc"
+istanbul-lib-hook@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.2.0.tgz#ae556fd5a41a6e8efa0b1002b1e416dfeaf9816c"
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.4.2, istanbul-lib-instrument@^1.7.2, istanbul-lib-instrument@^1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.3.tgz#925b239163eabdd68cc4048f52c2fa4f899ecfa7"
+istanbul-lib-instrument@^1.10.1, istanbul-lib-instrument@^1.4.2:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
   dependencies:
     babel-generator "^6.18.0"
     babel-template "^6.16.0"
     babel-traverse "^6.18.0"
     babel-types "^6.18.0"
-    babylon "^6.17.4"
-    istanbul-lib-coverage "^1.1.1"
+    babylon "^6.18.0"
+    istanbul-lib-coverage "^1.2.0"
     semver "^5.3.0"
 
-istanbul-lib-report@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz#f0e55f56655ffa34222080b7a0cd4760e1405fc9"
+istanbul-lib-report@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz#e886cdf505c4ebbd8e099e4396a90d0a28e2acb5"
   dependencies:
-    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-coverage "^1.2.0"
     mkdirp "^0.5.1"
     path-parse "^1.0.5"
     supports-color "^3.1.2"
 
-istanbul-lib-source-maps@^1.1.0, istanbul-lib-source-maps@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz#a6fe1acba8ce08eebc638e572e294d267008aa0c"
+istanbul-lib-source-maps@^1.1.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz#20fb54b14e14b3fb6edb6aca3571fd2143db44e6"
   dependencies:
-    debug "^2.6.3"
-    istanbul-lib-coverage "^1.1.1"
+    debug "^3.1.0"
+    istanbul-lib-coverage "^1.1.2"
     mkdirp "^0.5.1"
     rimraf "^2.6.1"
     source-map "^0.5.3"
 
-istanbul-reports@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.1.tgz#042be5c89e175bc3f86523caab29c014e77fee4e"
+istanbul-lib-source-maps@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz#cc7ccad61629f4efff8e2f78adb8c522c9976ec7"
+  dependencies:
+    debug "^3.1.0"
+    istanbul-lib-coverage "^1.2.0"
+    mkdirp "^0.5.1"
+    rimraf "^2.6.1"
+    source-map "^0.5.3"
+
+istanbul-reports@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.3.0.tgz#2f322e81e1d9520767597dca3c20a0cce89a3554"
   dependencies:
     handlebars "^4.0.3"
 
@@ -5283,8 +5559,8 @@ jest-environment-node@^20.0.3:
     jest-util "^20.0.3"
 
 jest-haste-map@^20.0.4:
-  version "20.0.4"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-20.0.4.tgz#653eb55c889ce3c021f7b94693f20a4159badf03"
+  version "20.0.5"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-20.0.5.tgz#abad74efb1a005974a7b6517e11010709cab9112"
   dependencies:
     fb-watchman "^2.0.0"
     graceful-fs "^4.1.11"
@@ -5598,7 +5874,7 @@ kefir@^3.2.0:
   dependencies:
     symbol-observable "^1.0.1"
 
-kind-of@^3.0.2:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   dependencies:
@@ -5609,6 +5885,14 @@ kind-of@^4.0.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
   dependencies:
     is-buffer "^1.1.5"
+
+kind-of@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+
+kind-of@^6.0.0, kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
 kramed-text-renderer@0.2.1:
   version "0.2.1"
@@ -6020,9 +6304,19 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
+map-cache@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
+
+map-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
+  dependencies:
+    object-visit "^1.0.0"
 
 "match-stream@>= 0.0.2 < 1":
   version "0.0.2"
@@ -6123,6 +6417,24 @@ micromatch@^2.1.5, micromatch@^2.3.11:
     object.omit "^2.0.0"
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
+
+micromatch@^3.1.8:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    braces "^2.3.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    extglob "^2.0.4"
+    fragment-cache "^0.2.1"
+    kind-of "^6.0.2"
+    nanomatch "^1.2.9"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.2"
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -6239,6 +6551,13 @@ mississippi@^1.2.0, mississippi@^1.3.0, mississippi@~1.3.0:
     stream-each "^1.1.0"
     through2 "^2.0.0"
 
+mixin-deep@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^1.0.1"
+
 mkdirp@0.5, mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -6309,6 +6628,23 @@ nan@^2.3.0:
 nan@^2.3.3, nan@^2.4.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
+
+nanomatch@^1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.9.tgz#879f7150cb2dab7a471259066c104eee6e0fa7c2"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    fragment-cache "^0.2.1"
+    is-odd "^2.0.0"
+    is-windows "^1.0.2"
+    kind-of "^6.0.2"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 natives@^1.1.0:
   version "1.1.0"
@@ -6456,13 +6792,13 @@ node-libs-browser@^2.0.0:
     vm-browserify "0.0.4"
 
 node-notifier@^5.0.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.1.2.tgz#2fa9e12605fa10009d44549d6fcd8a63dde0e4ff"
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.2.1.tgz#fa313dd08f5517db0e2502e5758d664ac69f9dea"
   dependencies:
     growly "^1.3.0"
-    semver "^5.3.0"
-    shellwords "^0.1.0"
-    which "^1.2.12"
+    semver "^5.4.1"
+    shellwords "^0.1.1"
+    which "^1.3.0"
 
 node-pre-gyp@^0.6.36:
   version "0.6.36"
@@ -7069,9 +7405,13 @@ nunjucks@2.5.2:
     chokidar "^1.6.0"
     yargs "^3.32.0"
 
-"nwmatcher@>= 1.3.7 < 2.0.0", "nwmatcher@>= 1.3.9 < 2.0.0":
+"nwmatcher@>= 1.3.7 < 2.0.0":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.1.tgz#7ae9b07b0ea804db7e25f05cb5fe4097d4e4949f"
+
+"nwmatcher@>= 1.3.9 < 2.0.0":
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.4.tgz#2285631f34a95f0d0395cd900c96ed39b58f346e"
 
 oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
@@ -7080,6 +7420,14 @@ oauth-sign@~0.8.1, oauth-sign@~0.8.2:
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-copy@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
+  dependencies:
+    copy-descriptor "^0.1.0"
+    define-property "^0.2.5"
+    kind-of "^3.0.3"
 
 object-hash@^1.1.4:
   version "1.2.0"
@@ -7100,6 +7448,12 @@ object-keys@~0.4.0:
 object-path@^0.9.2:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.9.2.tgz#0fd9a74fc5fad1ae3968b586bda5c632bd6c05a5"
+
+object-visit@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
+  dependencies:
+    isobject "^3.0.0"
 
 object.assign@^4.0.4:
   version "4.1.0"
@@ -7125,6 +7479,12 @@ object.omit@^2.0.0:
   dependencies:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
+
+object.pick@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
+  dependencies:
+    isobject "^3.0.1"
 
 object.values@^1.0.4:
   version "1.0.4"
@@ -7272,8 +7632,8 @@ p-locate@^2.0.0:
     p-limit "^1.1.0"
 
 p-map@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.1.1.tgz#05f5e4ae97a068371bc2a5cc86bfbdbc19c4ae7a"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
 
 p-timeout@^1.1.1:
   version "1.2.0"
@@ -7364,6 +7724,10 @@ parse5@^1.5.1:
 parseurl@~1.3.0, parseurl@~1.3.1, parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
+
+pascalcase@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
 
 path-array@^1.0.0:
   version "1.0.1"
@@ -7537,6 +7901,10 @@ pmx@^1.0.1:
     debug "^3"
     json-stringify-safe "^5.0"
     vxx "^1.2.0"
+
+posix-character-classes@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
 postcss-calc@^5.2.0, postcss-calc@^5.3.1:
   version "5.3.1"
@@ -8360,6 +8728,13 @@ regex-cache@^0.4.2:
     is-equal-shallow "^0.1.3"
     is-primitive "^2.0.0"
 
+regex-not@^1.0.0, regex-not@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
+  dependencies:
+    extend-shallow "^3.0.2"
+    safe-regex "^1.1.0"
+
 regexpu-core@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
@@ -8395,7 +8770,7 @@ repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
 
-repeat-string@^1.5.2:
+repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -8464,7 +8839,34 @@ request@2.72.0, request@~2.72.0:
     tough-cookie "~2.2.0"
     tunnel-agent "~0.4.1"
 
-request@^2.79.0, request@^2.81.0, request@~2.81.0:
+request@^2.79.0:
+  version "2.85.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.85.0.tgz#5a03615a47c61420b3eb99b7dba204f83603e1fa"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.6.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.1"
+    forever-agent "~0.6.1"
+    form-data "~2.3.1"
+    har-validator "~5.0.3"
+    hawk "~6.0.2"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.17"
+    oauth-sign "~0.8.2"
+    performance-now "^2.1.0"
+    qs "~6.5.1"
+    safe-buffer "^5.1.1"
+    stringstream "~0.0.5"
+    tough-cookie "~2.3.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.1.0"
+
+request@^2.81.0, request@~2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -8570,6 +8972,10 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
+resolve-url@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
+
 resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
@@ -8580,9 +8986,15 @@ resolve@^1.0.0:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.1.6, resolve@^1.3.2:
+resolve@^1.1.6:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.2.tgz#1f0442c9e0cbb8136e87b9305f932f46c7f28235"
+  dependencies:
+    path-parse "^1.0.5"
+
+resolve@^1.3.2:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
   dependencies:
     path-parse "^1.0.5"
 
@@ -8592,6 +9004,10 @@ restore-cursor@^2.0.0:
   dependencies:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
+
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
 retry@^0.10.0, retry@~0.10.0, retry@~0.10.1:
   version "0.10.1"
@@ -8678,6 +9094,12 @@ safe-json-stringify@~1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz#81a098f447e4bbc3ff3312a243521bc060ef5911"
 
+safe-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
+  dependencies:
+    ret "~0.1.10"
+
 sane@~1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/sane/-/sane-1.6.0.tgz#9610c452307a135d29c1fdfe2547034180c46775"
@@ -8733,7 +9155,7 @@ semver@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.1.0.tgz#85f2cf8550465c4df000cf7d86f6b054106ab9e5"
 
-semver@5.5.0, semver@^5.2:
+semver@5.5.0, semver@^5.2, semver@^5.4.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -8805,6 +9227,24 @@ set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
+set-value@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.1"
+    to-object-path "^0.3.0"
+
+set-value@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
+
 "setimmediate@>= 1.0.1 < 2", "setimmediate@>= 1.0.2 < 2", setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
@@ -8868,9 +9308,9 @@ shelljs@^0.7.8:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shellwords@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.0.tgz#66afd47b6a12932d9071cbfd98a52e785cd0ba14"
+shellwords@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
 
 shimmer@^1.0.0, shimmer@^1.1.0, shimmer@^1.2.0:
   version "1.2.0"
@@ -8916,6 +9356,33 @@ slide@^1.1.3, slide@^1.1.5, slide@~1.1.3, slide@~1.1.6:
 smart-buffer@^1.0.13:
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-1.1.15.tgz#7f114b5b65fab3e2a35aa775bb12f0d1c649bf16"
+
+snapdragon-node@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
+  dependencies:
+    define-property "^1.0.0"
+    isobject "^3.0.0"
+    snapdragon-util "^3.0.1"
+
+snapdragon-util@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
+  dependencies:
+    kind-of "^3.2.0"
+
+snapdragon@^0.8.1:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.2.tgz#64922e7c565b0e14204ba1aa7d6964278d25182d"
+  dependencies:
+    base "^0.11.1"
+    debug "^2.2.0"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    map-cache "^0.2.2"
+    source-map "^0.5.6"
+    source-map-resolve "^0.5.0"
+    use "^3.1.0"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -8974,6 +9441,16 @@ source-list-map@~0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
 
+source-map-resolve@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.1.tgz#7ad0f593f2281598e854df80f19aae4b92d7a11a"
+  dependencies:
+    atob "^2.0.0"
+    decode-uri-component "^0.2.0"
+    resolve-url "^0.2.1"
+    source-map-url "^0.4.0"
+    urix "^0.1.0"
+
 source-map-support@^0.4.15, source-map-support@^0.4.6:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
@@ -8991,6 +9468,10 @@ source-map-support@^0.5.0:
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.3.tgz#2b3d5fff298cfa4d1afd7d4352d569e9a0158e76"
   dependencies:
     source-map "^0.6.0"
+
+source-map-url@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
 source-map@0.5.6, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.6"
@@ -9040,6 +9521,12 @@ spdx-license-ids@^1.0.2, spdx-license-ids@~1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
+split-string@^3.0.1, split-string@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
+  dependencies:
+    extend-shallow "^3.0.0"
+
 split2@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/split2/-/split2-2.1.1.tgz#7a1f551e176a90ecd3345f7246a0cfe175ef4fd0"
@@ -9083,6 +9570,13 @@ stackframe@^0.3.1:
 static-eval@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-0.1.1.tgz#2f3c9e727604a61ac761b9663562a76c61f5c523"
+
+static-extend@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
+  dependencies:
+    define-property "^0.2.5"
+    object-copy "^0.1.0"
 
 statuses@1, statuses@~1.3.1:
   version "1.3.1"
@@ -9366,12 +9860,12 @@ term-size@^1.2.0:
   dependencies:
     execa "^0.7.0"
 
-test-exclude@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.1.1.tgz#4d84964b0966b0087ecc334a2ce002d3d9341e26"
+test-exclude@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.1.tgz#dfa222f03480bca69207ca728b37d74b45f724fa"
   dependencies:
     arrify "^1.0.1"
-    micromatch "^2.3.11"
+    micromatch "^3.1.8"
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
@@ -9470,9 +9964,37 @@ to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
-tough-cookie@^2.2.0, tough-cookie@^2.3.2, tough-cookie@~2.3.0, tough-cookie@~2.3.2:
+to-object-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+  dependencies:
+    kind-of "^3.0.2"
+
+to-regex-range@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
+  dependencies:
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+
+to-regex@^3.0.1, to-regex@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
+  dependencies:
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    regex-not "^1.0.2"
+    safe-regex "^1.1.0"
+
+tough-cookie@^2.2.0, tough-cookie@~2.3.0, tough-cookie@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
+  dependencies:
+    punycode "^1.4.1"
+
+tough-cookie@^2.3.2, tough-cookie@~2.3.3:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
   dependencies:
     punycode "^1.4.1"
 
@@ -9483,6 +10005,10 @@ tough-cookie@~2.2.0:
 tr46@~0.0.1, tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+
+traverse@0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
 
 "traverse@>=0.3.0 <0.4":
   version "0.3.9"
@@ -9580,6 +10106,15 @@ underscore@^1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
+union-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
+  dependencies:
+    arr-union "^3.1.0"
+    get-value "^2.0.6"
+    is-extendable "^0.1.1"
+    set-value "^0.4.3"
+
 uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
@@ -9620,6 +10155,13 @@ unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 
+unset-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
+  dependencies:
+    has-value "^0.3.1"
+    isobject "^3.0.0"
+
 unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
@@ -9652,6 +10194,10 @@ urijs@1.18.0:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.18.0.tgz#091cbb7f6d60401b2e5e35c57a04177b9bbd12f2"
 
+urix@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+
 url-parse-lax@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
@@ -9668,6 +10214,12 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/use/-/use-3.1.0.tgz#14716bf03fdfefd03040aef58d8b4b85f3a7c544"
+  dependencies:
+    kind-of "^6.0.2"
 
 user-home@2.0.0:
   version "2.0.0"
@@ -9815,8 +10367,8 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
 
 webidl-conversions@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.1.tgz#8015a17ab83e7e1b311638486ace81da6ce206a0"
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
 webpack-dev-middleware@^1.11.0:
   version "1.12.2"
@@ -9928,7 +10480,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@1, which@^1.2.14, which@^1.2.8:
+which@1, which@^1.2.14, which@^1.2.8, which@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:
@@ -9983,11 +10535,10 @@ wordwrap@~1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
 worker-farm@^1.3.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.4.1.tgz#a438bc993a7a7d133bcb6547c95eca7cff4897d8"
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.6.0.tgz#aecc405976fab5a95526180846f0dba288f3a4a0"
   dependencies:
-    errno "^0.1.4"
-    xtend "^4.0.1"
+    errno "~0.1.7"
 
 worker-farm@~1.3.1:
   version "1.3.1"
@@ -10067,7 +10618,7 @@ xmlhttprequest@~1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.7.0.tgz#dc697a8df0258afacad526c1c296b1bdd12c4ab3"
 
-"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
Add snapshot tests for Webpack config. This does not include config options which produce side effects and will be removed.

Changed default test runner options. Existing options were only useful for CI, and had negative effects on local development (including continually updating snapshot tests).