### PR TITLE
Prevent images from being inlined into bundle.

### DIFF
--- a/packages/gluestick/src/config/__tests__/__snapshots__/compileWebpackConfig.test.js.snap
+++ b/packages/gluestick/src/config/__tests__/__snapshots__/compileWebpackConfig.test.js.snap
@@ -489,13 +489,6 @@ Object {
         "test": /\\\\\\.\\(png\\|jpg\\|gif\\|ico\\|svg\\)\\(\\\\\\?v=\\\\d\\+\\\\\\.\\\\d\\+\\\\\\.\\\\d\\+\\)\\?\\$/,
         "use": Array [
           Object {
-            "loader": "/project/packages/gluestick/node_modules/extract-text-webpack-plugin/loader.js",
-            "options": Object {
-              "omit": 1,
-              "remove": true,
-            },
-          },
-          Object {
             "loader": "file-loader",
             "options": Object {
               "name": "[name]-[hash].[ext]",

--- a/packages/gluestick/src/config/webpack/webpack.config.client.prod.js
+++ b/packages/gluestick/src/config/webpack/webpack.config.client.prod.js
@@ -10,13 +10,8 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 module.exports = (clientConfig: WebpackConfig): WebpackConfig => {
   const config: Object = clone(clientConfig);
   config.devtool = 'hidden-source-map';
-  const scssLoaders = config.module.rules[1].use;
+  const cssLoaders = config.module.rules[1].use;
   config.module.rules[1].use = ExtractTextPlugin.extract({
-    fallback: scssLoaders[0],
-    use: scssLoaders.slice(1),
-  });
-  const cssLoaders = config.module.rules[2].use;
-  config.module.rules[2].use = ExtractTextPlugin.extract({
     fallback: cssLoaders[0],
     use: cssLoaders.slice(1),
   });


### PR DESCRIPTION
ExtractTextWebpackPlugin was mistakenly applied to the "CSS loader" which no longer exists... which means it was applied to the image loader. This caused some images to be inlined into the bundle without any warning/error.