### PR TITLE
Update docker image name

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-slim
+FROM node:8-jessie-slim
 
 ARG GLUESTICK_VERSION
 


### PR DESCRIPTION
`node:8-slim` is now `node:8-jessie-slim`: https://github.com/nodejs/docker-node/pull/921

This should fix a Docker deploy issue we're currently experiencing with every release.