### PR TITLE
Add autoprefixer as a dependency

### DIFF
--- a/packages/gluestick/package.json
+++ b/packages/gluestick/package.json
@@ -7,8 +7,7 @@
   "homepage": "https://github.com/TrueCar/gluestick",
   "bugs": "https://github.com/TrueCar/gluestick/issues",
   "license": "MIT",
-  "scripts": {
-  },
+  "scripts": {},
   "keywords": [
     "react",
     "redux",
@@ -70,6 +69,7 @@
     "redux-thunk": "^2.2.0"
   },
   "dependencies": {
+    "autoprefixer": "^6.7.7",
     "axios": "0.15.3",
     "babel-core": "^6.24.1",
     "chalk": "2.3.2",


### PR DESCRIPTION
# What
Adds autoprefixer as a dependency so that apps that use postcss.config.js do not have to include it as a dependency of their project (it will be a transitive dependency from gluestick)