### PR TITLE
Add back Jest as a dependency of Gluestick.

### DIFF
--- a/packages/gluestick/package.json
+++ b/packages/gluestick/package.json
@@ -91,6 +91,7 @@
     "http-proxy-middleware": "0.17.4",
     "ignore-loader": "0.1.2",
     "inquirer": "3.2.0",
+    "jest": "20.0.4",
     "lru-cache": "4.1.1",
     "mkdirp": "0.5.1",
     "node-fetch": "^1.7.1",
@@ -116,5 +117,16 @@
     "webpack-dev-middleware": "^1.11.0",
     "webpack-hot-middleware": "^2.18.2",
     "webpack-node-externals": "1.7.2"
+  },
+  "jest": {
+    "roots": [
+      "src"
+    ],
+    "setupFiles": [
+      "./jest.js"
+    ],
+    "transformIgnorePatterns": [
+      "node_modules/(?!gluestick*)"
+    ]
   }
 }


### PR DESCRIPTION
Projects using Gluestick implicitly have access to jest through it. Removing this causes `gluestick test` to fail.