### PR TITLE
Allow custom status code through location.state.

### DIFF
--- a/packages/gluestick/src/renderer/middleware.js
+++ b/packages/gluestick/src/renderer/middleware.js
@@ -124,8 +124,10 @@ const middleware: Middleware = async (req, res, { assets }) => {
     );
     if (redirectLocation) {
       callHook(hooks.preRedirect, redirectLocation);
+      const status =
+        (redirectLocation.state && redirectLocation.state.status) || 301;
       res.redirect(
-        301,
+        status,
         `${redirectLocation.pathname}${redirectLocation.search}`,
       );
       return;


### PR DESCRIPTION
This allows 302 redirects (or other status codes) if `location.state.status` exists.