### PR TITLE
Lock down autoprefixer to 6.7.7

### DIFF
--- a/packages/gluestick/package.json
+++ b/packages/gluestick/package.json
@@ -68,7 +68,7 @@
     "redux-thunk": "^2.2.0"
   },
   "dependencies": {
-    "autoprefixer": "^6.7.7",
+    "autoprefixer": "6.7.7",
     "axios": "0.15.3",
     "babel-core": "^6.24.1",
     "chalk": "2.3.2",


### PR DESCRIPTION
We should lock down dependencies to reduce risk.