### PR TITLE
Fix CSS bundle size increase.

### DIFF
--- a/packages/gluestick/src/config/__tests__/__snapshots__/compileWebpackConfig.test.js.snap
+++ b/packages/gluestick/src/config/__tests__/__snapshots__/compileWebpackConfig.test.js.snap
@@ -39,10 +39,6 @@ Object {
           "style-loader",
           Object {
             "loader": "css-loader",
-            "options": Object {
-              "minimize": false,
-              "sourceMap": false,
-            },
           },
           Object {
             "loader": "postcss-loader",
@@ -51,8 +47,6 @@ Object {
             "loader": "sass-loader",
             "options": Object {
               "outputStyle": "expanded",
-              "sourceMap": false,
-              "sourceMapContents": true,
             },
           },
         ],
@@ -164,10 +158,6 @@ Object {
                 "style-loader",
                 Object {
                   "loader": "css-loader",
-                  "options": Object {
-                    "minimize": false,
-                    "sourceMap": false,
-                  },
                 },
                 Object {
                   "loader": "postcss-loader",
@@ -176,8 +166,6 @@ Object {
                   "loader": "sass-loader",
                   "options": Object {
                     "outputStyle": "expanded",
-                    "sourceMap": false,
-                    "sourceMapContents": true,
                   },
                 },
               ],
@@ -485,10 +473,6 @@ Object {
           },
           Object {
             "loader": "css-loader",
-            "options": Object {
-              "minimize": false,
-              "sourceMap": false,
-            },
           },
           Object {
             "loader": "postcss-loader",
@@ -497,8 +481,6 @@ Object {
             "loader": "sass-loader",
             "options": Object {
               "outputStyle": "expanded",
-              "sourceMap": false,
-              "sourceMapContents": true,
             },
           },
         ],
@@ -613,10 +595,6 @@ Object {
                 "style-loader",
                 Object {
                   "loader": "css-loader",
-                  "options": Object {
-                    "minimize": false,
-                    "sourceMap": false,
-                  },
                 },
                 Object {
                   "loader": "postcss-loader",
@@ -625,8 +603,6 @@ Object {
                   "loader": "sass-loader",
                   "options": Object {
                     "outputStyle": "expanded",
-                    "sourceMap": false,
-                    "sourceMapContents": true,
                   },
                 },
               ],

--- a/packages/gluestick/src/config/webpack/webpack.config.client.js
+++ b/packages/gluestick/src/config/webpack/webpack.config.client.js
@@ -12,8 +12,6 @@ const progressHandler = require('./progressHandler');
 const ChunksPlugin = require('./ChunksPlugin');
 const getAliasesForApps = require('./getAliasesForApps');
 
-const isProduction: boolean = process.env.NODE_ENV === 'production';
-
 module.exports = (
   logger: Logger,
   settings: Object,

--- a/packages/gluestick/src/config/webpack/webpack.config.client.js
+++ b/packages/gluestick/src/config/webpack/webpack.config.client.js
@@ -94,10 +94,6 @@ module.exports = (
             'style-loader',
             {
               loader: `css-loader`,
-              options: {
-                sourceMap: !!isProduction,
-                minimize: !!isProduction,
-              },
             },
             {
               loader: 'postcss-loader',
@@ -106,8 +102,6 @@ module.exports = (
               loader: 'sass-loader',
               options: {
                 outputStyle: 'expanded',
-                sourceMap: !!isProduction,
-                sourceMapContents: true,
               },
             },
           ],


### PR DESCRIPTION
This fixes a performance regression where duplicate CSS ended up in the final output. It does so by compressing only the final output, instead of compressing on both css-loader and optimizeCssPlugin.

Disable CSS sourcemaps in develop. This improves incremental build times, and is currently not getting enough use to justify itself.