### PR TITLE
Add custom cache key strategy support

### DIFF
--- a/packages/gluestick/src/__tests__/mocks/context.js
+++ b/packages/gluestick/src/__tests__/mocks/context.js
@@ -96,6 +96,7 @@ const request: Request = {
   url: '/',
   headers: { 'user-agent': '' },
   method: 'GET',
+  query: {},
 };
 
 const entriesConfig: EntriesConfig = {

--- a/packages/gluestick/src/renderer/__tests__/render.test.js
+++ b/packages/gluestick/src/renderer/__tests__/render.test.js
@@ -82,6 +82,7 @@ describe('renderer/render', () => {
     url: '',
     hostname: '',
     method: 'GET',
+    query: {},
   };
 
   const store = {

--- a/packages/gluestick/src/renderer/helpers/__tests__/cacheManager.test.js
+++ b/packages/gluestick/src/renderer/helpers/__tests__/cacheManager.test.js
@@ -46,9 +46,19 @@ describe('renderer/helpers/cacheManager', () => {
       true,
     );
     const cache = {
-      get: jest.fn(key => (key === 'localhost/' ? 'output' : null)),
+      get: jest.fn(key => {
+        if (key === 'localhost/') {
+          return 'output';
+        } else if (key === 'localhost-/test-123') {
+          return 'cache';
+        } else if (key === 'localhost-/test-124') {
+          return 'cache2';
+        }
+        return null;
+      }),
       set: jest.fn(),
     };
+
     it('should return cached output', () => {
       expect(
         cacheManager.getCachedIfProd(
@@ -76,6 +86,87 @@ describe('renderer/helpers/cacheManager', () => {
         'cache',
         1000000,
       ]);
+    });
+
+    describe('when a custom cache key strategy is defined', () => {
+      beforeAll(() => {
+        cache.set.mockClear();
+        cacheManager.setCacheIfProd(
+          {
+            hostname: 'localhost',
+            url: '/test',
+            query: {
+              styleId: '123',
+              unused: 'hello',
+            },
+          },
+          'cache',
+          1000,
+          cache,
+          ({ hostname, url, query }) => `${hostname}-${url}-${query.styleId}`,
+        );
+        cacheManager.setCacheIfProd(
+          {
+            hostname: 'localhost',
+            url: '/test',
+            query: {
+              styleId: '124',
+              unused: 'hello',
+            },
+          },
+          'cache',
+          1000,
+          cache,
+          ({ hostname, url, query }) => `${hostname}-${url}-${query.styleId}`,
+        );
+      });
+
+      it('should set cache using the custom cache key', () => {
+        expect(cache.set.mock.calls[0]).toEqual([
+          'localhost-/test-123',
+          'cache',
+          1000000,
+        ]);
+      });
+
+      it('should return cached output', () => {
+        const cached1 = cacheManager.getCachedIfProd(
+          {
+            hostname: 'localhost',
+            url: '/test',
+            query: {
+              styleId: '123',
+              unused: 'hello',
+            },
+          },
+          cache,
+        );
+        const cached2 = cacheManager.getCachedIfProd(
+          {
+            hostname: 'localhost',
+            url: '/test',
+            query: {
+              styleId: '123',
+              unused: 'blah',
+            },
+          },
+          cache,
+        );
+        const cached3 = cacheManager.getCachedIfProd(
+          {
+            hostname: 'localhost',
+            url: '/test',
+            query: {
+              styleId: '124',
+              unused: 'hello',
+            },
+          },
+          cache,
+        );
+        expect(cached1).toEqual('cache');
+        expect(cached2).toEqual('cache');
+        expect(cached3).toEqual('cache2');
+      });
     });
   });
 });

--- a/packages/gluestick/src/renderer/helpers/__tests__/cacheManager.test.js
+++ b/packages/gluestick/src/renderer/helpers/__tests__/cacheManager.test.js
@@ -119,6 +119,28 @@ describe('renderer/helpers/cacheManager', () => {
           cache,
           ({ hostname, url, query }) => `${hostname}-${url}-${query.styleId}`,
         );
+
+        const currentState = { currentUser: { loaded: true } };
+        cacheManager.setCacheIfProd(
+          {
+            hostname: 'localhost',
+            url: '/login',
+            query: {
+              styleId: '124',
+              unused: 'hello',
+            },
+          },
+          'cache',
+          1000,
+          cache,
+          ({ hostname, url }, state) => {
+            if (state.currentUser.loaded) {
+              return null;
+            }
+            return `${hostname}-${url}`;
+          },
+          currentState,
+        );
       });
 
       it('should set cache using the custom cache key', () => {
@@ -166,6 +188,12 @@ describe('renderer/helpers/cacheManager', () => {
         expect(cached1).toEqual('cache');
         expect(cached2).toEqual('cache');
         expect(cached3).toEqual('cache2');
+      });
+
+      describe('when a falsy value is returned from the custom cache key', () => {
+        it('should not set the cache', () => {
+          expect(cache.set.mock.calls[2]).toBeUndefined();
+        });
       });
     });
   });

