### PR TITLE
Pull correctly-named image during deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
       - run: git config --global user.name "CircleCI"
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
 
-      - run: docker pull node:8-slim
+      - run: docker pull node:8-jessie-slim
       - run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
       - run: BRANCH=$CIRCLE_BRANCH npm run publish -- $CIRCLE_TAG  
 


### PR DESCRIPTION
In #1219 I updated the name of the base image that is used to build the gluestick image but it turns out that we're also performing a separate pull of the image in our CircleCI configuration. Update that bit too.