### PR TITLE
Use contenthash for much more granular hashing

### DIFF
--- a/packages/gluestick/package.json
+++ b/packages/gluestick/package.json
@@ -112,20 +112,14 @@
     "shelljs": "^0.7.8",
     "sorted-object": "2.0.1",
     "source-map-support": "^0.5.0",
-    "webpack": "^3.6.0",
+    "webpack": "^3.12.0",
     "webpack-dev-middleware": "^1.11.0",
     "webpack-hot-middleware": "^2.18.2",
     "webpack-node-externals": "1.7.2"
   },
   "jest": {
-    "roots": [
-      "src"
-    ],
-    "setupFiles": [
-      "./jest.js"
-    ],
-    "transformIgnorePatterns": [
-      "node_modules/(?!gluestick*)"
-    ]
+    "roots": ["src"],
+    "setupFiles": ["./jest.js"],
+    "transformIgnorePatterns": ["node_modules/(?!gluestick*)"]
   }
 }

--- a/packages/gluestick/src/config/__tests__/__snapshots__/compileWebpackConfig.test.js.snap
+++ b/packages/gluestick/src/config/__tests__/__snapshots__/compileWebpackConfig.test.js.snap
@@ -57,7 +57,7 @@ Object {
           Object {
             "loader": "file-loader",
             "options": Object {
-              "name": "[name]-[hash].[ext]",
+              "name": "[name]-[contenthash].[ext]",
             },
           },
           Object {
@@ -72,7 +72,7 @@ Object {
           Object {
             "loader": "file-loader",
             "options": Object {
-              "name": "[name]-[hash].[ext]",
+              "name": "[name]-[contenthash].[ext]",
             },
           },
         ],
@@ -83,9 +83,9 @@ Object {
     "net": "empty",
   },
   "output": Object {
-    "chunkFilename": "[name].[hash].js",
+    "chunkFilename": "[name].[contenthash].js",
     "crossOriginLoading": "anonymous",
-    "filename": "[name].[hash].js",
+    "filename": "[name].[contenthash].js",
     "path": "/project/build/assets",
     "publicPath": "http://0.0.0.0:8888/assets/",
   },
@@ -176,7 +176,7 @@ Object {
                 Object {
                   "loader": "file-loader",
                   "options": Object {
-                    "name": "[name]-[hash].[ext]",
+                    "name": "[name]-[contenthash].[ext]",
                   },
                 },
                 Object {
@@ -191,7 +191,7 @@ Object {
                 Object {
                   "loader": "file-loader",
                   "options": Object {
-                    "name": "[name]-[hash].[ext]",
+                    "name": "[name]-[contenthash].[ext]",
                   },
                 },
               ],
@@ -202,8 +202,8 @@ Object {
           "net": "empty",
         },
         "output": Object {
-          "chunkFilename": "[name].[hash].js",
-          "filename": "[name].[hash].js",
+          "chunkFilename": "[name].[contenthash].js",
+          "filename": "[name].[contenthash].js",
           "path": "/project/build/assets",
           "publicPath": "/assets/",
         },
@@ -338,7 +338,7 @@ Object {
             "loader": "file-loader",
             "options": Object {
               "emitFile": false,
-              "name": "[name]-[hash].[ext]",
+              "name": "[name]-[contenthash].[ext]",
             },
           },
           Object {
@@ -354,7 +354,7 @@ Object {
             "loader": "file-loader",
             "options": Object {
               "emitFile": false,
-              "name": "[name]-[hash].[ext]",
+              "name": "[name]-[contenthash].[ext]",
             },
           },
         ],
@@ -491,7 +491,7 @@ Object {
           Object {
             "loader": "file-loader",
             "options": Object {
-              "name": "[name]-[hash].[ext]",
+              "name": "[name]-[contenthash].[ext]",
             },
           },
           Object {
@@ -506,7 +506,7 @@ Object {
           Object {
             "loader": "file-loader",
             "options": Object {
-              "name": "[name]-[hash].[ext]",
+              "name": "[name]-[contenthash].[ext]",
             },
           },
         ],
@@ -517,8 +517,8 @@ Object {
     "net": "empty",
   },
   "output": Object {
-    "chunkFilename": "[name].[hash].js",
-    "filename": "[name].[hash].js",
+    "chunkFilename": "[name].[contenthash].js",
+    "filename": "[name].[contenthash].js",
     "path": "/project/build/assets",
     "publicPath": "/assets/",
   },
@@ -545,7 +545,7 @@ Object {
         "vendor",
       ],
       "deepChildren": undefined,
-      "filenameTemplate": "vendor-[hash].bundle.js",
+      "filenameTemplate": "vendor-[contenthash].bundle.js",
       "ident": "/project/packages/gluestick/node_modules/webpack/lib/optimize/CommonsChunkPlugin.js2",
       "minChunks": undefined,
       "minSize": undefined,
@@ -606,7 +606,7 @@ Object {
                 Object {
                   "loader": "file-loader",
                   "options": Object {
-                    "name": "[name]-[hash].[ext]",
+                    "name": "[name]-[contenthash].[ext]",
                   },
                 },
                 Object {
@@ -621,7 +621,7 @@ Object {
                 Object {
                   "loader": "file-loader",
                   "options": Object {
-                    "name": "[name]-[hash].[ext]",
+                    "name": "[name]-[contenthash].[ext]",
                   },
                 },
               ],
@@ -632,8 +632,8 @@ Object {
           "net": "empty",
         },
         "output": Object {
-          "chunkFilename": "[name].[hash].js",
-          "filename": "[name].[hash].js",
+          "chunkFilename": "[name].[contenthash].js",
+          "filename": "[name].[contenthash].js",
           "path": "/project/build/assets",
           "publicPath": "/assets/",
         },
@@ -660,7 +660,7 @@ Object {
               "vendor",
             ],
             "deepChildren": undefined,
-            "filenameTemplate": "vendor-[hash].bundle.js",
+            "filenameTemplate": "vendor-[contenthash].bundle.js",
             "ident": "/project/packages/gluestick/node_modules/webpack/lib/optimize/CommonsChunkPlugin.js2",
             "minChunks": undefined,
             "minSize": undefined,
@@ -785,7 +785,7 @@ Object {
             "loader": "file-loader",
             "options": Object {
               "emitFile": false,
-              "name": "[name]-[hash].[ext]",
+              "name": "[name]-[contenthash].[ext]",
             },
           },
           Object {
@@ -801,7 +801,7 @@ Object {
             "loader": "file-loader",
             "options": Object {
               "emitFile": false,
-              "name": "[name]-[hash].[ext]",
+              "name": "[name]-[contenthash].[ext]",
             },
           },
         ],

--- a/packages/gluestick/src/config/vendorDll.js
+++ b/packages/gluestick/src/config/vendorDll.js
@@ -182,8 +182,8 @@ const getConfig = (
     },
     output: {
       path: buildDllPath,
-      filename: '[name]-[hash].dll.js',
-      library: '[name]_[hash]', // or libraryTarget
+      filename: '[name]-[contenthash].dll.js',
+      library: '[name]_[contenthash]', // or libraryTarget
     },
     plugins: [
       new webpack.DefinePlugin({
@@ -195,7 +195,7 @@ const getConfig = (
           buildDllPath,
           manifestFilename.replace('vendor', '[name]'),
         ),
-        name: '[name]_[hash]',
+        name: '[name]_[contenthash]',
       }),
     ].concat(noProgress ? [] : [progressHandler(logger, 'vendor')]),
     bail: true,

--- a/packages/gluestick/src/config/webpack/webpack.config.client.js
+++ b/packages/gluestick/src/config/webpack/webpack.config.client.js
@@ -65,8 +65,8 @@ module.exports = (
     output: {
       path: outputPath, // filesystem path for static files
       publicPath: `/${publicPath}/`.replace(/\/\//g, '/'), // network path for static files
-      filename: '[name].[hash].js', // file name pattern for entry scripts
-      chunkFilename: '[name].[hash].js', // file name pattern for chunk scripts
+      filename: '[name].[contenthash].js', // file name pattern for entry scripts
+      chunkFilename: '[name].[contenthash].js', // file name pattern for chunk scripts
     },
     module: {
       rules: [
@@ -110,7 +110,7 @@ module.exports = (
             {
               loader: 'file-loader',
               options: {
-                name: '[name]-[hash].[ext]',
+                name: '[name]-[contenthash].[ext]',
               },
             },
             {
@@ -126,7 +126,7 @@ module.exports = (
             {
               loader: 'file-loader',
               options: {
-                name: '[name]-[hash].[ext]',
+                name: '[name]-[contenthash].[ext]',
               },
             },
           ],
@@ -144,7 +144,7 @@ module.exports = (
       new webpack.optimize.CommonsChunkPlugin({
         name: 'vendor',
         filename: `vendor${process.env.NODE_ENV === 'production'
-          ? '-[hash]'
+          ? '-[contenthash]'
           : ''}.bundle.js`,
       }),
     ].filter(Boolean),

--- a/packages/gluestick/src/config/webpack/webpack.config.client.js
+++ b/packages/gluestick/src/config/webpack/webpack.config.client.js
@@ -65,8 +65,8 @@ module.exports = (
     output: {
       path: outputPath, // filesystem path for static files
       publicPath: `/${publicPath}/`.replace(/\/\//g, '/'), // network path for static files
-      filename: '[name].[contenthash].js', // file name pattern for entry scripts
-      chunkFilename: '[name].[contenthash].js', // file name pattern for chunk scripts
+      filename: '[name].[chunkhash].js', // file name pattern for entry scripts
+      chunkFilename: '[name].[chunkhash].js', // file name pattern for chunk scripts
     },
     module: {
       rules: [
@@ -110,7 +110,7 @@ module.exports = (
             {
               loader: 'file-loader',
               options: {
-                name: '[name]-[contenthash].[ext]',
+                name: '[name]-[hash].[ext]',
               },
             },
             {
@@ -126,7 +126,7 @@ module.exports = (
             {
               loader: 'file-loader',
               options: {
-                name: '[name]-[contenthash].[ext]',
+                name: '[name]-[hash].[ext]',
               },
             },
           ],
@@ -144,7 +144,7 @@ module.exports = (
       new webpack.optimize.CommonsChunkPlugin({
         name: 'vendor',
         filename: `vendor${process.env.NODE_ENV === 'production'
-          ? '-[contenthash]'
+          ? '-[chunkhash]'
           : ''}.bundle.js`,
       }),
     ].filter(Boolean),

--- a/packages/gluestick/src/config/webpack/webpack.config.server.js
+++ b/packages/gluestick/src/config/webpack/webpack.config.server.js
@@ -122,7 +122,7 @@ module.exports = (
             {
               loader: 'file-loader',
               options: {
-                name: '[name]-[hash].[ext]',
+                name: '[name]-[contenthash].[ext]',
                 emitFile: false,
               },
             },
@@ -139,7 +139,7 @@ module.exports = (
             {
               loader: 'file-loader',
               options: {
-                name: '[name]-[hash].[ext]',
+                name: '[name]-[contenthash].[ext]',
                 emitFile: false,
               },
             },

--- a/packages/gluestick/src/config/webpack/webpack.config.server.js
+++ b/packages/gluestick/src/config/webpack/webpack.config.server.js
@@ -122,7 +122,7 @@ module.exports = (
             {
               loader: 'file-loader',
               options: {
-                name: '[name]-[contenthash].[ext]',
+                name: '[name]-[hash].[ext]',
                 emitFile: false,
               },
             },
@@ -139,7 +139,7 @@ module.exports = (
             {
               loader: 'file-loader',
               options: {
-                name: '[name]-[contenthash].[ext]',
+                name: '[name]-[hash].[ext]',
                 emitFile: false,
               },
             },


### PR DESCRIPTION
Currently [hash] is used everywhere which generates a new hash for all files on every build, causing reuploads for everything.

[contenthash] generates a hash based on individual file contents.