### PR TITLE
Update generated .flowconfig file

### DIFF
--- a/packages/gluestick/src/generator/templates/_flowconfig.js
+++ b/packages/gluestick/src/generator/templates/_flowconfig.js
@@ -4,10 +4,10 @@ import type { CreateTemplate } from '../../types';
 
 module.exports = (createTemplate: CreateTemplate) => createTemplate`
 [ignore]
-# fbjs lib problems
-.*/node_modules/fbjs/.*
-# radium lib problems
-.*/node_modules/radium/.*
+# ignore problematic dependencies
+.*/node_modules/config-chain/.*
+.*/node_modules/**/chalk/.*
+.*/node_modules/**/radium/.*
 
 [include]
 


### PR DESCRIPTION
Newly-generated gluestick apps currently fail some flow checks around dependencies. This PR updates the `[ignore]` section of the generated .flowconfig file to the minimal set of ignores needed to make flow happy.

This is also needed to get CI e2e builds for `develop` to start passing again (this started failing months ago):
https://circleci.com/gh/TrueCar/gluestick/4312
https://circleci.com/gh/TrueCar/gluestick/4299
https://circleci.com/gh/TrueCar/gluestick/4288
https://circleci.com/gh/TrueCar/gluestick/4063

Note: fbjs seemed to no longer be an issue when running e2e tests locally.

Flow errors currently breaking CI:

```node_modules/config-chain/test/broken.json:11
 11:   "dependencies": {
       ^^^^^^^^^^^^^^ Unexpected string

  1 [ignore]
node_modules/flow-typed/node_modules/chalk/index.js.flow:5
  5: export type Level = $Values<{
                         ^ identifier `$Values`. Could not resolve name

node_modules/inquirer/node_modules/chalk/index.js.flow:5
  5: export type Level = $Values<{
                         ^ identifier `$Values`. Could not resolve name

node_modules/postcss-modules-extract-imports/node_modules/chalk/index.js.flow:5
  5: export type Level = $Values<{
                         ^ identifier `$Values`. Could not resolve name

node_modules/postcss-modules-local-by-default/node_modules/chalk/index.js.flow:5
  5: export type Level = $Values<{
                         ^ identifier `$Values`. Could not resolve name

node_modules/postcss-modules-scope/node_modules/chalk/index.js.flow:5
  5: export type Level = $Values<{
                         ^ identifier `$Values`. Could not resolve name

node_modules/postcss-modules-values/node_modules/chalk/index.js.flow:5
  5: export type Level = $Values<{
                         ^ identifier `$Values`. Could not resolve name


Found 7 errors
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! test-gs-app@1.0.0 flow: `flow`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the test-gs-app@1.0.0 flow script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.```

