### PR TITLE
Fix enzyme-react-adapter dependency version

### DIFF
--- a/packages/gluestick-generators/src/templates/package.js
+++ b/packages/gluestick-generators/src/templates/package.js
@@ -65,7 +65,7 @@ const templatePackage = createTemplate`
     "babel-jest": "18.0.0",
     "babel-plugin-react-transform": "2.0.2",
     "enzyme": "3.3.0",
-    "enzyme-adapter-react-16": "1.5.1",
+    "enzyme-adapter-react-16": "1.5.0",
     "eslint": "3.14.1",
     "eslint-plugin-react": "6.9.0",
     "flow-bin": "0.45.0",


### PR DESCRIPTION
Fixes version in #1210. Really use 1.5.0 this time 😄 