--- a/packages/gluestick/src/renderer/helpers/cacheManager.js
+++ b/packages/gluestick/src/renderer/helpers/cacheManager.js
@@ -55,16 +55,20 @@ module.exports = function createCacheManager(
     maxAge = DEFAULT_TTL,
     cache = _cache,
     cacheKeyStrategy,
+    state,
   ) => {
     if (isProduction) {
       const defaultKey: string = getCacheKey(req);
       let key = defaultKey;
       if (cacheKeyStrategy) {
-        key = cacheKeyStrategy(req);
+        key = cacheKeyStrategy(req, state);
         customCacheKeyStrategies[defaultKey] = cacheKeyStrategy;
       }
-      cache.set(key, value, maxAge * 1000);
-      logger.debug(`Set cache: ${key}`);
+
+      if (key) {
+        cache.set(key, value, maxAge * 1000);
+        logger.debug(`Set cache: ${key}`);
+      }
     }
   };
   return {

--- a/packages/gluestick/src/renderer/helpers/cacheManager.js
+++ b/packages/gluestick/src/renderer/helpers/cacheManager.js
@@ -27,11 +27,11 @@ const getCacheKey = ({
   return `${hostname}${url}`;
 };
 
+const customCacheKeyStrategies = {};
 module.exports = function createCacheManager(
   logger: BaseLogger,
   isProduction: boolean,
 ): CacheManager {
-  const customCacheKeyStrategies = {};
 
   const getCachedIfProd: GetCachedIfProd = (req, cache = _cache) => {
     if (isProduction) {

--- a/packages/gluestick/src/renderer/helpers/cacheManager.js
+++ b/packages/gluestick/src/renderer/helpers/cacheManager.js
@@ -4,32 +4,32 @@ import type {
   BaseLogger,
   CacheManager,
   GetCachedIfProd,
-  SetCacheIfProd
-} from "../../types";
+  SetCacheIfProd,
+} from '../../types';
 
-const LRU = require("lru-cache");
+const LRU = require('lru-cache');
 
 // Creating cache
 const DEFAULT_TTL: number = 60 * 60;
 const lruOptions: { maxAge: number, max: number } = {
   maxAge: DEFAULT_TTL * 1000,
-  max: 50
+  max: 50,
 };
 const _cache: Object = LRU(lruOptions);
 
 const getCacheKey = ({
   hostname,
-  url
+  url,
 }: {
   hostname: string,
-  url: string
+  url: string,
 }): string => {
   return `${hostname}${url}`;
 };
 
 module.exports = function createCacheManager(
   logger: BaseLogger,
-  isProduction: boolean
+  isProduction: boolean,
 ): CacheManager {
   const customCacheKeyStrategies = {};
 
@@ -54,7 +54,7 @@ module.exports = function createCacheManager(
     value,
     maxAge = DEFAULT_TTL,
     cache = _cache,
-    cacheKeyStrategy
+    cacheKeyStrategy,
   ) => {
     if (isProduction) {
       const defaultKey: string = getCacheKey(req);
@@ -69,6 +69,6 @@ module.exports = function createCacheManager(
   };
   return {
     getCachedIfProd,
-    setCacheIfProd
+    setCacheIfProd,
   };
 };

--- a/packages/gluestick/src/renderer/helpers/cacheManager.js
+++ b/packages/gluestick/src/renderer/helpers/cacheManager.js
@@ -32,7 +32,6 @@ module.exports = function createCacheManager(
   logger: BaseLogger,
   isProduction: boolean,
 ): CacheManager {
-
   const getCachedIfProd: GetCachedIfProd = (req, cache = _cache) => {
     if (isProduction) {
       const defaultKey: string = getCacheKey(req);

--- a/packages/gluestick/src/renderer/helpers/cacheManager.js
+++ b/packages/gluestick/src/renderer/helpers/cacheManager.js
@@ -4,36 +4,43 @@ import type {
   BaseLogger,
   CacheManager,
   GetCachedIfProd,
-  SetCacheIfProd,
-} from '../../types';
+  SetCacheIfProd
+} from "../../types";
 
-const LRU = require('lru-cache');
+const LRU = require("lru-cache");
 
 // Creating cache
 const DEFAULT_TTL: number = 60 * 60;
 const lruOptions: { maxAge: number, max: number } = {
   maxAge: DEFAULT_TTL * 1000,
-  max: 50,
+  max: 50
 };
 const _cache: Object = LRU(lruOptions);
 
 const getCacheKey = ({
   hostname,
-  url,
+  url
 }: {
   hostname: string,
-  url: string,
+  url: string
 }): string => {
   return `${hostname}${url}`;
 };
 
 module.exports = function createCacheManager(
   logger: BaseLogger,
-  isProduction: boolean,
+  isProduction: boolean
 ): CacheManager {
+  const customCacheKeyStrategies = {};
+
   const getCachedIfProd: GetCachedIfProd = (req, cache = _cache) => {
     if (isProduction) {
-      const key: string = getCacheKey(req);
+      const defaultKey: string = getCacheKey(req);
+      let key = defaultKey;
+      if (customCacheKeyStrategies[defaultKey]) {
+        const cacheKeyStrategy = customCacheKeyStrategies[defaultKey];
+        key = cacheKeyStrategy(req);
+      }
       const value: string = cache.get(key);
       if (value) {
         logger.debug(`Get cached: ${key}`);
@@ -47,15 +54,21 @@ module.exports = function createCacheManager(
     value,
     maxAge = DEFAULT_TTL,
     cache = _cache,
+    cacheKeyStrategy
   ) => {
     if (isProduction) {
-      const key: string = getCacheKey(req);
-      logger.debug(`Set cache: ${key}`);
+      const defaultKey: string = getCacheKey(req);
+      let key = defaultKey;
+      if (cacheKeyStrategy) {
+        key = cacheKeyStrategy(req);
+        customCacheKeyStrategies[defaultKey] = cacheKeyStrategy;
+      }
       cache.set(key, value, maxAge * 1000);
+      logger.debug(`Set cache: ${key}`);
     }
   };
   return {
     getCachedIfProd,
-    setCacheIfProd,
+    setCacheIfProd
   };
 };

--- a/packages/gluestick/src/renderer/render.js
+++ b/packages/gluestick/src/renderer/render.js
@@ -135,6 +135,7 @@ module.exports = async function render(
       currentRoute.cacheTTL,
       undefined, // Do not override the default cache
       currentRoute.cacheKey,
+      currentState,
     );
   }
   return {

--- a/packages/gluestick/src/renderer/render.js
+++ b/packages/gluestick/src/renderer/render.js
@@ -4,18 +4,18 @@ import type {
   Request,
   RenderOutput,
   RenderMethod,
-  Plugin
-} from "../types";
+  Plugin,
+} from '../types';
 
-const React = require("react");
-const { RouterContext } = require("react-router");
-const Oy = require("oy-vey").default;
-const { renderToString, renderToStaticMarkup } = require("react-dom/server");
-const linkAssets = require("./helpers/linkAssets");
+const React = require('react');
+const { RouterContext } = require('react-router');
+const Oy = require('oy-vey').default;
+const { renderToString, renderToStaticMarkup } = require('react-dom/server');
+const linkAssets = require('./helpers/linkAssets');
 
 const getRenderer = (
   isEmail: boolean,
-  renderMethod?: RenderMethod
+  renderMethod?: RenderMethod,
 ): Function => {
   if (renderMethod) {
     return renderMethod;
@@ -28,19 +28,19 @@ type EntryRequirements = {
   entryName: string,
   store: Object,
   routes: Function,
-  httpClient: Object
+  httpClient: Object,
 };
 type WrappersRequirements = {
   EntryWrapper: Object,
   BodyWrapper: Object,
   entryWrapperConfig: Object,
   envVariables: any[],
-  entriesPlugins: Plugin[]
+  entriesPlugins: Plugin[],
 };
 type AssetsCacheOpts = {
   assets: Object,
   loadjsConfig: Object,
-  cacheManager: Object
+  cacheManager: Object,
 };
 
 module.exports = async function render(
@@ -53,16 +53,16 @@ module.exports = async function render(
     BodyWrapper,
     entryWrapperConfig,
     envVariables,
-    entriesPlugins
+    entriesPlugins,
   }: WrappersRequirements,
   { assets, loadjsConfig, cacheManager }: AssetsCacheOpts,
-  { renderMethod }: { renderMethod?: RenderMethod } = {}
+  { renderMethod }: { renderMethod?: RenderMethod } = {},
 ): Promise<RenderOutput> {
   const { scriptTags, styleTags } = await linkAssets(
     context,
     entryName,
     assets,
-    loadjsConfig
+    loadjsConfig,
   );
 
   const isEmail = !!currentRoute.email;
@@ -77,7 +77,7 @@ module.exports = async function render(
       httpClient={httpClient}
       rootWrappers={rootWrappers}
       rootWrappersOptions={{
-        userAgent: req.headers["user-agent"]
+        userAgent: req.headers['user-agent'],
       }}
     />
   );
@@ -88,7 +88,7 @@ module.exports = async function render(
 
   const renderResults: Object = await getRenderer(isEmail, renderMethod)(
     entryWrapper,
-    styleTags
+    styleTags,
   );
   const bodyWrapperContent: String = renderMethod
     ? renderResults.body
@@ -117,7 +117,7 @@ module.exports = async function render(
     />
   );
 
-  const docType: string = currentRoute.docType || "<!doctype html>";
+  const docType: string = currentRoute.docType || '<!doctype html>';
 
   let responseString: string;
   if (isEmail) {
@@ -134,11 +134,11 @@ module.exports = async function render(
       responseString,
       currentRoute.cacheTTL,
       undefined, // Do not override the default cache
-      currentRoute.cacheKey
+      currentRoute.cacheKey,
     );
   }
   return {
     responseString,
-    rootElement // only for testing
+    rootElement, // only for testing
   };
 };

--- a/packages/gluestick/src/renderer/render.js
+++ b/packages/gluestick/src/renderer/render.js
@@ -4,18 +4,18 @@ import type {
   Request,
   RenderOutput,
   RenderMethod,
-  Plugin,
-} from '../types';
+  Plugin
+} from "../types";
 
-const React = require('react');
-const { RouterContext } = require('react-router');
-const Oy = require('oy-vey').default;
-const { renderToString, renderToStaticMarkup } = require('react-dom/server');
-const linkAssets = require('./helpers/linkAssets');
+const React = require("react");
+const { RouterContext } = require("react-router");
+const Oy = require("oy-vey").default;
+const { renderToString, renderToStaticMarkup } = require("react-dom/server");
+const linkAssets = require("./helpers/linkAssets");
 
 const getRenderer = (
   isEmail: boolean,
-  renderMethod?: RenderMethod,
+  renderMethod?: RenderMethod
 ): Function => {
   if (renderMethod) {
     return renderMethod;
@@ -28,19 +28,19 @@ type EntryRequirements = {
   entryName: string,
   store: Object,
   routes: Function,
-  httpClient: Object,
+  httpClient: Object
 };
 type WrappersRequirements = {
   EntryWrapper: Object,
   BodyWrapper: Object,
   entryWrapperConfig: Object,
   envVariables: any[],
-  entriesPlugins: Plugin[],
+  entriesPlugins: Plugin[]
 };
 type AssetsCacheOpts = {
   assets: Object,
   loadjsConfig: Object,
-  cacheManager: Object,
+  cacheManager: Object
 };
 
 module.exports = async function render(
@@ -53,16 +53,16 @@ module.exports = async function render(
     BodyWrapper,
     entryWrapperConfig,
     envVariables,
-    entriesPlugins,
+    entriesPlugins
   }: WrappersRequirements,
   { assets, loadjsConfig, cacheManager }: AssetsCacheOpts,
-  { renderMethod }: { renderMethod?: RenderMethod } = {},
+  { renderMethod }: { renderMethod?: RenderMethod } = {}
 ): Promise<RenderOutput> {
   const { scriptTags, styleTags } = await linkAssets(
     context,
     entryName,
     assets,
-    loadjsConfig,
+    loadjsConfig
   );
 
   const isEmail = !!currentRoute.email;
@@ -77,7 +77,7 @@ module.exports = async function render(
       httpClient={httpClient}
       rootWrappers={rootWrappers}
       rootWrappersOptions={{
-        userAgent: req.headers['user-agent'],
+        userAgent: req.headers["user-agent"]
       }}
     />
   );
@@ -88,7 +88,7 @@ module.exports = async function render(
 
   const renderResults: Object = await getRenderer(isEmail, renderMethod)(
     entryWrapper,
-    styleTags,
+    styleTags
   );
   const bodyWrapperContent: String = renderMethod
     ? renderResults.body
@@ -117,7 +117,7 @@ module.exports = async function render(
     />
   );
 
-  const docType: string = currentRoute.docType || '<!doctype html>';
+  const docType: string = currentRoute.docType || "<!doctype html>";
 
   let responseString: string;
   if (isEmail) {
@@ -129,10 +129,16 @@ module.exports = async function render(
     responseString = `${docType}${renderToStaticMarkup(rootElement)}`;
   }
   if (currentRoute.cache) {
-    cacheManager.setCacheIfProd(req, responseString, currentRoute.cacheTTL);
+    cacheManager.setCacheIfProd(
+      req,
+      responseString,
+      currentRoute.cacheTTL,
+      undefined, // Do not override the default cache
+      currentRoute.cacheKey
+    );
   }
   return {
     responseString,
-    rootElement, // only for testing
+    rootElement // only for testing
   };
 };

--- a/packages/gluestick/src/types.js
+++ b/packages/gluestick/src/types.js
@@ -156,7 +156,7 @@ export type SetCacheIfProd = (
   value: string,
   maxAge?: number,
   cache?: Object,
-  cacheKeyStrategy?: (req: Request, state?: Object) => string,
+  cacheKeyStrategy?: (req: Request, state?: Object) => string | null,
   state?: Object,
 ) => void;
 

--- a/packages/gluestick/src/types.js
+++ b/packages/gluestick/src/types.js
@@ -1,12 +1,12 @@
 /* @flow */
-import type { GSConfig } from 'application-config';
+import type { GSConfig } from "application-config";
 
-export type { GSConfig } from 'application-config';
-export type { Entries } from 'project-entries';
-export type { EntriesConfig } from 'project-entries-config';
+export type { GSConfig } from "application-config";
+export type { Entries } from "project-entries";
+export type { EntriesConfig } from "project-entries-config";
 
 export type ProjectConfig = {
-  [key: string]: any,
+  [key: string]: any
 };
 
 export type WebpackConfigEntry = string | boolean | Object | any[];
@@ -16,30 +16,30 @@ export type WebpackConfig = {
   resolve?: {
     extensions?: string[],
     alias?: {
-      [key: string]: string,
-    },
+      [key: string]: string
+    }
   },
-  [key: string]: WebpackConfigEntry,
+  [key: string]: WebpackConfigEntry
 };
 
 export type UniversalSettings = {
   server: {
     input: string,
-    output: string,
-  },
+    output: string
+  }
 };
 
 export type CompiledConfig = {
   universalSettings: UniversalSettings,
   client: WebpackConfig,
   server: WebpackConfig,
-  vendor?: WebpackConfig,
+  vendor?: WebpackConfig
 };
 
 export type Config = {
   projectConfig?: ProjectConfig,
   GSConfig: GSConfig,
-  webpackConfig: CompiledConfig,
+  webpackConfig: CompiledConfig
 };
 
 export type Logger = BaseLogger & {
@@ -49,7 +49,7 @@ export type Logger = BaseLogger & {
   print: (...args: any[]) => void,
   printCommandInfo: () => void,
   fatal: (...args: any[]) => void,
-  resetLine: () => void,
+  resetLine: () => void
 };
 
 export type BaseLogger = {
@@ -58,7 +58,7 @@ export type BaseLogger = {
   info: (...args: any[]) => void,
   warn: (...args: any[]) => void,
   debug: (...args: any[]) => void,
-  error: (...args: any[]) => void,
+  error: (...args: any[]) => void
 };
 
 export type CommandAPI = {
@@ -68,53 +68,53 @@ export type CommandAPI = {
   getPlugins: Function,
   getGluestickConfig: Function,
   getWebpackConfig: Function,
-  getContextConfig: Function,
+  getContextConfig: Function
 };
 
 export type CLIContext = {
   config: Config,
-  logger: Logger,
+  logger: Logger
 };
 
 export type Context = {
   config: Config,
-  logger: BaseLogger,
+  logger: BaseLogger
 };
 
 export type Question = {
   type: string,
   name: string,
-  message: string,
+  message: string
 };
 
 export type CreateTemplate = (
   interpolations: Array<*>,
-  strings: Array<string>,
+  strings: Array<string>
 ) => (args: Object) => string;
 
 export type Generator = {
   name: string,
-  config: any,
+  config: any
 };
 
 export type WrittenTemplate = {
   written: string[],
-  modified: string[],
+  modified: string[]
 };
 
 export type GeneratorOptions = {
-  [key: string]: any,
+  [key: string]: any
 };
 
 export type PredefinedGeneratorOptions = {
   name: string,
   dir?: string,
-  entryPoint: string,
+  entryPoint: string
 };
 
 export type Compiler = {
   run: (error: any) => void,
-  plugin: (event: string, callback: Function) => void,
+  plugin: (event: string, callback: Function) => void
 };
 
 export type Response = {
@@ -125,14 +125,14 @@ export type Response = {
   redirect: (code: number, location: string) => void,
   header: (header: string, value: string) => void,
   status: (code: number) => Response,
-  json: (json: Object) => void,
+  json: (json: Object) => void
 };
 
 export type Request = {
   url: string,
   hostname: string,
   headers: Object,
-  method: string,
+  method: string
 };
 
 export type RenderRequirements = {
@@ -141,12 +141,12 @@ export type RenderRequirements = {
   reducers: Object,
   config: ?Object,
   name: string,
-  key: string,
+  key: string
 };
 
 export type RenderOutput = {
   responseString: string,
-  rootElement: Object,
+  rootElement: Object
 };
 
 export type GetCachedIfProd = (req: Request, cache?: Object) => string | null;
@@ -155,33 +155,34 @@ export type SetCacheIfProd = (
   value: string,
   maxAge?: number,
   cache?: Object,
+  cacheKeyStrategy?: (req: Request) => string
 ) => void;
 
 export type CacheManager = {
   getCachedIfProd: GetCachedIfProd,
-  setCacheIfProd: SetCacheIfProd,
+  setCacheIfProd: SetCacheIfProd
 };
 
 export type MismatchedModules = {
   [key: string]: {
     required: string,
     project: string,
-    type: string,
-  },
+    type: string
+  }
 };
 
 export type ProjectPackage = {
   dependencies: {
-    [key: string]: string,
+    [key: string]: string
   },
   devDependencies: {
-    [key: string]: string,
-  },
+    [key: string]: string
+  }
 };
 
 export type UpdateDepsPromptResults = {
   shouldFix: boolean,
-  mismatchedModules: MismatchedModules,
+  mismatchedModules: MismatchedModules
 };
 
 export type Hook = Function | Function[];
@@ -195,77 +196,77 @@ export type GSHooks = {
   postRenderProps?: Hook,
   postGetCurrentRoute?: Hook,
   postRender?: Hook,
-  error?: Hook,
+  error?: Hook
 };
 
 export type WebpackHooks = {
   webpackClientConfig?: Hook,
   webpackServerConfig?: Hook,
-  webpackVendorDllConfig?: Hook,
+  webpackVendorDllConfig?: Hook
 };
 
 export type Plugin = {
   name: string,
   meta: {
-    [key: string]: any,
+    [key: string]: any
   },
   body: Function | null,
-  options?: Object,
+  options?: Object
 };
 
 export type ConfigPlugin = {
   name: string,
   meta: {
-    [key: string]: any,
+    [key: string]: any
   },
   postOverwrites: {
     gluestickConfig?: (config: GSConfig) => void,
     clientWebpackConfig?: (config: WebpackConfig) => WebpackConfig,
     serverWebpackConfig?: (config: WebpackConfig) => WebpackConfig,
-    vendorDllWebpackConfig?: (config: WebpackConfig) => WebpackConfig,
-  },
+    vendorDllWebpackConfig?: (config: WebpackConfig) => WebpackConfig
+  }
 };
 
 export type RuntimePlugin = {
   name: string,
   meta: {
-    [key: string]: any,
+    [key: string]: any
   },
   body: {
-    rootWrapper?: (component: Object) => Object,
-  },
+    rootWrapper?: (component: Object) => Object
+  }
 };
 
 export type ServerPlugin = {
   name: string,
   meta: {
-    [key: string]: any,
+    [key: string]: any
   },
   renderMethod: Function,
   hooks: GSHooks,
-  logger: Logger,
+  logger: Logger
 };
 
 export type RenderMethod = (
   root: Object,
-  styleTags: Object[],
+  styleTags: Object[]
 ) => { body: string, head: Object[], additionalScripts?: Object[] };
 
 export type BabelOptions = {
   plugins: Array<string | mixed[]>,
-  presets: Array<string | mixed[]>,
+  presets: Array<string | mixed[]>
 };
 
 export type ChunkInfo = {
   url: string,
-  name: string,
+  name: string
 };
 
 export type ChunksInfo = {
   javascript: {
-    [key: ?string]: ChunkInfo,
+    [key: ?string]: ChunkInfo
   },
   styles: {
-    [key: ?string]: ChunkInfo,
-  },
+    [key: ?string]: ChunkInfo
+  }
 };

--- a/packages/gluestick/src/types.js
+++ b/packages/gluestick/src/types.js
@@ -133,6 +133,7 @@ export type Request = {
   hostname: string,
   headers: Object,
   method: string,
+  query: Object,
 };
 
 export type RenderRequirements = {

--- a/packages/gluestick/src/types.js
+++ b/packages/gluestick/src/types.js
@@ -157,6 +157,7 @@ export type SetCacheIfProd = (
   maxAge?: number,
   cache?: Object,
   cacheKeyStrategy?: (req: Request) => string,
+  state?: Object,
 ) => void;
 
 export type CacheManager = {

--- a/packages/gluestick/src/types.js
+++ b/packages/gluestick/src/types.js
@@ -1,12 +1,12 @@
 /* @flow */
-import type { GSConfig } from "application-config";
+import type { GSConfig } from 'application-config';
 
-export type { GSConfig } from "application-config";
-export type { Entries } from "project-entries";
-export type { EntriesConfig } from "project-entries-config";
+export type { GSConfig } from 'application-config';
+export type { Entries } from 'project-entries';
+export type { EntriesConfig } from 'project-entries-config';
 
 export type ProjectConfig = {
-  [key: string]: any
+  [key: string]: any,
 };
 
 export type WebpackConfigEntry = string | boolean | Object | any[];
@@ -16,30 +16,30 @@ export type WebpackConfig = {
   resolve?: {
     extensions?: string[],
     alias?: {
-      [key: string]: string
-    }
+      [key: string]: string,
+    },
   },
-  [key: string]: WebpackConfigEntry
+  [key: string]: WebpackConfigEntry,
 };
 
 export type UniversalSettings = {
   server: {
     input: string,
-    output: string
-  }
+    output: string,
+  },
 };
 
 export type CompiledConfig = {
   universalSettings: UniversalSettings,
   client: WebpackConfig,
   server: WebpackConfig,
-  vendor?: WebpackConfig
+  vendor?: WebpackConfig,
 };
 
 export type Config = {
   projectConfig?: ProjectConfig,
   GSConfig: GSConfig,
-  webpackConfig: CompiledConfig
+  webpackConfig: CompiledConfig,
 };
 
 export type Logger = BaseLogger & {
@@ -49,7 +49,7 @@ export type Logger = BaseLogger & {
   print: (...args: any[]) => void,
   printCommandInfo: () => void,
   fatal: (...args: any[]) => void,
-  resetLine: () => void
+  resetLine: () => void,
 };
 
 export type BaseLogger = {
@@ -58,7 +58,7 @@ export type BaseLogger = {
   info: (...args: any[]) => void,
   warn: (...args: any[]) => void,
   debug: (...args: any[]) => void,
-  error: (...args: any[]) => void
+  error: (...args: any[]) => void,
 };
 
 export type CommandAPI = {
@@ -68,53 +68,53 @@ export type CommandAPI = {
   getPlugins: Function,
   getGluestickConfig: Function,
   getWebpackConfig: Function,
-  getContextConfig: Function
+  getContextConfig: Function,
 };
 
 export type CLIContext = {
   config: Config,
-  logger: Logger
+  logger: Logger,
 };
 
 export type Context = {
   config: Config,
-  logger: BaseLogger
+  logger: BaseLogger,
 };
 
 export type Question = {
   type: string,
   name: string,
-  message: string
+  message: string,
 };
 
 export type CreateTemplate = (
   interpolations: Array<*>,
-  strings: Array<string>
+  strings: Array<string>,
 ) => (args: Object) => string;
 
 export type Generator = {
   name: string,
-  config: any
+  config: any,
 };
 
 export type WrittenTemplate = {
   written: string[],
-  modified: string[]
+  modified: string[],
 };
 
 export type GeneratorOptions = {
-  [key: string]: any
+  [key: string]: any,
 };
 
 export type PredefinedGeneratorOptions = {
   name: string,
   dir?: string,
-  entryPoint: string
+  entryPoint: string,
 };
 
 export type Compiler = {
   run: (error: any) => void,
-  plugin: (event: string, callback: Function) => void
+  plugin: (event: string, callback: Function) => void,
 };
 
 export type Response = {
@@ -125,14 +125,14 @@ export type Response = {
   redirect: (code: number, location: string) => void,
   header: (header: string, value: string) => void,
   status: (code: number) => Response,
-  json: (json: Object) => void
+  json: (json: Object) => void,
 };
 
 export type Request = {
   url: string,
   hostname: string,
   headers: Object,
-  method: string
+  method: string,
 };
 
 export type RenderRequirements = {
@@ -141,12 +141,12 @@ export type RenderRequirements = {
   reducers: Object,
   config: ?Object,
   name: string,
-  key: string
+  key: string,
 };
 
 export type RenderOutput = {
   responseString: string,
-  rootElement: Object
+  rootElement: Object,
 };
 
 export type GetCachedIfProd = (req: Request, cache?: Object) => string | null;
@@ -155,34 +155,34 @@ export type SetCacheIfProd = (
   value: string,
   maxAge?: number,
   cache?: Object,
-  cacheKeyStrategy?: (req: Request) => string
+  cacheKeyStrategy?: (req: Request) => string,
 ) => void;
 
 export type CacheManager = {
   getCachedIfProd: GetCachedIfProd,
-  setCacheIfProd: SetCacheIfProd
+  setCacheIfProd: SetCacheIfProd,
 };
 
 export type MismatchedModules = {
   [key: string]: {
     required: string,
     project: string,
-    type: string
-  }
+    type: string,
+  },
 };
 
 export type ProjectPackage = {
   dependencies: {
-    [key: string]: string
+    [key: string]: string,
   },
   devDependencies: {
-    [key: string]: string
-  }
+    [key: string]: string,
+  },
 };
 
 export type UpdateDepsPromptResults = {
   shouldFix: boolean,
-  mismatchedModules: MismatchedModules
+  mismatchedModules: MismatchedModules,
 };
 
 export type Hook = Function | Function[];
@@ -196,77 +196,77 @@ export type GSHooks = {
   postRenderProps?: Hook,
   postGetCurrentRoute?: Hook,
   postRender?: Hook,
-  error?: Hook
+  error?: Hook,
 };
 
 export type WebpackHooks = {
   webpackClientConfig?: Hook,
   webpackServerConfig?: Hook,
-  webpackVendorDllConfig?: Hook
+  webpackVendorDllConfig?: Hook,
 };
 
 export type Plugin = {
   name: string,
   meta: {
-    [key: string]: any
+    [key: string]: any,
   },
   body: Function | null,
-  options?: Object
+  options?: Object,
 };
 
 export type ConfigPlugin = {
   name: string,
   meta: {
-    [key: string]: any
+    [key: string]: any,
   },
   postOverwrites: {
     gluestickConfig?: (config: GSConfig) => void,
     clientWebpackConfig?: (config: WebpackConfig) => WebpackConfig,
     serverWebpackConfig?: (config: WebpackConfig) => WebpackConfig,
-    vendorDllWebpackConfig?: (config: WebpackConfig) => WebpackConfig
-  }
+    vendorDllWebpackConfig?: (config: WebpackConfig) => WebpackConfig,
+  },
 };
 
 export type RuntimePlugin = {
   name: string,
   meta: {
-    [key: string]: any
+    [key: string]: any,
   },
   body: {
-    rootWrapper?: (component: Object) => Object
-  }
+    rootWrapper?: (component: Object) => Object,
+  },
 };
 
 export type ServerPlugin = {
   name: string,
   meta: {
-    [key: string]: any
+    [key: string]: any,
   },
   renderMethod: Function,
   hooks: GSHooks,
-  logger: Logger
+  logger: Logger,
 };
 
 export type RenderMethod = (
   root: Object,
-  styleTags: Object[]
+  styleTags: Object[],
 ) => { body: string, head: Object[], additionalScripts?: Object[] };
 
 export type BabelOptions = {
   plugins: Array<string | mixed[]>,
-  presets: Array<string | mixed[]>
+  presets: Array<string | mixed[]>,
 };
 
 export type ChunkInfo = {
   url: string,
-  name: string
+  name: string,
 };
 
 export type ChunksInfo = {
   javascript: {
-    [key: ?string]: ChunkInfo
+    [key: ?string]: ChunkInfo,
   },
   styles: {
-    [key: ?string]: ChunkInfo
-  }
+    [key: ?string]: ChunkInfo,
+  },
 };

--- a/packages/gluestick/src/types.js
+++ b/packages/gluestick/src/types.js
@@ -156,7 +156,7 @@ export type SetCacheIfProd = (
   value: string,
   maxAge?: number,
   cache?: Object,
-  cacheKeyStrategy?: (req: Request) => string,
+  cacheKeyStrategy?: (req: Request, state?: Object) => string,
   state?: Object,
 ) => void;
 


### PR DESCRIPTION
Sometimes apps need certain routes to be able to have custom cache key support (e.g. to be able to separately cache certain route query params as unique cached payloads). As of the current gluestick, only the hostname and pathname are used in determining unique cache keys.

This PR adds in the ability for users to define a `cacheKey` prop on their routes, which is a function that takes in a request object and returns a cache key.

This is intended to be a non-breaking change, with the current caching behavior remaining intact, with only routes containing the new `cacheKey` prop now seeing different behavior