### PR TITLE
Patch express req.host to include port number

### DIFF
--- a/packages/gluestick/shared/lib/__tests__/getHttpClient.test.js
+++ b/packages/gluestick/shared/lib/__tests__/getHttpClient.test.js
@@ -141,7 +141,7 @@ describe('lib/getHttpClient', () => {
   it('should set baseURL with https if req.secure is true', () => {
     const host = 'hola.com:332211';
     const req = {
-      hostname: host,
+      host,
       headers: {
         cookie: 'name=Lincoln',
         host,
@@ -157,7 +157,7 @@ describe('lib/getHttpClient', () => {
   it('should set baseURL with http if req.secure is false', () => {
     const host = 'hola.com:332211';
     const req = {
-      hostname: host,
+      host,
       headers: {
         cookie: 'name=Lincoln',
         host,

--- a/packages/gluestick/shared/lib/getHttpClient.js
+++ b/packages/gluestick/shared/lib/getHttpClient.js
@@ -47,7 +47,7 @@ export default function getHttpClient(
   // If a request object is provided, then we want to merge the custom headers
   // with the headers that we sent from the browser in the request.
   client = httpClient.create({
-    baseURL: protocol + req.hostname,
+    baseURL: protocol + req.host,
     headers: {
       ...headers,
     },

--- a/packages/gluestick/src/commands/__tests__/start-client.test.js
+++ b/packages/gluestick/src/commands/__tests__/start-client.test.js
@@ -115,7 +115,7 @@ describe('commands/start-client', () => {
   it('should start express with webpack dev and hot middlewares', () => {
     startClientCommand(commandApi, [{}]);
     waitUntilValidCallback();
-    expect(middlewares.length).toBe(3);
+    expect(middlewares.length).toBe(4);
     const res = { render: jest.fn() };
     proxyOnErrorCallback(null, {}, res);
     expect(res.render.mock.calls[0][0].includes('poll.html')).toBeTruthy();

--- a/packages/gluestick/src/commands/start-client.js
+++ b/packages/gluestick/src/commands/start-client.js
@@ -6,6 +6,8 @@ const fs = require('fs');
 const webpack = require('webpack');
 const express = require('express');
 const proxy = require('http-proxy-middleware');
+
+const patchRequestHost = require('../lib/patchRequestHost');
 const progressHandler = require('../config/webpack/progressHandler');
 const { printWebpackStats, debounce } = require('../utils');
 const build = require('./build');
@@ -115,6 +117,7 @@ module.exports = (
       },
     );
     app.set('view engine', 'html');
+    app.use(patchRequestHost());
     const devMiddleware = require('webpack-dev-middleware')(
       compiler,
       developmentServerOptions,

--- a/packages/gluestick/src/lib/patchRequestHost.js
+++ b/packages/gluestick/src/lib/patchRequestHost.js
@@ -1,0 +1,40 @@
+/*
+ * Apply a patch to req.host to fix a bug that exists in Express v4.
+ *
+ * Specifically, without this patch, req.host will only return the host _name_
+ * and not the full host including the port number.
+ *
+ * This patch currently exists in Express v5, which is also currently alpha.
+ *
+ * For more information, see:
+ *
+ * https://expressjs.com/en/guide/migrating-5.html#req.host
+ * https://github.com/expressjs/express/blob/4.16.4/lib/request.js#L448-L452
+ * https://github.com/expressjs/express/blob/5.0.0-alpha.7/lib/request.js#L395-L415
+ */
+function patchRequestHost () {
+  return function patchRequestHost (req, res, next) {
+    defineGetter(req, 'host', function host (){
+      var trust = this.app.get('trust proxy fn');
+      var val = this.get('X-Forwarded-Host');
+
+      if (!val || !trust(this.connection.remoteAddress, 0)) {
+        val = this.get('Host');
+      }
+
+      return val || undefined;
+    });
+
+    next();
+  };
+}
+
+function defineGetter(obj, name, getter) {
+  Object.defineProperty(obj, name, {
+    configurable: true,
+    enumerable: true,
+    get: getter
+  });
+}
+
+module.exports = patchRequestHost;

--- a/packages/gluestick/src/lib/patchRequestHost.js
+++ b/packages/gluestick/src/lib/patchRequestHost.js
@@ -12,11 +12,11 @@
  * https://github.com/expressjs/express/blob/4.16.4/lib/request.js#L448-L452
  * https://github.com/expressjs/express/blob/5.0.0-alpha.7/lib/request.js#L395-L415
  */
-function patchRequestHost () {
-  return function patchRequestHost (req, res, next) {
-    defineGetter(req, 'host', function host (){
-      var trust = this.app.get('trust proxy fn');
-      var val = this.get('X-Forwarded-Host');
+function patchRequestHost() {
+  return function(req, res, next) {
+    defineGetter(req, 'host', function host() {
+      const trust = this.app.get('trust proxy fn');
+      let val = this.get('X-Forwarded-Host');
 
       if (!val || !trust(this.connection.remoteAddress, 0)) {
         val = this.get('Host');
@@ -33,7 +33,7 @@ function defineGetter(obj, name, getter) {
   Object.defineProperty(obj, name, {
     configurable: true,
     enumerable: true,
-    get: getter
+    get: getter,
   });
 }
 

--- a/packages/gluestick/src/renderer/main.js
+++ b/packages/gluestick/src/renderer/main.js
@@ -19,6 +19,7 @@ const onFinished = require('on-finished');
 const applicationConfig = require('application-config').default;
 const entries = require('project-entries').default;
 
+const patchRequestHost = require('../lib/patchRequestHost');
 const serverPlugins = require('../plugins/serverPlugins');
 const createPluginUtils = require('../plugins/utils');
 const setProxies = require('./helpers/setProxies');
@@ -53,6 +54,7 @@ module.exports = function main() {
   }
 
   const app: Object = express();
+  app.use(patchRequestHost());
   app.use(compression());
   app.use(
     '/assets',


### PR DESCRIPTION
Express has a long-standing bug in v4 where the port number is dropped from `host`, which is why `req.host` is marked as deprecated. In v5, `req.host` is fixed and `req.hostname` does not include the port.

For now, we're using middleware to patch `req.host` to include the port number, which is correct behavior.