### PR TITLE
Remove obsolete package and docs

### DIFF
--- a/docs/configuration/CachingAndHooks.md
+++ b/docs/configuration/CachingAndHooks.md
@@ -16,28 +16,6 @@ Example:
 *Additional optional cache properties:*
 `cacheTTL` - number of seconds to store the cache for a particular route
 
-Gluestick allows SSR component caching by using [`electrode-react-ssr-caching`](https://github.com/electrode-io/electrode-react-ssr-caching).
-For using it you need to determine `cacheConfig` in `src/config/caching.server.js`
-
-Example:
-```javascript
-export default {
-  components: {
-    "Component1": {
-        strategy: "simple",
-        enable: true
-    },
-    "Component2": {
-        strategy: "template",
-        enable: true
-    },
-  },
-};
-```
-
-[`Here`](https://github.com/electrode-io/electrode-react-ssr-caching) you can find more information about `cacheConfig`.
-
-
 ## Hooks
 Gluestick also provide hooks which can be defined in `src/gluestick.hooks.js`.
 You can use single hook or array of hooks like in example below. Usually you have to return modified value at the end of hook.

--- a/packages/gluestick/package.json
+++ b/packages/gluestick/package.json
@@ -80,7 +80,6 @@
     "compression": "1.7.0",
     "cross-spawn": "^5.1.0",
     "duplicate-package-checker-webpack-plugin": "^1.2.5",
-    "electrode-react-ssr-caching": "^0.1.5",
     "enzyme": "2.9.1",
     "eventsource-polyfill": "0.9.6",
     "express": "4.15.3",


### PR DESCRIPTION
We removed electrode SSR caching support in #1135 but didn't fully remove the package and documentation for it. This PR cleans up remaining references.