### PR TITLE
update enzyme-react-adapter to 1.5.0

### DIFF
--- a/packages/gluestick-generators/src/templates/package.js
+++ b/packages/gluestick-generators/src/templates/package.js
@@ -65,7 +65,7 @@ const templatePackage = createTemplate`
     "babel-jest": "18.0.0",
     "babel-plugin-react-transform": "2.0.2",
     "enzyme": "3.3.0",
-    "enzyme-adapter-react-16": "1.1.1",
+    "enzyme-adapter-react-16": "1.5.1",
     "eslint": "3.14.1",
     "eslint-plugin-react": "6.9.0",
     "flow-bin": "0.45.0",


### PR DESCRIPTION
This supports shallow rendering and `.find` of `React.Fragment`.  See https://github.com/airbnb/enzyme/pull/1498