### PR TITLE
Use req.hostname for hostname query in axios client

### DIFF
--- a/packages/gluestick/shared/lib/__tests__/getHttpClient.test.js
+++ b/packages/gluestick/shared/lib/__tests__/getHttpClient.test.js
@@ -139,10 +139,12 @@ describe('lib/getHttpClient', () => {
   });
 
   it('should set baseURL with https if req.secure is true', () => {
+    const host = 'hola.com:332211';
     const req = {
+      hostname: host,
       headers: {
         cookie: 'name=Lincoln',
-        host: 'hola.com:332211',
+        host
       },
       secure: true,
     };
@@ -153,10 +155,12 @@ describe('lib/getHttpClient', () => {
   });
 
   it('should set baseURL with http if req.secure is false', () => {
+    const host = 'hola.com:332211';
     const req = {
+      hostname: host,
       headers: {
         cookie: 'name=Lincoln',
-        host: 'hola.com:332211',
+        host: host,
       },
       secure: false,
     };

--- a/packages/gluestick/shared/lib/__tests__/getHttpClient.test.js
+++ b/packages/gluestick/shared/lib/__tests__/getHttpClient.test.js
@@ -144,7 +144,7 @@ describe('lib/getHttpClient', () => {
       hostname: host,
       headers: {
         cookie: 'name=Lincoln',
-        host
+        host,
       },
       secure: true,
     };
@@ -160,7 +160,7 @@ describe('lib/getHttpClient', () => {
       hostname: host,
       headers: {
         cookie: 'name=Lincoln',
-        host: host,
+        host,
       },
       secure: false,
     };

--- a/packages/gluestick/shared/lib/getHttpClient.js
+++ b/packages/gluestick/shared/lib/getHttpClient.js
@@ -47,7 +47,7 @@ export default function getHttpClient(
   // If a request object is provided, then we want to merge the custom headers
   // with the headers that we sent from the browser in the request.
   client = httpClient.create({
-    baseURL: protocol + req.headers.host,
+    baseURL: protocol + req.hostname,
     headers: {
       ...headers,
     },


### PR DESCRIPTION
This will ensure that the value of X-Forwarded-Host is used whenever `trust proxy` is enabled, falling back to the normal host header when it is disabled.